### PR TITLE
Fixing the AI bias towards hoomins

### DIFF
--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -324,7 +324,7 @@ AI MODULES
 /obj/item/weapon/aiModule/asimov/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)
 	..()
 	target.clear_inherent_laws()
-	target.add_inherent_law("You may not injure a crew member or, through inaction, allow a human being to come to harm.")
+	target.add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
 	target.add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
 	target.add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 	target.show_laws()


### PR DESCRIPTION
Changes cases of 'human' to crew member, to prevent specieism and also because the law specifies crew members to prevent the headbanging situation I had to deal with as Mendicant earlier. It now applies to crew - exactly the same as before only the AI can't wiggle out of not killing Unathi. Antags are the same as before.
Pank.
