### PR TITLE
Un-sillifies vamp regeneration.

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1153,6 +1153,9 @@
 							adjustBruteLoss(-1)
 							adjustFireLoss(-1)
 							adjustToxLoss(-1)
+							spawn(60)
+								for(var/datum/organ/internal/I in internal_organs)
+									I.damage = 0
 			else if(resting)
 				if(halloss > 0)
 					adjustHalLoss(-3)


### PR DESCRIPTION
Because a vampire suddenly dropping dead from a heart attack is 3silly4me. So now the coffin sleep regeneration also heals internal organs. Should be a good incentive to steal some. I may fully undeadify vampires later on, if that is requested.
