### PR TITLE
Vampiric Regeneration 2: The Actuallytestening

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1170,7 +1170,7 @@
 					spawn(0)
 						emote("snore")
 				if(mind)
-					if(mind.vampire) //VAMP COFFIN REGEN CODE BEGIN
+					if(mind.vampire) //VAMP COFFIN REGEN CODE BEGINS
 						if(istype(loc, /obj/structure/closet/coffin))
 							var/mob/living/carbon/human/H = mind.current
 							H.adjustBruteLoss(-2)


### PR DESCRIPTION
A fix for the coffin not actually fixing organs. Right now, it is pretty potent, if less so than ling regen - it regenerates all damages per tick,  plus has a chance to fix all organs (up to and including regrowing) along with a message to inform the player it's happened (I tested it, it's rare enough not to be a constant message spam, but as rare that it does not trigger at least once per a sleeping session.

You could tweak the values for balance, but coffin regen is very risky - it requires using a particular, conspicuous structure and being helplessly exposed to attack by anyone who finds it, and it immediately arouses suspicion when one is seen using/dragging one around.

However, it does _NOT_ fix bloodloss, which I reckon makes sense - the last thing you want to happen to you as a vampire is to lose blood.
