### PR TITLE
Removes angle(elevation) offset from telesci

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -12,7 +12,7 @@
 	var/z_co = 1
 	var/power_off
 	var/rotation_off
-	var/angle_off
+	//var/angle_off
 
 	var/rotation = 0
 	var/angle = 45
@@ -86,9 +86,9 @@
 
 	var/t = "<div class='statusDisplay'>[temp_msg]</div><BR>"
 	t += "<A href='?src=\ref[src];setrotation=1'>Set Bearing</A>"
-	t += "<div class='statusDisplay'>[rotation]°</div>"
+	t += "<div class='statusDisplay'>[rotation]Â°</div>"
 	t += "<A href='?src=\ref[src];setangle=1'>Set Elevation</A>"
-	t += "<div class='statusDisplay'>[angle]°</div>"
+	t += "<div class='statusDisplay'>[angle]Â°</div>"
 	t += "<span class='linkOn'>Set Power</span>"
 	t += "<div class='statusDisplay'>"
 
@@ -151,7 +151,7 @@
 
 		var/truePower = Clamp(power + power_off, 1, 1000)
 		var/trueRotation = rotation + rotation_off
-		var/trueAngle = Clamp(angle + angle_off, 1, 90)
+		var/trueAngle = Clamp(angle, 1, 90)
 
 		var/datum/projectile_data/proj_data = projectile_trajectory(telepad.x, telepad.y, trueRotation, trueAngle, truePower)
 		last_tele_data = proj_data
@@ -304,6 +304,6 @@
 
 /obj/machinery/computer/telescience/proc/recalibrate()
 	teles_left = rand(30, 40)
-	angle_off = rand(-25, 25)
+	//angle_off = rand(-25, 25)
 	power_off = rand(-4, 0)
 	rotation_off = rand(-10, 10)


### PR DESCRIPTION
Simply put, this makes telescience actually usable and adds consistency with every other codebases's telescience.

Only the angle(elevation) offset is removed, both the bearing and power offsets still remain. You will still have to calibrate telescience, it's just not practically impossible to do so anymore.