### PR TITLE
Assault mode venders

### DIFF
--- a/code/modules/urist/machinery/uristvending.dm
+++ b/code/modules/urist/machinery/uristvending.dm
@@ -175,3 +175,45 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	products = list(/obj/item/weapon/storage/belt/vanity/leather = 5,/obj/item/weapon/storage/belt/vanity/cowboy = 5,/obj/item/weapon/storage/belt/vanity/black = 10,/obj/item/weapon/storage/belt/vanity/red = 10,/obj/item/weapon/storage/belt/vanity/green = 10,/obj/item/weapon/storage/belt/vanity/purple = 10,/obj/item/weapon/storage/belt/vanity/blue = 10,/obj/item/weapon/storage/belt/vanity/orange = 10)
 	prices = list(/obj/item/weapon/storage/belt/vanity/leather = 250,/obj/item/weapon/storage/belt/vanity/cowboy = 250,/obj/item/weapon/storage/belt/vanity/black = 100,/obj/item/weapon/storage/belt/vanity/red = 100,/obj/item/weapon/storage/belt/vanity/green = 100,/obj/item/weapon/storage/belt/vanity/purple = 100,/obj/item/weapon/storage/belt/vanity/blue = 100,/obj/item/weapon/storage/belt/vanity/orange = 100)
 	contraband = list(/obj/item/weapon/storage/belt/utility = 1)
+
+//Assault mode vender
+
+/obj/machinery/vending/urist/assaultdispenser
+	name = "Military Ammunition Vender"
+	desc = "An automated military supply cache for efficent storage and distribution of ammunition and material."
+	icon_state = "clothing2"
+	vend_reply = "Git some!"
+	product_ads = "Food for your rifle.;Out of rounds? We're here for you.;Resupply here!"
+	product_slogans = "Bullets for every occasion!;Tactical reloads!;RAMAREZ!"
+	vend_delay = 5
+	products = list(
+		//ammo
+		/obj/item/ammo_magazine/a556/m16 = 60,
+		/obj/item/ammo_magazine/a762/m60 = 60,
+		/obj/item/ammo_magazine/a762/m14 = 60,
+		/obj/item/weapon/storage/box/shotgunammo = 60,
+		/obj/item/weapon/storage/box/shotgunshells = 60,
+		/obj/item/ammo_magazine/c45m/m3 = 60,
+		/obj/item/ammo_magazine/mc9mm/bhp = 60,
+		//guns
+		/obj/item/weapon/gun/projectile/automatic/l6_saw/m60 = 3,
+		/obj/item/weapon/gun/projectile/automatic/m14 = 10,
+		/obj/item/weapon/gun/projectile/automatic/m16 = 15,
+		/obj/item/weapon/gun/projectile/automatic/m16/gl = 5,
+		/obj/item/weapon/gun/projectile/shotgun/pump/combat/ithaca = 10,
+		/obj/item/weapon/gun/projectile/automatic/m3 = 10,
+		/obj/item/weapon/gun/projectile/bhp9mm = 10,
+		//gernades and mines
+		/obj/item/weapon/storage/box/anforgrenade = 20,
+		/obj/item/weapon/storage/box/mines = 5
+		)
+	contraband = list(
+		/obj/item/weapon/storage/box/flashshells = 5,
+		/obj/item/weapon/storage/box/beanbags = 5,
+		/obj/item/ammo_magazine/mc9mmt = 10,
+		/obj/item/ammo_magazine/c45m = 10,
+		/obj/item/ammo_magazine/a556 = 10,
+		/obj/item/ammo_magazine/c762 = 10
+		)
+		
+		

--- a/code/modules/urist/machinery/uristvending.dm
+++ b/code/modules/urist/machinery/uristvending.dm
@@ -202,7 +202,7 @@ Please keep it tidy, by which I mean put comments describing the item before the
 		/obj/item/weapon/gun/projectile/automatic/m16/gl = 5,
 		/obj/item/weapon/gun/projectile/shotgun/pump/combat/ithaca = 10,
 		/obj/item/weapon/gun/projectile/automatic/m3 = 10,
-		/obj/item/weapon/gun/projectile/bhp9mm = 10,
+		/obj/item/weapon/gun/projectile/bhp9mm = 20,
 		//gernades and mines
 		/obj/item/weapon/storage/box/anforgrenade = 20,
 		/obj/item/weapon/storage/box/mines = 5
@@ -210,7 +210,7 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	contraband = list(
 		/obj/item/weapon/storage/box/flashshells = 5,
 		/obj/item/weapon/storage/box/beanbags = 5,
-		/obj/item/ammo_magazine/mc9mmt = 10,
+		/obj/item/ammo_magazine/c38 = 10,
 		/obj/item/ammo_magazine/c45m = 10,
 		/obj/item/ammo_magazine/a556 = 10,
 		/obj/item/ammo_magazine/c762 = 10

--- a/code/modules/urist/machinery/uristvending.dm
+++ b/code/modules/urist/machinery/uristvending.dm
@@ -227,15 +227,11 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	vend_reply = "Suit up!"
 	icon_state = "clothing2"
 	products = list(
-		/obj/item/clothing/suit/urist/armor/anfor/nco = 2,
 		/obj/item/clothing/suit/urist/armor/anfor/marine = 20,
-		/obj/item/clothing/suit/urist/armor/anfor/engi = 5,
-		/obj/item/clothing/suit/urist/armor/anfor/medic = 5,
-		/obj/item/clothing/under/urist/anfor = 30,
-		/obj/item/clothing/head/helmet/urist/anfor = 30,
-		/obj/item/clothing/head/soft/anfor = 2,
-		/obj/item/clothing/shoes/urist/anforjackboots = 30,
-		/obj/item/weapon/storage/belt/security/tactical = 30
+		/obj/item/clothing/under/urist/anfor = 20,
+		/obj/item/clothing/head/helmet/urist/anfor = 20,
+		/obj/item/clothing/shoes/urist/anforjackboots = 20,
+		/obj/item/weapon/storage/belt/security/tactical = 20
 		)
 	contraband = list(
 		/obj/item/weapon/storage/fancy/cigar = 1

--- a/code/modules/urist/machinery/uristvending.dm
+++ b/code/modules/urist/machinery/uristvending.dm
@@ -179,8 +179,8 @@ Please keep it tidy, by which I mean put comments describing the item before the
 //Assault mode vender
 
 /obj/machinery/vending/urist/assaultdispenser
-	name = "Military Ammunition Vender"
-	desc = "An automated military supply cache for efficent storage and distribution of ammunition and material."
+	name = "ANFOR Ammunition Vender"
+	desc = "An automated ANFOR supply cache for efficent storage and distribution of ammunition and material."
 	icon_state = "clothing2"
 	vend_reply = "Git some!"
 	product_ads = "Food for your rifle.;Out of rounds? We're here for you.;Resupply here!"
@@ -188,24 +188,24 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	vend_delay = 5
 	products = list(
 		//ammo
-		/obj/item/ammo_magazine/a556/m16 = 60,
-		/obj/item/ammo_magazine/a762/m60 = 60,
-		/obj/item/ammo_magazine/a762/m14 = 60,
+		/obj/item/ammo_magazine/a556/a22 = 60,
+		/obj/item/ammo_magazine/a762/a18 = 60,
+		/obj/item/ammo_magazine/a9mm = 60,
 		/obj/item/weapon/storage/box/shotgunammo = 60,
 		/obj/item/weapon/storage/box/shotgunshells = 60,
-		/obj/item/ammo_magazine/c45m/m3 = 60,
-		/obj/item/ammo_magazine/mc9mm/bhp = 60,
+		/obj/item/ammo_magazine/c45m/a7 = 60,
 		//guns
-		/obj/item/weapon/gun/projectile/automatic/l6_saw/m60 = 3,
-		/obj/item/weapon/gun/projectile/automatic/m14 = 10,
-		/obj/item/weapon/gun/projectile/automatic/m16 = 15,
-		/obj/item/weapon/gun/projectile/automatic/m16/gl = 5,
-		/obj/item/weapon/gun/projectile/shotgun/pump/combat/ithaca = 10,
-		/obj/item/weapon/gun/projectile/automatic/m3 = 10,
-		/obj/item/weapon/gun/projectile/bhp9mm = 20,
+		/obj/item/weapon/gun/projectile/automatic/a22 = 10,
+		/obj/item/weapon/gun/projectile/a18 = 10,
+		/obj/item/weapon/gun/projectile/automatic/asmg = 10,
+		/obj/item/weapon/gun/projectile/shotgun/pump/combat/A41 = 10,
+		/obj/item/weapon/gun/projectile/colt/a7 = 20,
+		//attachments
+		/obj/item/weapon/gunattachment/grenadelauncher = 10,
+		/obj/item/weapon/gunattachment/scope/a18 = 10,
 		//gernades and mines
-		/obj/item/weapon/storage/box/anforgrenade = 20,
-		/obj/item/weapon/storage/box/mines = 5
+		/obj/item/weapon/storage/box/anforgrenade = 10,
+		/obj/item/weapon/storage/box/mines = 3
 		)
 	contraband = list(
 		/obj/item/weapon/storage/box/flashshells = 5,

--- a/code/modules/urist/machinery/uristvending.dm
+++ b/code/modules/urist/machinery/uristvending.dm
@@ -184,7 +184,7 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	icon_state = "clothing2"
 	vend_reply = "Git some!"
 	product_ads = "Food for your rifle.;Out of rounds? We're here for you.;Resupply here!"
-	product_slogans = "Bullets for every occasion!;Tactical reloads!;RAMAREZ!"
+	product_slogans = "Bullets for every occasion!;Tactical reloads!;RAMIREZ!"
 	vend_delay = 5
 	products = list(
 		//ammo

--- a/code/modules/urist/machinery/uristvending.dm
+++ b/code/modules/urist/machinery/uristvending.dm
@@ -176,11 +176,11 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	prices = list(/obj/item/weapon/storage/belt/vanity/leather = 250,/obj/item/weapon/storage/belt/vanity/cowboy = 250,/obj/item/weapon/storage/belt/vanity/black = 100,/obj/item/weapon/storage/belt/vanity/red = 100,/obj/item/weapon/storage/belt/vanity/green = 100,/obj/item/weapon/storage/belt/vanity/purple = 100,/obj/item/weapon/storage/belt/vanity/blue = 100,/obj/item/weapon/storage/belt/vanity/orange = 100)
 	contraband = list(/obj/item/weapon/storage/belt/utility = 1)
 
-//Assault mode vender
+//Assault mode ammo vender
 
-/obj/machinery/vending/urist/assaultdispenser
-	name = "ANFOR Ammunition Vender"
-	desc = "An automated ANFOR supply cache for efficent storage and distribution of ammunition and material."
+/obj/machinery/vending/urist/assaultammodispenser
+	name = "ANFOR Weapon Cache"
+	desc = "An automated ANFOR supply cache for efficent storage and distribution of weapons, ammunition and material."
 	icon_state = "clothing2"
 	vend_reply = "Git some!"
 	product_ads = "Food for your rifle.;Out of rounds? We're here for you.;Resupply here!"
@@ -216,4 +216,29 @@ Please keep it tidy, by which I mean put comments describing the item before the
 		/obj/item/ammo_magazine/c762 = 10
 		)
 		
+//Assault mode clothing and armor vender
 		
+/obj/machinery/vending/urist/assaultclothingdispenser
+	name = "ANFOR Equipment Cache"
+	desc = "An automated ANFOR supply cache for efficent storage and distribution of armor and equipment."
+	product_slogans = "Look like a real soldier."
+	product_ads = "Keep yourself covered.;Protection for our fighting forces."
+	vend_delay = 15
+	vend_reply = "Suit up!"
+	icon_state = "clothing2"
+	products = list(
+		/obj/item/clothing/suit/urist/armor/anfor/nco = 2,
+		/obj/item/clothing/suit/urist/armor/anfor/marine = 20,
+		/obj/item/clothing/suit/urist/armor/anfor/engi = 5,
+		/obj/item/clothing/suit/urist/armor/anfor/medic = 5,
+		/obj/item/clothing/under/urist/anfor = 30,
+		/obj/item/clothing/head/helmet/urist/anfor = 30,
+		/obj/item/clothing/head/soft/anfor = 2,
+		/obj/item/clothing/shoes/urist/anforjackboots = 30,
+		/obj/item/weapon/storage/belt/security/tactical = 30
+		)
+	contraband = list(
+		/obj/item/weapon/storage/fancy/cigar = 1
+		)
+	
+	


### PR DESCRIPTION
Adds a vender which can be used for assault mode that dispences both weapons, ammo, grenades and mines. It includes all the assault mode guns and assault mode specific ammo and mags as well as the boxes of mines and grenades. It can be hacked to produce more mundane regular mags and ammo. Currently uses NT vender icon.