### PR TITLE
Traitor times 2 (Bay hates fun!)

### DIFF
--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -34,7 +34,7 @@
 	var/num_traitors = 1
 	var/max_traitors = 1
 	var/traitor_prob = 0
-	max_traitors = round(num_players / 10) + 1
+	max_traitors = round(num_players / 5) + 1
 	traitor_prob = (num_players - (max_traitors - 1) * 10) * 10
 
 	// Stop setup if no possible traitors


### PR DESCRIPTION
Changing Autotraitor to assign a traitor per five people instead of ten, so we'll have four traitors at 20 people. Because the rounds were horribly slow most of the time anyways, and it basically reverts us to /tg/ standard.
