### PR TITLE
Fixes #123 - for Rev

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -351,7 +351,7 @@
 		feedback_set_details("round_end_result","loss - rev heads killed")
 		world << "\red <FONT size = 3><B> The heads of staff managed to stop the revolution!</B></FONT>"
 	..()
-return 1
+	return 1
 
 /datum/game_mode/proc/auto_declare_completion_revolution()
 	var/list/targets = list()


### PR DESCRIPTION
The bug was caused by objectiveless antags. I could've tinkered with adding objectivelessness checks everywhere, but I reckoned that taking down heads is the entire point of the mode and it's the hows and whys that remain up to players, as they did before, so I removed them from the mode code altogether.
