### PR TITLE
Vampire rebalance.

### DIFF
--- a/code/modules/urist/gamemodes/vampire/vampire.dm
+++ b/code/modules/urist/gamemodes/vampire/vampire.dm
@@ -303,9 +303,9 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 			break
 		if(H.stat < 2) //alive
 			blood = min(10, H.vessel.get_reagent_amount("blood"))// if they have less than 10 blood, give them the remnant else they get 10 blood
-			src.mind.vampire.bloodtotal += (blood/2)
-			src.mind.vampire.bloodusable += (blood*2)
-			H.traumatic_shock += 30 // vampire bites suck
+			src.mind.vampire.bloodtotal += (blood)
+			src.mind.vampire.bloodusable += (blood*1.2)
+			H.traumatic_shock += 15 // vampire bites suck, a long suckership will hurt the victim enough to knock them out
 		else
 			blood = min(5, H.vessel.get_reagent_amount("blood"))// The dead only give 5 bloods
 			src.mind.vampire.bloodtotal += blood
@@ -360,7 +360,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 			vamp.powers.Add(VAMP_SLAVE)
 
 	// TIER 5
-	if(vamp.bloodtotal >= 500)
+	if(vamp.bloodtotal >= 600)
 		if(!(VAMP_FULL in vamp.powers))
 			vamp.powers.Add(VAMP_FULL)
 

--- a/code/modules/urist/gamemodes/vampire/vampire.dm
+++ b/code/modules/urist/gamemodes/vampire/vampire.dm
@@ -11,7 +11,7 @@
 /datum/game_mode/vampire
 	name = "vampire"
 	config_tag = "vampire"
-	restricted_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Chaplain") //Consistent screening has filtered all infiltration attempts on high value jobs
+	restricted_jobs = list("AI", "Cyborg", "Chaplain") //fuck job protection just cause, leaving Chaplin in because while hilarious, it kills counterplay "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //Consistent screening has filtered all infiltration attempts on high value jobs
 	protected_jobs = list()
 	required_players = 1
 	required_players_secret = 7
@@ -47,7 +47,7 @@
 
 /datum/game_mode/vampire/pre_setup()
 	// mixed mode scaling
-/*	if(istype(ticker.mode, /datum/game_mode/mixed)) //no mixed mode here - scrdest
+/*	if(istype(ticker.mode, /datum/game_mode/mixed)) //no mixed mode here yet - scrdest
 		mixed = 1
 	if(mixed)
 		recommended_enemies = 2
@@ -62,7 +62,7 @@
 			if(player.assigned_role == job)
 				possible_vampires -= player
 
-	vampire_amount = min(recommended_enemies, max(required_enemies,(1 + round(num_players() / 10))))
+	vampire_amount = min(recommended_enemies, max(required_enemies,(1 + round(num_players() / 7.5))))
 
 	if(possible_vampires.len>0)
 		for(var/i = 0, i < vampire_amount, i++)
@@ -303,14 +303,14 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 			break
 		if(H.stat < 2) //alive
 			blood = min(10, H.vessel.get_reagent_amount("blood"))// if they have less than 10 blood, give them the remnant else they get 10 blood
-			src.mind.vampire.bloodtotal += blood
-			src.mind.vampire.bloodusable += blood
-			H.adjustCloneLoss(10) // beep boop 10 damage
+			src.mind.vampire.bloodtotal += (blood/2)
+			src.mind.vampire.bloodusable += (blood*2)
+			H.traumatic_shock += 30 // vampire bites suck
 		else
 			blood = min(5, H.vessel.get_reagent_amount("blood"))// The dead only give 5 bloods
 			src.mind.vampire.bloodtotal += blood
 		if(bloodtotal != src.mind.vampire.bloodtotal)
-			src << "<span class='notice'> <b>You have accumulated [src.mind.vampire.bloodtotal] [src.mind.vampire.bloodtotal > 1 ? "units" : "unit"] of blood[src.mind.vampire.bloodusable != bloodusable ?", and have [src.mind.vampire.bloodusable] left to use</span>" : "."]"
+			src << "<span class='notice'> <b>You have accumulated [src.mind.vampire.bloodtotal] [src.mind.vampire.bloodtotal > 1 ? "units" : "unit"] of blood[src.mind.vampire.bloodusable != bloodusable ?", and have [src.mind.vampire.bloodusable] usable blood</span>" : "."]"
 		check_vampire_upgrade(mind)
 		H.vessel.remove_reagent("blood",25)
 

--- a/code/modules/urist/gamemodes/vampire/vampire_powers.dm
+++ b/code/modules/urist/gamemodes/vampire/vampire_powers.dm
@@ -70,7 +70,7 @@
 
 /client/proc/vampire_rejuvinate()
 	set category = "Vampire"
-	set name = "Rejuvinate "
+	set name = "Rejuvenate "
 	set desc= "Flush your system with spare blood to remove any incapacitating effects. Heals more powerful vampires."
 	var/datum/mind/M = usr.mind
 	if(!M) return
@@ -93,12 +93,12 @@
 
 /client/proc/vampire_hypnotise()
 	set category = "Vampire"
-	set name = "Hypnotise (20)"
+	set name = "Hypnotise"
 	set desc= "A piercing stare that incapacitates and memory-wipes your victim for a good length of time. Ahelp if your victim does not comply." //added the amnesia to clamp down on sucking dry. Ain't no fun for anybody. -scrdest
 	var/datum/mind/M = usr.mind
 	if(!M) return
 
-	var/mob/living/carbon/C = M.current.vampire_active(20, 0, 1)
+	var/mob/living/carbon/C = M.current.vampire_active(0, 0, 1)
 
 	if(!C) return
 	M.current.visible_message("<span class='warning'>[M.current.name]'s eyes flash briefly as he stares into [C.name]'s eyes</span>")
@@ -116,19 +116,19 @@
 			C.Weaken(20)
 			C.Stun(20)
 			C.stuttering = 20
-		M.current.remove_vampire_blood(20)
+		M.current.remove_vampire_blood(0)
 	else
 		M.current << "<span class='warning'> You broke your gaze.</span>"
 		return
 
 /client/proc/vampire_disease()
 	set category = "Vampire"
-	set name = "Diseased Touch (100)"
+	set name = "Diseased Touch (50)" //too useless to cost that much
 	set desc = "Touches your victim with infected blood giving them the Shutdown Syndrome which quickly shutsdown their major organs resulting in a quick painful death."
 	var/datum/mind/M = usr.mind
 	if(!M) return
 
-	var/mob/living/carbon/C = M.current.vampire_active(100, 0, 1)
+	var/mob/living/carbon/C = M.current.vampire_active(50, 0, 1)
 	if(!C) return
 	if(!M.current.vampire_can_reach(C, 1))
 		M.current << "<span class='warning'> <b>You cannot touch [C.name] from where you are standing!</span>"
@@ -154,7 +154,7 @@
 	shutdown.stage = 2
 	shutdown.clicks = 185
 	infect_virus2(C,shutdown,0)
-	M.current.remove_vampire_blood(100)
+	M.current.remove_vampire_blood(50)
 	M.current.verbs -= /client/proc/vampire_disease
 	spawn(1800) M.current.verbs += /client/proc/vampire_disease
 
@@ -182,16 +182,16 @@
 
 /client/proc/vampire_shapeshift()
 	set category = "Vampire"
-	set name = "Shapeshift (50)"
-	set desc = "Changes your name and appearance at the cost of 50 blood and has a cooldown of 3 minutes."
+	set name = "Shapeshift"
+	set desc = "Changes your name and appearance, has a cooldown of 3 minutes."
 	var/datum/mind/M = usr.mind
 	if(!M) return
-	if(M.current.vampire_power(50, 0))
+	if(M.current.vampire_power(0, 0))
 		M.current.visible_message("<span class='warning'>[M.current.name] transforms!</span>")
 		M.current.client.prefs.real_name = random_name(M.current.gender)
 		M.current.client.prefs.randomize_appearance_for(M.current)
 		M.current.regenerate_icons()
-		M.current.remove_vampire_blood(50)
+		M.current.remove_vampire_blood(0)
 		M.current.verbs -= /client/proc/vampire_shapeshift
 		spawn(1800) M.current.verbs += /client/proc/vampire_shapeshift
 
@@ -351,7 +351,7 @@
 /client/proc/vampire_jaunt()
 	//AHOY COPY PASTE INCOMING
 	set category = "Vampire"
-	set name = "Mist Form (30)"
+	set name = "Mist Form (15)" //leaving it with a cost to make shadowstep less useless
 	set desc = "You take on the form of mist for a short period of time."
 	var/jaunt_duration = 50 //in deciseconds
 	var/datum/mind/M = usr.mind
@@ -360,7 +360,7 @@
 	if(usr.z == 2)
 		return 0
 
-	else if(M.current.vampire_power(30, 0))
+	else if(M.current.vampire_power(15, 0))
 		if(M.current.buckled) M.current.buckled.unbuckle()
 		spawn(0)
 			var/mobloc = get_turf(M.current.loc)
@@ -401,7 +401,7 @@
 			M.current.client.eye = M.current
 			del(animation)
 			del(holder)
-		M.current.remove_vampire_blood(30)
+		M.current.remove_vampire_blood(15)
 		M.current.verbs -= /client/proc/vampire_jaunt
 		spawn(600) M.current.verbs += /client/proc/vampire_jaunt
 
@@ -409,7 +409,7 @@
 // Less smoke spam.
 /client/proc/vampire_shadowstep()
 	set category = "Vampire"
-	set name = "Shadowstep (30)"
+	set name = "Shadowstep"
 	set desc = "Vanish into the shadows."
 	var/datum/mind/M = usr.mind
 	if(!M) return
@@ -421,7 +421,7 @@
 	// Maximum lighting_lumcount.
 	var/max_lum = 1
 
-	if(M.current.vampire_power(30, 0))
+	if(M.current.vampire_power(0, 0))
 		if(M.current.buckled) M.current.buckled.unbuckle()
 		spawn(0)
 			var/list/turfs = new/list()
@@ -458,7 +458,7 @@
 			usr.loc = picked
 			spawn(10)
 				del(animation)
-		M.current.remove_vampire_blood(30)
+		M.current.remove_vampire_blood(0)
 		M.current.verbs -= /client/proc/vampire_shadowstep
 		spawn(20)
 			M.current.verbs += /client/proc/vampire_shadowstep


### PR DESCRIPTION
An attempt to make Vamp less slooooooooooooow.

Removes job protection unless needed for sanity (borg does not VANT TO ZUCK YOUR BLEH, and square-moustached British comedians shouldn't be vamped to foster counterplay).

Slightly increases scaling; 2 at 15 seems reasonable. I'm afraid of going overboard on it because even with just Rejuv VAMP STRONK, and vamp gang-ups even STRONKer.

Decouples total blood (i.e. the 'level up' blood for all intents and purposes) from usable blood; you gain the former half as fast, but the latter twice as fast as before (this is, from each 'suck' of blood), meaning gaining powers is a slower process, but you should burn through your powers more slowly, hopefully encouraging vamps to do shit instead of chugging monkeymen.

Axes cloneloss from suckage; it made no sense, was a pain in the ass to fix, and essentially turned vamp into a far more irritating husker than lings. And speaking of, causes pain instead; I'll nerf the amount, since I didn't realize at the time it was per-suck, and was in the hurry to fix other shit.