### PR TITLE
Paranoia 3.1: The Idiot Coder: The Spawnfixening

### DIFF
--- a/code/modules/urist/gamemodes/paranoia/conspiracyitems.dm
+++ b/code/modules/urist/gamemodes/paranoia/conspiracyitems.dm
@@ -119,10 +119,13 @@
 	var/cached_progress = 0 					//persistent progress - if you stop uploading, you can resume it later if it's the same file
 	var/progress = 0 							//temporary progress
 	var/lastuploaded = -1 						//caches id of the last intel item
-	
+
 /obj/item/device/inteluplink/AltClick()
 	if(Adjacent(usr))
-		open_computer()
+		if(!open)
+			open_computer()
+		else if(open)
+			close_computer()
 
 /obj/item/device/inteluplink/New(var/maker)
 	..()
@@ -258,8 +261,8 @@
 		if(I.hidden_uplink)
 			var/obj/item/device/uplink/hidden/suplink = I.hidden_uplink
 			suplink.uses += stored_crystals
-			stored_crystals = 0
 			user << "<span class='notice'>Your [I] pings quietly as [stored_crystals] telecrystals are added to it.</span>"
+			stored_crystals = 0
 	..()
 
 //a suit that looks like a black-haired human in a suit, for muh Reptilians and/or Thin Mints

--- a/code/modules/urist/gamemodes/paranoia/paranoia.dm
+++ b/code/modules/urist/gamemodes/paranoia/paranoia.dm
@@ -77,7 +77,7 @@
 //INTEL-DROPPING CODE BEGIN//
 
 /datum/game_mode/paranoia/process()
-	if(world.time < next_intel_drop)
+	if(world.time > next_intel_drop)
 		process_intel_drop()
 	..()
 


### PR DESCRIPTION
Fixes intel spawns, uplinks saying 0 TCs were added, makes uplinks open/close via Alt-click.

Of *course* the problem with the spawns was just a '<' where a '>' should be. Tested, works fine now, and plays ball with latespawned intel spawnpoints.