### PR TITLE
Paranoia 3: The Omega Code

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1684,6 +1684,7 @@
 #include "code\modules\urist\gamemodes\paranoia\conspiracyitems.dm"
 #include "code\modules\urist\gamemodes\paranoia\conspiracyleader.dm"
 #include "code\modules\urist\gamemodes\paranoia\paranoia.dm"
+#include "code\modules\urist\gamemodes\paranoia\paranoiahelpers.dm"
 #include "code\modules\urist\gamemodes\scom\alienspawns.dm"
 #include "code\modules\urist\gamemodes\scom\civilian_mobs.dm"
 #include "code\modules\urist\gamemodes\scom\machinery.dm"

--- a/code/modules/urist/gamemodes/paranoia/conspiracyitems.dm
+++ b/code/modules/urist/gamemodes/paranoia/conspiracyitems.dm
@@ -55,8 +55,10 @@
 	var/basedesc = "A file containing top-secret data."
 	var/faction = "Broken Code Initiative"
 
-/obj/item/weapon/conspiracyintel/New()
+/obj/item/weapon/conspiracyintel/New(var/presetconspiracy)
 	..()
+	if(presetconspiracy)
+		faction = presetconspiracy
 	var/datatype = pick("blueprints","financial records","operational reports","experimental data","access codes","personnel files","schematics","operation plans","communication frequencies")
 	var/valuedesc
 	value = pick(2,4,6)
@@ -297,3 +299,10 @@
 	..()
 	new /obj/item/clothing/suit/urist/fleshsuit(src)
 	new /obj/item/clothing/mask/gas/voice/fleshmask(src)
+
+/obj/effect/landmark/intelspawn
+	var/probability = 50 //so that it can be tweaked for areas with various amounts of traffic
+
+/obj/effect/landmark/intelspawn/New()
+	invisibility = 101
+	return

--- a/code/modules/urist/gamemodes/paranoia/conspiracyleader.dm
+++ b/code/modules/urist/gamemodes/paranoia/conspiracyleader.dm
@@ -23,7 +23,7 @@ var/datum/antagonist/agent/agents
 	hard_cap = 3
 	hard_cap_round = 1
 	initial_spawn_req = 1
-	initial_spawn_target = 2
+	initial_spawn_target = 1
 
 	//Inround agents.
 	faction_role_text = "Conspiracy Agent"
@@ -58,7 +58,7 @@ var/datum/antagonist/agent/agents
 	if(!M.mind)
 		return
 
-	var/datum/antagonist/agent/conspiracy = get_mob_conspiracy(src)
+	var/datum/antagonist/agent/conspiracy = M.get_mob_conspiracy(src)
 
 	if(!conspiracy)
 		src << "<span class='warning'>Something's wrong. You belong to too many conspiracies at once!</span>"
@@ -98,7 +98,9 @@ var/datum/antagonist/agent/agents
 		return 0
 
 	spawn_uplink(agent_mob)
-	new /obj/item/device/inteluplink(agent_mob.loc, maker = src.faction_descriptor)
+	var/intel_laptop = new /obj/item/device/inteluplink(agent_mob.loc, maker = src.faction_descriptor)
+	if(!(agent_mob.equip_to_storage(intel_laptop)))
+		agent_mob.put_in_hands(intel_laptop)
 
 /datum/antagonist/agent/proc/spawn_uplink(var/mob/living/carbon/human/agent_mob)
 	if(!istype(agent_mob))

--- a/code/modules/urist/gamemodes/paranoia/paranoiahelpers.dm
+++ b/code/modules/urist/gamemodes/paranoia/paranoiahelpers.dm
@@ -1,0 +1,65 @@
+/proc/is_other_conspiracy(var/datum/mind/player,var/datum/antagonist/agent/conspiracy)
+	var/paranoia_parent = /datum/antagonist/agent
+	var/nonselfsum = 0 //how many other conspiracies the mind is a member of. Shouldn't come up, but better safe than sorry.
+	var/own //belongs to the target faction
+	for(var/antag_type in all_antag_types)
+		var/datum/antagonist/antag = all_antag_types[antag_type]
+		if(istype(antag,paranoia_parent))
+			if(istype(antag, conspiracy))
+				if(player in antag.current_antagonists)
+					own = 1
+				if(player in antag.pending_antagonists)
+					own = 1
+			else
+				if(player in antag.current_antagonists)
+					nonselfsum++
+				if(player in antag.pending_antagonists)
+					nonselfsum++
+		else
+			continue
+	if(own)
+		if(nonselfsum)
+			return 0 //somehow belongs to the target and other conspiracies
+		else
+			return -1 //doesn't need converting
+	return nonselfsum //number of conspiracy factions to strip
+
+/proc/strip_all_other_conspiracies(var/datum/mind/player,var/datum/antagonist/agent/conspiracy)
+	var/list/antaglist = all_antag_types.Copy()
+	var/paranoia_parent = /datum/antagonist/agent
+	antaglist -= paranoia_parent //kinda hacky, but prevents weirdness
+	for(var/antag_type in antaglist)
+		var/datum/antagonist/antag = antaglist[antag_type]
+		if(istype(antag,paranoia_parent))
+			if(istype(antag, conspiracy))
+				continue
+			else
+				if(player in antag.current_antagonists)
+					antag.remove_antagonist(player)
+		else
+			continue
+
+/mob/proc/get_mob_conspiracy(var/mob/M)
+
+	var/datum/mind/player = M.mind
+	if(!player)
+		return
+
+	var/list/antaglist = all_antag_types.Copy()
+	var/paranoia_parent = /datum/antagonist/agent
+	var/conspiracy_number = 0 //test to prevent cases where someone belongs to more than one and it overwrites, which shouldn't happen
+	var/mob_conspiracy
+	antaglist -= paranoia_parent
+
+	for(var/antag_type in antaglist)
+		var/datum/antagonist/antag = antaglist[antag_type]
+		if(istype(antag,paranoia_parent))
+			if(player in antag.current_antagonists)
+				conspiracy_number++
+				mob_conspiracy = antag
+
+	if(conspiracy_number == 0)
+		return -1
+	else if(conspiracy_number == 1)
+		return mob_conspiracy
+	return //this is an error state!


### PR DESCRIPTION
Assuming the antag spawning works, that is, I can't really test it by myself and if the last test is anything to go by, it could take a couple hours out of four people's life to do so. But optimistically, the mode should be fully playable.

**1)** Adds handling of periodic (10-15 minutes) intel spawns. I couldn't decide which method to use so I just used them all and var'd their usage so you can enable or disable landmark spawns and leader/laptop spawns independently of each other on runtime via gamemode debug.

**The leader spawns** are straightforward; it ALWAYS spawns an intel item of the respective faction; if there is a faction leader, it spawns in his storage items or, failing that, his hands, and failing THAT on the ground. The same spawning behavior was added to the uplink laptops.

Speaking of laptops, if there isn't a leader, the same intel will be spawned on and only on the first laptop of the appropriate faction the gamemode can find.

**The landmark spawns** are trickier. They spawn random-type intel on a prob; it can be set on the individual landmark for fine-tuning of spawning, e.g. lower the odds for slightly higher-traffic areas to encourage exploration, or for areas requiring more specific access; defaults to 50%, both as the landmark's var and in case of null value in that var.

At the same time, to allow to potentially add a jillion landmarks for variety, there's a var controlling how many intel pieces can spawn in one 'drop', so that even if all prob(10) landmarks you plopped down miraculously triggered, no more than X will spawn. It's pretty generous for now, it will probably need tweaking.

**LANDMARKS ARE NOT MAPPED IN YET!** I want to do it in a separate PR, because, y'know. Maps.

2) _Hopefully_ fixes the antag spawns. In yesterday's test, only Men in Grey spawned. I noticed I changed the antag id's (because laptops originally used that for the faction name and you pointed out they were lowercase there) but forgot to change antag_tags to match, but since MIG's id was already uppercase, it wasn't changed for them. It, uh, also possibly means the mode might runtime now. :x 

If that doesn't work, it's probably the initial_spawn vars counting all agent subtypes for spawning a particular subtype, which would be painfully dumb to do but unsurprising.