### PR TITLE
Spoop cleanup

### DIFF
--- a/code/modules/urist/mob/humanhostiles.dm
+++ b/code/modules/urist/mob/humanhostiles.dm
@@ -5,7 +5,7 @@
 	icon_state = "gunman"
 	icon_living = "gunman"
 	icon_dead = "gunman_dead"
-	icon_gib = "syndicate_gib"
+	icon_gib = null
 	speak_chance = 0
 	turns_per_move = 5
 	response_help = "pokes"
@@ -55,6 +55,8 @@
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "syndicateranged"
 	icon_living = "syndicateranged"
+	icon_dead = "syndicate_dead"
+	icon_gib = "syndicate_gib"
 	casingtype = /obj/item/ammo_casing/a10mm
 	projectilesound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	projectiletype = /obj/item/projectile/bullet/pistol/medium
@@ -120,6 +122,7 @@
 	move_to_delay = 9 //this armor is *heavy*
 	maxHealth = 200 //but it offers some serious protection
 	health = 200
+	resistance = 4 //including padding
 	minimum_distance = 1
 	faction = "NTIS"
 	attack_sound = 'sound/weapons/genhit3.ogg'
@@ -151,4 +154,4 @@
 /mob/living/simple_animal/hostile/urist/cultist/death()
 	..()
 	new /obj/effect/effect/smoke/bad(loc)
-	del src
+	qdel(src)

--- a/code/modules/urist/mob/spoopymobs.dm
+++ b/code/modules/urist/mob/spoopymobs.dm
@@ -1,4 +1,4 @@
-/mob/living/simple_animal/hostile/zombie
+/mob/living/simple_animal/hostile/urist/zombie
 	name = "zombie"
 	desc = "Dead man walking - and hungry for your flesh."
 	speak_emote = list("groans")
@@ -6,8 +6,8 @@
 	icon_state = "zombie_s"
 	icon_living = "zombie_s"
 	icon_dead = "zombie_d"
-	health = 20
-	maxHealth = 20
+	health = 40
+	maxHealth = 40
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	attacktext = "bit"
@@ -26,73 +26,81 @@
 	aggro_vision_range = 15 //fairly easy to evade a single one, but DO NOT PISS THEM OFF
 	move_to_delay = 7
 	stat_attack = 1
+	ranged = 0
+	var/plague = 0 //whether biting dead people spawns new zombies
+	var/regen = 0 //if true, they won't stay down, but revive after a delay
+	var/regen_delay = 900 //delay for regen revive
 
-/mob/living/simple_animal/hostile/zombie/say()
+/mob/living/simple_animal/hostile/urist/zombie/say()
 	var/message = "Braaaaaaains!"
 	..(message)
 
-/mob/living/simple_animal/hostile/zombie/regen //variant if you want to really fuck players' day up.
+/mob/living/simple_animal/hostile/urist/zombie/death()
+	..()
+	if(regen)
+		var/tempnameholder = src.name
+		var/tempdescholder = src.desc
+		src.name = "corpse"
+		src.desc = "It's a corpse. Very dead."
+
+		var/matrix/M = matrix() //shamelessly stolen from human update_icons
+		M.Turn(90)
+		M.Translate(1,-6)
+		src.transform = M
+
+		src << "You begin to regenerate. This will take about [regen_delay/600] minutes."
+		spawn(regen_delay)
+			var/matrix/N = matrix()
+			src.transform = N
+			health = maxHealth
+			src.name = tempnameholder
+			src.desc = tempdescholder
+
+/mob/living/simple_animal/hostile/urist/zombie/generic
+	plague = 0
+	regen = 0
+
+/mob/living/simple_animal/hostile/urist/zombie/regen //variant if you want to really fuck players' day up.
 	desc = "This zombie SIMPLY. WON'T. STAY. DEAD. Run!"
-	health = 40
-	maxHealth = 40
+	health = 60
+	maxHealth = 60
 	idle_vision_range = 3
+	regen = 1
 	icon_dead = "zombie_s" //ugly, but effective, workaround to use sprite rotation instead of having a custom death icon
 
-/mob/living/simple_animal/hostile/zombie/regen/New()
-	..()
-	src.health = -1 //starts masqueraded as a unknown corpse
-
-/mob/living/simple_animal/hostile/zombie/regen/death()
-	..()
-	var/tempnameholder = src.name
-	var/tempdescholder = src.desc
-	src.name = "corpse"
-	src.desc = "It's a corpse. Very dead."
-
-	var/matrix/M = matrix() //shamelessly stolen from human update_icons
-	M.Turn(90)
-	M.Translate(1,-6)
-	src.transform = M
-
-	src << "You begin to regenerate. This will take about 1.5 minutes."
-	spawn(900)
-		var/matrix/N = matrix()
-		src.transform = N
-		health = maxHealth
-		src.name = tempnameholder
-		src.desc = tempdescholder
-
-
-/mob/living/simple_animal/hostile/zombie/regen/plague //Because non-infectious unkillable zombies weren't bad enough. Round-ender.
+/mob/living/simple_animal/hostile/urist/zombie/regenplague //Because non-infectious unkillable zombies weren't bad enough. Round-ender.
 	desc = "A bloodthirsty and brain-hungry corpse revived by an unknown infectious pathogen with extreme regenerative abilities."
 	stat_attack = 2
+	regen = 1
+	plague = 1
 
-/mob/living/simple_animal/hostile/zombie/regen/plague/AttackingTarget()
-	if(istype(target, /mob/living/carbon/human))
-		var/mob/living/carbon/human/victim = target
-		if(victim.stat == DEAD)
-			src.visible_message("<span class = 'warning'> <b>[src]</b> chomps at [victim]'s brain!</span>", "<span class = 'warning'>You munch on [victim]'s brain!</span>")
-			victim.Zombify(src.type)
-			return
+/mob/living/simple_animal/hostile/urist/zombie/AttackingTarget()
+	if(plague)
+		var/infectious = src.plague
+		var/regenerative = src.regen
+		var/resilience = src.maxHealth
+		if(istype(src.target, /mob/living/carbon/human))
+			var/mob/living/carbon/human/victim = target
+			if(victim.stat == DEAD)
+				src.visible_message("<span class = 'warning'> <b>[src]</b> chomps at [victim]'s brain!</span>", "<span class = 'warning'>You munch on [victim]'s brain!</span>")
+				victim.Zombify(regenerative, infectious, resilience)
+				return
+		else if(istype(src.target, /mob/living/simple_animal/hostile/scom/civ))
+			var/mob/living/simple_animal/hostile/scom/civ/victim = target
+			if(victim.stat == DEAD)
+				src.visible_message("<span class = 'warning'> <b>[src]</b> chomps at [victim]'s brain!</span>", "<span class = 'warning'>You munch on [victim]'s brain!</span>")
+				victim.SAZombify(regenerative, infectious, resilience)
+				return
 		else
 			..()
-	else if(istype(target, /mob/living/simple_animal/hostile/scom/civ))
-		var/mob/living/simple_animal/hostile/scom/civ/victim = target
-		if(victim.stat == DEAD)
-			src.visible_message("<span class = 'warning'> <b>[src]</b> chomps at [victim]'s brain!</span>", "<span class = 'warning'>You munch on [victim]'s brain!</span>")
-			victim.SAZombify(src.type)
-			return
-		else
-			..()
-	else
-		..()
+	..()
 
-/mob/living/simple_animal/hostile/zombie/regen/plague/verb/EatBrain()
+/mob/living/simple_animal/hostile/urist/zombie/verb/EatBrain()
 
 	set name = "Eat Brain"
 	set desc = "Eat a target corpse's brain to zombify him."
 
-	if(stat)
+	if(stat || !(plague))
 		src << "You cannot eat brains in your current state."
 		return
 
@@ -110,19 +118,17 @@
 	if(istype(T, /mob/living/carbon/human))
 		var/mob/living/carbon/human/victim = T
 		src.visible_message("<span class = 'warning'><b>[src]</b> chomps at [victim]'s brain!</span>", "<span class = 'warning'>You munch on [victim]'s brain!</span>")
-		victim.Zombify(src.type)
+		victim.Zombify(src.regen, src.plague, src.maxHealth)
 	else if(istype(T, /mob/living/simple_animal/hostile/scom/civ))
 		var/mob/living/simple_animal/hostile/scom/civ/victim = T
 		src.visible_message("<span class = 'warning'> <b>[src]</b> chomps at [victim]'s brain!</span>", "<span class = 'warning'>You munch on [victim]'s brain!</span>")
-		victim.SAZombify(src.type)
+		victim.SAZombify(src.regen, src.plague, src.maxHealth)
 	return
 
 
-/mob/living/carbon/human/proc/Zombify(var/mobpath) //I swear officer, that Animalize() proc fell out the back of a truck.
+/mob/living/carbon/human/proc/Zombify(var/regens = 0, var/infects = 0, var/hitpoints = 40) //I swear officer, that Animalize() proc fell out the back of a truck.
 
-	if(!(istype(mobpath, /mob/living/simple_animal/hostile/zombie))) //not very elegant, but it prevens abuse for other mobtypes
-		mobpath = /mob/living/simple_animal/hostile/zombie/regen/plague
-
+	var/mobpath = /mob/living/simple_animal/hostile/urist/zombie
 	if(transforming)
 		return
 	for(var/obj/item/W in src)
@@ -144,7 +150,7 @@
 	for(var/t in organs)
 		qdel(t)
 
-	var/mob/living/simple_animal/hostile/zombie/new_mob = new mobpath(src.loc)
+	var/mob/living/simple_animal/hostile/urist/zombie/new_mob = new mobpath(src.loc)
 
 	new_mob.key = key
 	new_mob.a_intent = "hurt"
@@ -161,37 +167,43 @@
 		if(!(old_name == "unknown"))
 			new_mob.name = "zombified [old_name]"
 			new_mob.real_name = new_mob.name
+			new_mob.regen = regens
+			new_mob.plague = infects
+			new_mob.maxHealth = hitpoints
+			new_mob.health = hitpoints
 
 	spawn()
 		qdel(src)
 	return
 
-/mob/living/simple_animal/hostile/scom/civ/proc/SAZombify(var/mobpath)//contrary to the name, does not involve undead Goons
+/mob/living/simple_animal/hostile/scom/civ/proc/SAZombify(var/regens = 0, var/infects = 0, var/hitpoints = 40)//contrary to the name, does not involve undead Goons
+	var/mobpath = /mob/living/simple_animal/hostile/urist/zombie/regenplague
 
-	if(!(istype(mobpath, /mob/living/simple_animal/hostile/zombie)))
-		mobpath = "/mob/living/simple_animal/hostile/zombie/regen/plague"
-
-	var/mob/living/simple_animal/hostile/zombie/new_mob = new mobpath(src.loc)
+	var/mob/living/simple_animal/hostile/urist/zombie/new_mob = new mobpath(src.loc)
 
 	icon = null
 	invisibility = 101
 
 	new_mob.key = key
 	new_mob.a_intent = "hurt"
+	new_mob.regen = regens
+	new_mob.plague = infects
+	new_mob.maxHealth = hitpoints
+	new_mob.health = hitpoints
 
 	spawn()
 		qdel(src)
 	return
 
-/mob/living/simple_animal/hostile/vampire
+/mob/living/simple_animal/hostile/urist/vampire
 	name = "vampire"
 	desc = "A bloodthirsty undead abomination."
 	icon = 'icons/uristmob/simpleanimals.dmi'
 	icon_state = "vampire_m_s"
 	icon_living = "vampire_m_s"
 	icon_dead = "vampire_m_d"
-	health = 50
-	maxHealth = 50
+	health = 100
+	maxHealth = 100
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	attacktext = "bit"
@@ -206,8 +218,16 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
+	ranged = 0
 
-/mob/living/simple_animal/hostile/vampire/female
-	icon_state = "vampire_f_s"
-	icon_living = "vampire_f_s"
-	icon_dead = "vampire_f_d"
+/mob/living/simple_animal/hostile/urist/vampire/New()
+	var/danglybits = pick(0, 1) //random gender
+	if(danglybits)
+		icon_state = "vampire_m_s"
+		icon_living = "vampire_m_s"
+		icon_dead = "vampire_m_d"
+	else
+		icon_state = "vampire_f_s"
+		icon_living = "vampire_f_s"
+		icon_dead = "vampire_f_d"
+	..()


### PR DESCRIPTION
Genericizes and cleans up zombie code. Subtypes are just var presets, types are interchangeable with some VV. Regenplagues no longer start dead. 

Vampire NPCs now are gendered randomly, may introduce gender overrides later if someone wants them. Also both vamps and zombs are now hostile/urist subtypes, mostly for cleanup purposes.