### PR TITLE
[DNM] Rags: Ghetto Bandages

### DIFF
--- a/code/modules/urist/items/uristmed.dm
+++ b/code/modules/urist/items/uristmed.dm
@@ -134,3 +134,41 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 					return
 			else
 				user << "<span class='notice'>The [affecting.display_name] is cut open, you'll need more than a [src]!</span>"
+
+
+/obj/item/clothing/suit/verb/rip(mob/user as mob)
+	set name = "Rip Apart Suit"
+	set category = "Object"
+
+	if(!usr.canmove || usr.stat || usr.restrained())
+		return 0
+	if(istype(src, /obj/item/clothing/suit/space) || istype(src, /obj/item/clothing/suit/armor) || istype(src, /obj/item/clothing/suit/wizrobe)) //add other protected instances as needed
+		return 0
+	else
+		user.visible_message( 	"<span class='notice'> [user] starts ripping [src] apart into rags!</span>", \
+											"<span class='notice'> You start ripping [src] apart into rags!</span>" )
+		spawn(100)
+			user << "<span class='notice'>You have ripped [src] into pieces, yielding two rags.</span>"
+
+			new /obj/item/weapon/clothesrag(get_turf(src))
+			new /obj/item/weapon/clothesrag(get_turf(src))
+
+			del(src)
+
+/obj/item/clothing/under/verb/rip(mob/user as mob)
+	set name = "Rip Apart Jumpsuit"
+	set category = "Object"
+
+	if(!usr.canmove || usr.stat || usr.restrained())
+		return 0
+/*	if(istype(src, /obj/item/clothing/under/BADSTUFFGOESHERE //I couldn't think of any item types here that shouldn't work, but leaving it here in case it's needed later
+		return 0*/
+	else
+		user.visible_message( 	"<span class='notice'> [user] starts ripping [src] apart into a rag!</span>", \
+											"<span class='notice'> You start ripping [src] apart into a rag!</span>" )
+		spawn(100)
+			user << "<span class='notice'>You have ripped [src] into pieces, yielding a rag.</span>"
+
+			new /obj/item/weapon/clothesrag(get_turf(src))
+
+			del(src)

--- a/code/modules/urist/items/uristmed.dm
+++ b/code/modules/urist/items/uristmed.dm
@@ -55,13 +55,14 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 /obj/item/weapon/clothesrag/proc/checkvolume()
 	if(src.bloodvolume >= src.bloodcapacity)
 		src.soaked = 1
+	else
+		src.soaked = 0
 	if(soaked)
 		usr << "The rag has reached its capacity!"
 		src.name = "bloody rag"
 		src.desc = "The sad remains of a piece of clothing. It has soaked up too much blood to be useful for stopping bleeding, better wash it!"
 		icon_state = "rag"
 	else
-		src.soaked = 0
 		src.name = "rag"
 		src.desc = "The sad remains of a piece of clothing. Could be used to press wounds to stop them from bleeding, but it might take some time and is of dubious cleanliness."
 		icon_state = "rag"

--- a/code/modules/urist/items/uristmed.dm
+++ b/code/modules/urist/items/uristmed.dm
@@ -61,6 +61,7 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 		src.desc = "The sad remains of a piece of clothing. It has soaked up too much blood to be useful for stopping bleeding, better wash it!"
 		icon_state = "rag"
 	else
+		src.soaked = 0
 		src.name = "rag"
 		src.desc = "The sad remains of a piece of clothing. Could be used to press wounds to stop them from bleeding, but it might take some time and is of dubious cleanliness."
 		icon_state = "rag"
@@ -120,28 +121,41 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 						src.checkvolume()
 						if(prob(33))
 							W.germ_level += 1 //rags are rarely sanitary
-						if(prob(20))
-							W.bandaged = 1
-							user.visible_message( 	"<span class='notice'> [user] stops the bleeding of [W.desc] on [M]'s [affecting.display_name] with the [src]!</span>", \
-											"<span class='notice'> You manage to stop the bleeding of [W.desc] on [M]'s [affecting.display_name] with the [src]!</span>" )
+						spawn(10)
+							if(prob(20))
+								affecting.status &= ~ORGAN_BLEEDING
+								user.visible_message( 	"<span class='notice'> [user] stops the bleeding of [W.desc] on [M]'s [affecting.display_name] with the [src]!</span>", \
+												"<span class='notice'> You manage to stop the bleeding of [W.desc] on [M]'s [affecting.display_name] with the [src]!</span>" )
+							else return 0
 
 
 					else
 						user <<	"<span class='warning'> This wound is not bleeding, use more advanced medical gear to heal the [W.desc] on [M]'s [affecting.display_name].</span>"
+						return 0
 		else
 			if (can_operate(H))        //Checks if mob is lying down on table for surgery
 				if (do_surgery(H,user,src))
 					return
 			else
 				user << "<span class='notice'>The [affecting.display_name] is cut open, you'll need more than a [src]!</span>"
+				return 0
 
 
 /obj/item/clothing/suit/verb/rip(mob/user as mob)
 	set name = "Rip Apart Suit"
 	set category = "Object"
+	set src in usr
+
+	var/mob/living/carbon/human/H = src.loc
 
 	if(!usr.canmove || usr.stat || usr.restrained())
 		return 0
+	if(!istype(H))
+		return 0
+	if(H.wear_suit == src)
+		user << "<span class='warning'>Deciding not to channel your inner barbarian, you think it's a good idea to take off your [src] first.</span>"
+		return
+
 	if(istype(src, /obj/item/clothing/suit/space) || istype(src, /obj/item/clothing/suit/armor) || istype(src, /obj/item/clothing/suit/wizrobe)) //add other protected instances as needed
 		return 0
 	else
@@ -150,25 +164,48 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 		spawn(100)
 			user << "<span class='notice'>You have ripped [src] into pieces, yielding two rags.</span>"
 
+			playsound(src.loc, 'sound/weapons/cablecuff.ogg', 100, 1)
+			spawn(5)
+				playsound(src.loc, 'sound/weapons/cablecuff.ogg', 100, 1)
+
 			new /obj/item/weapon/clothesrag(get_turf(src))
 			new /obj/item/weapon/clothesrag(get_turf(src))
 
 			del(src)
 
+			H.update_inv_l_hand()
+			H.update_inv_r_hand()
+
+
 /obj/item/clothing/under/verb/rip(mob/user as mob)
 	set name = "Rip Apart Jumpsuit"
 	set category = "Object"
+	set src in usr
+	var/mob/living/carbon/human/H = src.loc
 
 	if(!usr.canmove || usr.stat || usr.restrained())
 		return 0
 /*	if(istype(src, /obj/item/clothing/under/BADSTUFFGOESHERE //I couldn't think of any item types here that shouldn't work, but leaving it here in case it's needed later
 		return 0*/
+	if(!istype(H))
+		return 0
+	if(H.w_uniform == src)
+		user << "<span class='warning'>Deciding not to channel your inner barbarian, you think it's a good idea to take off your [src] first.</span>"
+		return
+
 	else
 		user.visible_message( 	"<span class='notice'> [user] starts ripping [src] apart into a rag!</span>", \
 											"<span class='notice'> You start ripping [src] apart into a rag!</span>" )
 		spawn(100)
 			user << "<span class='notice'>You have ripped [src] into pieces, yielding a rag.</span>"
 
+			playsound(src.loc, 'sound/weapons/cablecuff.ogg', 100, 1)
+			spawn(5)
+				playsound(src.loc, 'sound/weapons/cablecuff.ogg', 100, 1)
+
 			new /obj/item/weapon/clothesrag(get_turf(src))
 
 			del(src)
+
+			H.update_inv_l_hand()
+			H.update_inv_r_hand()

--- a/code/modules/urist/items/uristmed.dm
+++ b/code/modules/urist/items/uristmed.dm
@@ -39,3 +39,98 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 		new /obj/item/weapon/reagent_containers/syringe/antitoxin( src )
 		new /obj/item/device/healthanalyzer( src )
 		return
+
+//Rags from torn clothes, a quick and, literally, dirty way to stop the bleeding... eventually.
+
+/obj/item/weapon/clothesrag
+	name = "rag"
+	desc = "The sad remains of a piece of clothing. Could be used to press wounds to stop them from bleeding, but it might take some time and is of dubious cleanliness."
+	w_class = 1
+	icon = 'icons/obj/toy.dmi'
+	icon_state = "rag"
+	var/bloodvolume = 0 //how much blood has the rag soaked up
+	var/bloodcapacity = 5 //how many times the rag can soak up blood
+	var/soaked = 0 //if the rag has reached its capacity
+
+/obj/item/weapon/clothesrag/proc/checkvolume()
+	if(src.bloodvolume >= src.bloodcapacity)
+		src.soaked = 1
+	if(soaked)
+		usr << "The rag has reached its capacity!"
+		src.name = "bloody rag"
+		src.desc = "The sad remains of a piece of clothing. It has soaked up too much blood to be useful for stopping bleeding, better wash it!"
+		icon_state = "rag"
+	else
+		src.name = "rag"
+		src.desc = "The sad remains of a piece of clothing. Could be used to press wounds to stop them from bleeding, but it might take some time and is of dubious cleanliness."
+		icon_state = "rag"
+
+/obj/item/weapon/clothesrag/clean_blood()
+	..()
+	src.bloodvolume = 0
+	src.checkvolume()
+
+/obj/item/weapon/clothesrag/attack(mob/living/carbon/M as mob, mob/user as mob) //copypasta ahoy!
+
+	if(soaked)
+		user << "<span class='warning'> \The [src] is too bloody!</span>"
+		return 1
+
+	if (!istype(M))
+		user << "<span class='warning'> \The [src] cannot be applied to [M]!</span>"
+		return 1
+
+	if ( ! (istype(user, /mob/living/carbon/human) || \
+			istype(user, /mob/living/silicon) || \
+			istype(user, /mob/living/carbon/monkey)) )
+		user << "<span class='warning'> You don't have the dexterity to do this!</span>"
+		return 1
+
+	if (istype(M, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		var/datum/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
+
+		if(affecting.display_name == "head")
+			if(H.head && istype(H.head,/obj/item/clothing/head/helmet/space))
+				user << "<span class='warning'> You can't apply [src] through [H.head]!</span>"
+				return 1
+		else
+			if(H.wear_suit && istype(H.wear_suit,/obj/item/clothing/suit/space))
+				user << "<span class='warning'> You can't apply [src] through [H.wear_suit]!</span>"
+				return 1
+
+		if(affecting.status & ORGAN_ROBOT)
+			user << "<span class='warning'> This isn't useful at all on a robotic limb..</span>"
+			return 1
+
+		H.UpdateDamageIcon()
+
+		if(affecting.open == 0)
+			if(!affecting.bandage())
+				user << "<span class='warning'>The wounds on [M]'s [affecting.display_name] have already been bandaged.</span>"
+				return 1
+			else
+				for (var/datum/wound/W in affecting.wounds)
+					if (W.internal)
+						continue
+					if (W.current_stage <= W.max_bleeding_stage)
+						user.visible_message( 	"<span class='notice'> [user] presses [W.desc] on [M]'s [affecting.display_name] with the [src].</span>", \
+										"<span class='notice'> You press [W.desc] on [M]'s [affecting.display_name] with the rag, trying to stop the bleeding.</span>" )
+						src.bloodvolume += 1
+						src.checkvolume()
+						if(prob(33))
+							W.germ_level += 1 //rags are rarely sanitary
+						if(prob(20))
+							W.bandaged = 1
+							user.visible_message( 	"<span class='notice'> [user] stops the bleeding of [W.desc] on [M]'s [affecting.display_name] with the [src]!</span>", \
+											"<span class='notice'> You manage to stop the bleeding of [W.desc] on [M]'s [affecting.display_name] with the [src]!</span>" )
+
+
+					else
+						user <<	"<span class='warning'> This wound is not bleeding, use more advanced medical gear to heal the [W.desc] on [M]'s [affecting.display_name].</span>"
+		else
+			if (can_operate(H))        //Checks if mob is lying down on table for surgery
+				if (do_surgery(H,user,src))
+					return
+			else
+				user << "<span class='notice'>The [affecting.display_name] is cut open, you'll need more than a [src]!</span>"


### PR DESCRIPTION
That's right, something even shittier at keeping people alive than bandages proper, but still better than bleeding to death of a deep papercut. The idea, of course, is after yesterday's train round.

Rags use the damp rag sprite for now and are made by ripping apart suit or jumpsuit layer clothes for two or one rag, respectively, with checks for /space/ /wizrobe/ and /armor/ subtypes of suits to prevent breaking those; it could probably be done with something more elegant like vars or flags, but it would also mean shitting my code all over the branch.

Tearing clothes apart is not immediate; it takes a short while, but you may move during that, and requires the clothing to be held and NOT worn, so you cannot accidentally destroy all your clothes and you have a chance of disarming someone who stole and tries to destroy your clothes.

Unlike bandages, rags can be used multiple times, but they only stop the bleeding, only at a 20% chance (lower than self-applied splints, which are a pain already), slightly raise the wound's germ level and need washing. After being applied five times (so, statistically after stopping one wound) they become soaked with blood, requiring to be washed in a sink to be usable again. The icon stays the same for now, but I'll get some spritework for that later.

The PR is working as of right now, but it's working *TOO* well; I need an adult here, because the bandaging system is so arcane that it involves changing in pentagrams written in a newborn's blood to compile it - somehow, applying the rag bandages the organ even when I didn't tell it to, via some kind of weird cross-checking, so I hope @Zuhayr (because he checks up on us) or someone else who groks it can help me figure it out.