### PR TITLE
Colored lights.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1789,6 +1789,7 @@
 #include "code\modules\urist\structures\dresser.dm"
 #include "code\modules\urist\structures\emplacements.dm"
 #include "code\modules\urist\structures\engicart.dm"
+#include "code\modules\urist\structures\uristlighting.dm"
 #include "code\modules\urist\structures\uriststructures.dm"
 #include "code\modules\urist\vehicles\fourwheel.dm"
 #include "code\modules\urist\vehicles\motorcycle.dm"

--- a/code/modules/urist/modules/supplycrates.dm
+++ b/code/modules/urist/modules/supplycrates.dm
@@ -64,3 +64,23 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	containername = "Xenobiology supplies crate"
 	access = access_rd
 	group = "Medical / Science"
+
+/datum/supply_packs/tintedlighttubes
+	name = "Replacement tinted lights"
+	contains = list(/obj/item/weapon/storage/box/lights/mixedtint,
+					/obj/item/weapon/storage/box/lights/mixedtint,
+					/obj/item/weapon/storage/box/lights/mixedtint)
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "Replacement tinted lights"
+	group = "Engineering"
+
+/datum/supply_packs/redlightbulbs
+	name = "Replacement maintenance lights"
+	contains = list(/obj/item/weapon/storage/box/lights/redbulbs,
+					/obj/item/weapon/storage/box/lights/redbulbs,
+					/obj/item/weapon/storage/box/lights/redbulbs)
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "Replacement maintenance lights"
+	group = "Engineering"

--- a/code/modules/urist/structures/uristlighting.dm
+++ b/code/modules/urist/structures/uristlighting.dm
@@ -1,0 +1,108 @@
+///////////////////////////////////////////////////////////////////////////
+//                                                                       //
+//                      URIST CUSTOM LIGHTS                              //
+//    put both lightbulb-style obj/weapons and light machinery here      //
+//                                                                       //
+///////////////////////////////////////////////////////////////////////////
+
+//spoopy red maint lights, Alien-style
+/obj/machinery/light/small/red
+	icon_state = "firelight1"
+	fitting = "bulb"
+	brightness_range = 6
+	brightness_power = 1
+	active_power_usage = 10
+	desc = "A small, low-power lighting fixture used for maintenance lighting."
+	light_type = /obj/item/weapon/light/bulb //tentatively leaving it this way, so it can be swapped back for regular bulbs and vice-versa
+	brightness_color = "#B12525"
+
+/obj/item/weapon/light/bulb/red
+	name = "light bulb (maintenance)"
+	desc = "A replacement light bulb. This one has a red filter and is designed for usage in Maintenance."
+	icon_state = "flight"
+	base_state = "flight"
+	item_state = "contvapour"
+	brightness_range = 6
+	brightness_power = 1
+	brightness_color = "#B12525"
+
+//cold, blue tint; feedback was good on putting it in Medbay
+/obj/machinery/light/coldtint
+	brightness_color = "#B0DCEA"
+
+/obj/item/weapon/light/tube/tinted
+	name = "light tube (tinted)"
+	desc = "A replacement light tube."
+	brightness_color = "#F0008C" //PANK. Shouldn't show up normally, so it's a telltale color something's wrong.
+
+/obj/item/weapon/light/tube/tinted/coldtint
+	name = "light tube (cold-light)"
+	desc = "A replacement light tube. This one emits soothing high-Kelvin light."
+	icon_state = "ltube"
+	base_state = "ltube"
+	item_state = "c_tube"
+	brightness_color = "#B0DCEA"
+
+//super warm tint (color literally stolen from candles), for the Bar
+/obj/machinery/light/warmtint
+	brightness_color = "#E09D37"
+
+/obj/item/weapon/light/tube/tinted/warmtint
+	name = "light tube (incandescent)"
+	desc = "A replacement light tube. This one emits amber low-Kelvin light."
+	icon_state = "ltube"
+	base_state = "ltube"
+	item_state = "c_tube"
+	brightness_color = "#E09D37"
+
+//green tint
+/obj/machinery/light/greentint
+	brightness_color = "#A8FFB1"
+
+/obj/item/weapon/light/tube/tinted/greentint
+	name = "light tube (green)"
+	desc = "A replacement light tube. This one has an integrated green filter for vibrant green light."
+	icon_state = "ltube"
+	base_state = "ltube"
+	item_state = "c_tube"
+	brightness_color ="#A8FFB1"
+
+/obj/item/weapon/light/tube/tinted/redtint
+	name = "light tube (red)"
+	desc = "A replacement light tube. This one has an integrated red filter."
+	icon_state = "ltube"
+	base_state = "ltube"
+	item_state = "c_tube"
+	brightness_color ="#B12525"
+
+//because the train lamp sprite is nice
+/obj/item/device/flashlight/lamp/lantern
+	name = "lantern"
+	desc = "An apparently old-school portable kerosene lamp, using modern technology to provide an extremely long-lasting flame with no fire hazard."
+	icon = 'icons/urist/events/train.dmi'
+	icon_state = "wolfflight"
+	item_state = "lamp"
+	brightness_on = 3
+	light_color = "#E09D37"
+	w_class = 4
+	flags = CONDUCT
+
+	on = 1
+
+/obj/item/weapon/storage/box/lights/mixedtint
+	name = "box of replacement tinted lights"
+	icon_state = "lightmixed"
+
+/obj/item/weapon/storage/box/lights/mixedtint/New()
+	for(var/i = 0; i < 21; i++)
+		var/variant = pick((typesof(/obj/item/weapon/light/tube/tinted)) - (/obj/item/weapon/light/tube/tinted))
+		new variant(src)
+	..()
+
+/obj/item/weapon/storage/box/lights/redbulbs
+	name = "box of replacement red bulbs"
+
+/obj/item/weapon/storage/box/lights/redbulbs/New()
+	for(var/i = 0; i < 21; i++)
+		new /obj/item/weapon/light/bulb/red(src)
+	..()


### PR DESCRIPTION
Adds tinted light tubes (high/low color temp, red, green) and red bulbs for maint, along with pre-set light fixtures for them and orderable crates. *NOT* mapped in anywhere. All the screenshots except the maint one were made with the tubes switched by hand. Oh, and a proper flamey lantern using the train lantern sprite; kinda redundant, but I'm planning to use this one as bar lights eventually.

Taking the lights out of the fixture, once put in, unfortunately lose the descriptive tag, but I can't address it without messing with Bay code and it's a very minor issue.

Warm-tube lit bar (also proof-of-concept for mapping that in later):
![scrnshot4](https://cloud.githubusercontent.com/assets/4363639/12873988/498d8672-cdcb-11e5-875c-a6362b31831d.png)

Green/redbulb-lit Xenobio (also PoC):
![scrnshot6](https://cloud.githubusercontent.com/assets/4363639/12874007/adf2d4d2-cdcb-11e5-9eae-83d18a04d99c.png)

Redbulbs as maint lights in action:
![scrnshot5](https://cloud.githubusercontent.com/assets/4363639/12874014/d8cac49e-cdcb-11e5-9c1c-70204f435850.png)

Many different lights in play in Medbay:
![scrnshot2](https://cloud.githubusercontent.com/assets/4363639/12874020/14381c02-cdcc-11e5-89af-e6e53b1367e7.png)
