### PR TITLE
Adjusts the Botany speed so stuff goes fast enough for botany to be of use in 1-2 hour rounds.

### DIFF
--- a/code/game/machinery/hydroponics.dm
+++ b/code/game/machinery/hydroponics.dm
@@ -1,4 +1,4 @@
-#define HYDRO_SPEED_MULTIPLIER 0.25
+#define HYDRO_SPEED_MULTIPLIER 2
 
 /obj/machinery/hydroponics
 	name = "hydroponics tray"


### PR DESCRIPTION
Before it was set to speeds for 5-6 hour rounds on BS12. Since the average urist match is 1-2 hours this is way too slow.
