### PR TITLE
Makes the planet surface use dynamic lighting

### DIFF
--- a/code/modules/urist/modules/jungle/jungle_areas.dm
+++ b/code/modules/urist/modules/jungle/jungle_areas.dm
@@ -16,7 +16,7 @@
 	name = "jungle"
 	icon = 'icons/jungle.dmi'
 	icon_state = "area"
-	lighting_use_dynamic = 0
+	lighting_use_dynamic = 1
 	luminosity = 1
 	base_turf = /turf/simulated/jungle/clear/grass1
 

--- a/code/modules/urist/modules/jungle/jungle_turfs.dm
+++ b/code/modules/urist/modules/jungle/jungle_turfs.dm
@@ -12,6 +12,9 @@
 	var/icon_spawn_state = "grass1"
 //	luminosity = 3
 	var/farmed = 0
+	light_color = null
+	light_power = 2
+	light_range = 2 //for some reason, range 1 doesn't apply at all.
 
 /turf/simulated/jungle/update_air_properties() //No, you can't flood the jungle with phoron silly.
 	return
@@ -52,6 +55,8 @@
 	else if(large_trees_high && prob(4)) //1 in ten? //noooooope
 		new /obj/structure/flora/tree/jungle/large(src)
 
+	update_light()
+
 /turf/simulated/jungle/ex_act(severity)
 	return
 
@@ -90,12 +95,14 @@
 	icon_spawn_state = null
 
 /turf/simulated/jungle/clear/New()
-	set_light(2)
+	//set_light(2)
 
 	for(var/obj/structure/bush/B in src)
 		qdel(B)
 	for(var/obj/structure/flora/F in src)
 		qdel(F)
+
+	update_light()
 
 /turf/simulated/jungle/clear/grass1
 	bushes_spawn = 0
@@ -164,10 +171,13 @@
 	density = 1
 	opacity = 1
 	name = "impassable rock wall"
+	desc = "A massive wall of natural rock. No point in trying to mine it, try underground."
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "rock"
 //	icon_spawn_state = "rock"
 	icon_spawn_state = null
+	light_range = 0
+	light_power = 0
 
 /turf/simulated/jungle/rock/attackby()
 	return
@@ -191,6 +201,7 @@
 			T = get_step(src, WEST)
 			if (T)
 				T.overlays += image('icons/turf/walls.dmi', "rock_side_e", layer=6)
+		update_light()
 
 /turf/simulated/jungle/water
 	bushes_spawn = 0
@@ -273,3 +284,9 @@
 	icon_state = "test"
 	icon_spawn_state = null
 
+/turf/simulated/jungle/clear/underground
+	name = "dirt"
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "asteroid"
+	light_range = 0
+	light_power = 0

--- a/code/modules/urist/structures/uristlighting.dm
+++ b/code/modules/urist/structures/uristlighting.dm
@@ -112,3 +112,13 @@
 	for(var/i = 0; i < 21; i++)
 		new /obj/item/weapon/light/bulb/red(src)
 	..()
+
+//experiment - object-based sunlight.
+/obj/effect/sun
+	name = "sun"
+	desc = "You really shouldn't be seeing this."
+	invisibility = 101
+	anchored = 1
+	light_color = "#fcfcb6"
+	light_power = 1
+	light_range = 127

--- a/maps/templates/planet_cave1.dmm
+++ b/maps/templates/planet_cave1.dmm
@@ -1,11 +1,11 @@
 "a" = (/turf/simulated/jungle/med,/area/jungle)
 "b" = (/turf/simulated/jungle/thick,/area/jungle)
 "c" = (/turf/simulated/jungle/rock,/area/jungle)
-"d" = (/turf/simulated/jungle/clear/dark{icon = 'icons/turf/floors.dmi'; icon_state = "asteroid"},/area/jungle)
-"e" = (/obj/effect/spider,/turf/simulated/jungle/clear/dark{icon = 'icons/turf/floors.dmi'; icon_state = "asteroid"},/area/jungle)
-"f" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/jungle/clear/dark{icon = 'icons/turf/floors.dmi'; icon_state = "asteroid"},/area/jungle)
-"g" = (/obj/effect/landmark/loot_spawn/low,/turf/simulated/jungle/clear/dark{icon = 'icons/turf/floors.dmi'; icon_state = "asteroid"},/area/jungle)
-"h" = (/obj/effect/spider,/obj/effect/decal/cleanable/cobweb,/obj/effect/decal/cleanable/dirt,/turf/simulated/jungle/clear/dark,/area/jungle)
+"d" = (/turf/simulated/jungle/clear/underground,/area/jungle)
+"e" = (/obj/effect/spider,/turf/simulated/jungle/clear/underground,/area/jungle)
+"f" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/jungle/clear/underground,/area/jungle)
+"g" = (/obj/effect/landmark/loot_spawn/low,/turf/simulated/jungle/clear/underground,/area/jungle)
+"h" = (/obj/effect/spider,/obj/effect/decal/cleanable/cobweb,/obj/effect/decal/cleanable/dirt,/turf/simulated/jungle/clear/underground,/area/jungle)
 
 (1,1,1) = {"
 aabbbbbccccbbba


### PR DESCRIPTION
Turfs emit light via the light system proper, since luminosity setting was hacky.

Makes the cave floor a legit turf type and not an icon edit. Edits the rock wall not to be grass in desc. Adds an (unused) sun effect.

Tested, works. Minor stutter at the roundstart to update it all, but no issues later.