### PR TITLE
Anti-spam

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -221,7 +221,7 @@ SOCKET_TALK 0
 #TOR_BAN
 
 ## Comment this out to disable automuting
-#AUTOMUTE_ON
+AUTOMUTE_ON
 
 ## How long the delay is before the Away Mission gate opens. Default is half an hour.
 GATEWAY_DELAY 18000


### PR DESCRIPTION
Uses THE ANTI-SPAM MEASURE WE ALREADY HAD FUCKING IMPLEMENTED BUT DIDN'T ENABLE. ARGH.

Enables /client/proc/handle_spam_prevention() handling for OOC, ahelps et al which automutes successive identical messages above a threshold. It can be worked around by a spammer with half a braincell to show (so, pretty much none of them), but it's a matter of tweaking the existing filter.