### PR TITLE
Random back-end fixes:

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -70,7 +70,7 @@
 	move_to_delay = 3
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
-	rapid = 1
+	rapid = 2
 	status_flags = 0
 
 /mob/living/simple_animal/hostile/alien/queen/large

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -35,7 +35,7 @@
 
 /mob/living/simple_animal/hostile/hivebot/rapid
 	ranged = 1
-	rapid = 1
+	rapid = 2
 
 /mob/living/simple_animal/hostile/hivebot/strong
 	name = "Strong Hivebot"

--- a/code/modules/mob/living/simple_animal/hostile/hostile2.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile2.dm
@@ -168,8 +168,9 @@
 			LostTarget()
 	LostTarget()
 
-/mob/living/simple_animal/hostile/proc/Goto(var/target, var/delay, var/minimum_distance)
-	step_towards(src, target) //weird but necessary so they try to bump openable obstacles
+/mob/living/simple_animal/hostile/proc/Goto(var/atom/target, var/delay, var/minimum_distance)
+	if(get_dist(src, target.loc) > minimum_distance)
+		step_towards(src, target) //weird but necessary so they try to bump openable obstacles
 	walk_to(src, target, minimum_distance, delay)
 
 /mob/living/simple_animal/hostile/adjustBruteLoss(var/damage)

--- a/code/modules/mob/living/simple_animal/hostile/hostile2.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile2.dm
@@ -169,6 +169,7 @@
 	LostTarget()
 
 /mob/living/simple_animal/hostile/proc/Goto(var/target, var/delay, var/minimum_distance)
+	step_towards(src, target) //weird but necessary so they try to bump openable obstacles
 	walk_to(src, target, minimum_distance, delay)
 
 /mob/living/simple_animal/hostile/adjustBruteLoss(var/damage)

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -41,7 +41,7 @@
 	icon_dead = "piratemelee_dead"
 	projectilesound = 'sound/weapons/laser.ogg'
 	ranged = 1
-	rapid = 1
+	rapid = 2
 	projectiletype = /obj/item/projectile/beam
 	corpse = /obj/effect/landmark/mobcorpse/pirate/ranged
 	weapon1 = /obj/item/weapon/gun/energy/laser

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -7,7 +7,7 @@
 	icon_living = "drone3"
 	icon_dead = "drone_dead"
 	ranged = 1
-	rapid = 1
+	rapid = 2
 	speak_chance = 5
 	turns_per_move = 3
 	response_help = "pokes"

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -101,7 +101,7 @@
 
 /mob/living/simple_animal/hostile/syndicate/ranged
 	ranged = 1
-	rapid = 1
+	rapid = 2
 	icon_state = "syndicateranged"
 	icon_living = "syndicateranged"
 	casingtype = /obj/item/ammo_casing/a10mm

--- a/code/modules/urist/_helpers.dm
+++ b/code/modules/urist/_helpers.dm
@@ -351,3 +351,36 @@ B --><-- A
 	if(istype(A, /mob/living/carbon/human) && !(istype (A, /mob/living/carbon/human/monkey)) && !(istype (A, /mob/living/carbon/human/stok)) && !(istype (A, /mob/living/carbon/human/farwa))) // && !(istype (A, /mob/living/carbon/human/neara)))
 		return 1 //whoever thought subtyping all these under /human/monkey or whatever was a bad idea is literally Hitler
 	return 0
+
+//Creates a lying down icon by matrix transform. Made it a helper for less boilerplate --scr.
+/mob/proc/matrix_groundicon(var/turndegrees = 90)
+	var/matrix/M = matrix() //shamelessly stolen from human update_icons
+	M.Turn(turndegrees)
+	M.Translate(1,-6)
+	src.transform = M
+
+/proc/get_light_amt(var/turf/T, var/ignore_red = 0)
+	// Stolen from diona/life.dm since it was needed in various places. Ignore_red parameter for extra spoopy.
+	var/light_amount = 0
+	var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
+
+	if(L)
+		if(ignore_red)
+			light_amount = L.lum_g + L.lum_b
+		else
+			light_amount = L.lum_r + L.lum_g + L.lum_b //hardcapped so it's not abused by having a ton of flashlights
+	else
+		light_amount =  10
+
+	return light_amount
+
+/proc/shadow_check(var/turf/T, var/max_light = 2, var/or_equal = 0)
+	//True if light below max_light threshold, false otherwise
+	var/light_amt = get_light_amt(T)
+	if(or_equal)
+		if(light_amt <= max_light)
+			return 1
+	else
+		if(light_amt < max_light)
+			return 1
+	return 0

--- a/code/modules/urist/gamemodes/infestation/aliens/harvester.dm
+++ b/code/modules/urist/gamemodes/infestation/aliens/harvester.dm
@@ -168,12 +168,7 @@
 	if(iscloaking)
 		var/light_amount = 0
 		if(isturf(src.loc))
-			var/turf/T = src.loc
-			var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
-			if(L)
-				light_amount = L.lum_r + L.lum_g + L.lum_b //hardcapped so it's not abused by having a ton of flashlights
-			else
-				light_amount =  10
+			light_amount = get_light_amt(src.loc)
 
 		//	if(!istype(T))
 		//		return 0

--- a/code/modules/urist/gamemodes/scom/scom.dm
+++ b/code/modules/urist/gamemodes/scom/scom.dm
@@ -29,6 +29,8 @@ var/global/SCOMplayerC = 0 //ugly rename, but AFAIK playerC is a local var of di
 	var/SCOMplayercount = 0 //count is player number at the moment, C is at roundstart
 	var/list/teamnames = list(1,2,3,4) //all possible team names, putting this in one place for easy editing
 	var/list/freeteams = list()
+	auto_recall_shuttle = 1
+	ert_disabled = 1
 
 /datum/game_mode/scom/New()
 	freeteams = teamnames

--- a/code/modules/urist/gamemodes/vampire/vampire_powers.dm
+++ b/code/modules/urist/gamemodes/vampire/vampire_powers.dm
@@ -377,11 +377,7 @@
 	var/light_amount = 0
 	if(isturf(src.loc))
 		var/turf/T = src.loc
-		var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
-		if(L)
-			light_amount = L.lum_r + L.lum_g + L.lum_b //hardcapped so it's not abused by having a ton of flashlights
-		else
-			light_amount =  10
+		light_amount = get_light_amt(T)
 
 //	if(!istype(T))
 //		return 0
@@ -543,16 +539,7 @@
 				if(T.x>world.maxx-outer_tele_radius || T.x<outer_tele_radius)	continue	//putting them at the edge is dumb
 				if(T.y>world.maxy-outer_tele_radius || T.y<outer_tele_radius)	continue
 
-				// LIGHTING CHECK
-				var/light_amount = 0
-				var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
-
-				if(L)
-					light_amount = L.lum_r + L.lum_g + L.lum_b //hardcapped so it's not abused by having a ton of flashlights
-				else
-					light_amount =  10
-
-				if(light_amount > max_lum) continue
+				if(!(shadow_check(T, max_lum))) continue
 				turfs += T
 
 			if(!turfs.len)
@@ -574,7 +561,7 @@
 			animation.alpha = 127
 			animation.layer = 5
 			//animation.master = src
-			usr.loc = picked
+			usr.forceMove(picked)
 			spawn(10)
 				qdel(animation)
 		M.current.remove_vampire_blood(0)

--- a/code/modules/urist/items/guns.dm
+++ b/code/modules/urist/items/guns.dm
@@ -426,7 +426,7 @@ the sprite and make my own projectile -Glloyd*/
 	mag_type = MAGAZINE
 	multiple_sprites = 0
 
-/obj/item/weapon/gun/projectile/manualcycle/
+/obj/item/weapon/gun/projectile/manualcycle
 	var/bolt_open = 0
 
 /obj/item/weapon/gun/projectile/manualcycle/update_icon()

--- a/code/modules/urist/items/uristwar2.dm
+++ b/code/modules/urist/items/uristwar2.dm
@@ -72,6 +72,7 @@
 	caliber = "7.92x57mm"
 	ammo_type = /obj/item/ammo_casing/a792x57mm
 	icon = 'icons/urist/items/guns.dmi'
+	mag_type = MAGAZINE
 
 /obj/item/ammo_magazine/a792x57mm/stripper
 	name = "stripper clip (7.92x57mm)"
@@ -101,6 +102,7 @@
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a792x57mm/g43mag
+	allowed_magazines = list(/obj/item/ammo_magazine/a792x57mm/g43mag,/obj/item/ammo_magazine/a792x57mm/stripper)
 	requires_two_hands = 4
 	wielded_item_state = "woodarifle-wielded"
 	max_shells = 10
@@ -134,6 +136,7 @@
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a792x33mm
+	allowed_magazines = list(/obj/item/ammo_magazine/a792x33mm)
 	requires_two_hands = 4
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
 	wielded_item_state = "genericrifle-wielded"
@@ -159,8 +162,9 @@
 	ammo_type = /obj/item/ammo_casing/a792x33mm
 	icon = 'icons/urist/items/guns.dmi'
 	max_ammo = 30
+	mag_type = MAGAZINE
 
-/obj/item/ammo_magazine/a792x33mm/stg44mag/empty
+/obj/item/ammo_magazine/a792x33mm/empty
 	initial_ammo = 0
 
 /obj/item/ammo_casing/a792x33mm
@@ -184,6 +188,7 @@
 	slot_flags = SLOT_BELT || SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/mc9mm/mp40
+	allowed_magazines = list(/obj/item/ammo_magazine/mc9mm/mp40)
 	requires_two_hands = 1
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 	firemodes = list(
@@ -222,6 +227,7 @@
 	slot_flags = SLOT_BELT
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/mc9mm/p38
+	allowed_magazines = list(/obj/item/ammo_magazine/mc9mm/p38)
 
 /obj/item/weapon/gun/projectile/p38/update_icon()
 	..()
@@ -270,6 +276,7 @@
 	name = "MG 42 belt (7.92x57mm)"
 	icon_state = "mg42belt"
 	max_ammo = 250
+	mag_type = MAGAZINE
 
 /obj/item/ammo_magazine/a792x57mm/mg42/empty
 	initial_ammo = 0
@@ -394,6 +401,7 @@
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a762mm/svt40mag
+	allowed_magazines = list(/obj/item/ammo_magazine/a762mm/svt40mag)
 	requires_two_hands = 4
 	wielded_item_state = "woodarifle-wielded"
 	max_shells = 10
@@ -419,6 +427,7 @@
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a762mm/barmag
+	allowed_magazines = list(/obj/item/ammo_magazine/a762mm/barmag)
 	requires_two_hands = 4
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
 	wielded_item_state = "genericrifle-wielded"
@@ -459,6 +468,7 @@
 	slot_flags = SLOT_BELT || SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/mc9mm/ppsh
+	allowed_magazines = list(/obj/item/ammo_magazine/mc9mm/ppsh)
 	requires_two_hands = 1
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 	firemodes = list(
@@ -497,6 +507,7 @@
 	slot_flags = SLOT_BELT
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/mc9mm/tt33
+	allowed_magazines = list(/obj/item/ammo_magazine/mc9mm/tt33)
 
 /obj/item/weapon/gun/projectile/tt33/update_icon()
 	..()
@@ -550,6 +561,7 @@
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/a762mm/degtyaryov
+	allowed_magazines = list(/obj/item/ammo_magazine/a762mm/degtyaryov)
 	wielded_item_state = "genericLMG-wielded"
 	requires_two_hands = 6
 	max_shells = 60

--- a/code/modules/urist/mob/humanhostiles.dm
+++ b/code/modules/urist/mob/humanhostiles.dm
@@ -52,14 +52,14 @@
 	desc = "A henchman of the Internal Security department. You suddenly get an unpleasant sensation that you <I>'know too much'</I>."
 	ranged = 1
 	ranged_cooldown_cap = 5
-	rapid = 1
+	rapid = 2
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "syndicateranged"
 	icon_living = "syndicateranged"
 	icon_gib = "syndicate_gib"
 	casingtype = /obj/item/ammo_casing/a10mm
 	projectilesound = 'sound/weapons/gunshot/gunshot_smg.ogg'
-	projectiletype = /obj/item/projectile/bullet/pistol/medium
+	projectiletype = /obj/item/projectile/bullet/pistol/medium/smg
 	maxHealth = 100
 	health = 100
 
@@ -69,7 +69,7 @@
 	name = "\improper NTIS Agent"
 	desc = "A spook from the Internal Security department. You suddenly get an unpleasant sensation that you <I>'know too much'</I>."
 	faction = "NTIS" //NTIS is intended as NT Deathsquad affiliation
-	rapid = 1
+	rapid = 2
 	ranged_cooldown_cap = 5
 	maxHealth = 150
 	health = 150
@@ -82,7 +82,7 @@
 	icon_living = "ANTAG"
 	name = "\improper ANTAG Operative"
 	desc = "A member of a covert cell of a terrorist paramilitary collaborating with aliens to further their own goals, and a snappy dresser."
-	casingtype = /obj/item/ammo_casing/a10mm
+	casingtype = /obj/item/ammo_casing/a762
 	faction = "alien"
 	rapid = 0
 	maxHealth = 130
@@ -91,7 +91,7 @@
 	retreat_distance = 2
 	ranged_cooldown_cap = 2
 	projectilesound = 'sound/weapons/gunshot/gunshot3.ogg'
-	projectiletype = /obj/item/projectile/bullet/pistol/medium
+	projectiletype = /obj/item/projectile/bullet/rifle/a762
 
 /mob/living/simple_animal/hostile/urist/skrellterrorist
 	icon_state = "skrellorist"
@@ -100,12 +100,12 @@
 	desc = "An anti-human, Skrell-isolationist insurgent."
 	casingtype = /obj/item/ammo_casing/a10mm
 	faction = "skrellt"
-	rapid = 1
+	rapid = 2
 	maxHealth = 100
 	health = 100
 	minimum_distance = 8
 	projectilesound = 'sound/weapons/gunshot/gunshot3.ogg'
-	projectiletype = /obj/item/projectile/bullet/pistol/medium
+	projectiletype = /obj/item/projectile/bullet/pistol/medium/smg
 
 /mob/living/simple_animal/hostile/urist/riotcop
 	icon_state = "riotcop"

--- a/code/modules/urist/mob/spoopymobs.dm
+++ b/code/modules/urist/mob/spoopymobs.dm
@@ -248,6 +248,15 @@
 	attacktext = "stabbed"
 	melee_damage_lower = 10
 	melee_damage_upper = 20
+	min_oxy = 0
+	max_oxy = 0
+	min_tox = 0
+	max_tox = 0
+	min_co2 = 0
+	max_co2 = 0
+	min_n2 = 0
+	max_n2 = 0
+	minbodytemp = 0
 
 //a more persistent variant of the shadow wight with a different soundset
 /obj/effect/haunter
@@ -433,12 +442,28 @@
 	attacktext = "slashed"
 	attack_sound = 'sound/weapons/rapidslice.ogg'
 	attack_same = 1
-	var/stalkee //who he stalks
+	var/mob/stalkee //who he stalks
+	var/flickerlights = 0 //for more fun - can fuck with lights around the victim to get a TP zone.
 
 /mob/living/simple_animal/hostile/urist/stalker/New()
 	..()
-	if(!(stalkee))
+	GetNewStalkee()
+
+/mob/living/simple_animal/hostile/urist/stalker/proc/GetNewStalkee(var/mindplease = 1)
+	var/attempts = 3
+	while(!(stalkee))
 		stalkee = pick(player_list)
+		attempts--
+		var/recheck = 0
+		if(stalkee)
+			if(!(isliving(stalkee))) //for some reason new_players *were* being picked
+				recheck = 1
+			if((!(stalkee.mind)) && mindplease) //not much fun if they can't fight back
+				recheck = 1
+		if(recheck) //ugly but prevents trying to read a property of a null without parenthesis cancer
+			stalkee = null
+		if(attempts <= 0) //infinite loop prevention in case there are no
+			break
 
 /mob/living/simple_animal/hostile/urist/stalker/Found(var/atom/A)
 	if(A == stalkee)
@@ -447,11 +472,17 @@
 
 /mob/living/simple_animal/hostile/urist/stalker/Life()
 	if(..())
-		if(prob(25))
-			HuntingTeleport()
+		if(stalkee)
+			if(stalkee.stat != DEAD)
+				if(prob(25))
+					HuntingTeleport()
+			else
+				GetNewStalkee()
+		else
+			GetNewStalkee()
 
 /mob/living/simple_animal/hostile/urist/stalker/death()
-	..()
+	..(0, "disappears!")
 	qdel(src)
 
 /mob/living/simple_animal/hostile/urist/stalker/proc/HuntingTeleport()
@@ -460,15 +491,20 @@
 		if(istype(T,/turf/space)) continue
 		if(T.density) continue
 		if(T in range(src, 9)) continue //so they don't teleport pointlessly while in range
-		var/light_amount = 10
-		var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
-		if(L)
-			light_amount = L.lum_r + L.lum_g + L.lum_b //hardcapped so it's not abused by having a ton of flashlights
-		if(light_amount > 1) continue
-		destinations += T
+		if(shadow_check(T, 1))
+			destinations += T
 	if(destinations.len)
 		var/turf/picked = pick(destinations)
 		if(!picked || !isturf(picked))
 			return
-		src.loc = picked
+		src.forceMove(picked)
+	if(flickerlights)
+		if(stalkee)
+			if(isturf(stalkee.loc))
+				var/turf/stalkeeturf = stalkee.loc
+				for(var/datum/light_source/LS in stalkeeturf.affecting_lights)
+					if(istype(LS.source_atom, /obj/machinery/light))
+						var/obj/machinery/light/FL = LS.source_atom
+						if(prob(10))
+							FL.flicker(3)
 	return

--- a/code/modules/urist/modules/genetics/powers.dm
+++ b/code/modules/urist/modules/genetics/powers.dm
@@ -53,17 +53,12 @@
 
 	OnMobLife(var/mob/M)
 
-		var/light_amount = 0
 		if(isturf(M.loc))
 			var/turf/T = M.loc
-			var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
-			if(L)
-				light_amount = L.lum_r + L.lum_g + L.lum_b //I am so gonna regret copying this code instead of proccing it next dev cycle --scrdest
+			if(shadow_check(T, 2, 1))
+				M.alpha = 0
 			else
-				light_amount =  10
-
-		if(light_amount <= 2)
-			M.alpha = 0
+				M.alpha = round(255 * 0.80)
 		else
 			M.alpha = round(255 * 0.80)
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

!!Makes Hostile SA's open doors (among others) by adding a step_towards so they Bump the immediate first obstacle. May result in some sub-optimal paths, but worth it IMO.

Removes all boilerplate lumcounters from Vamp, Harvester, Stalker mob and the Shadow power, replaced with a new common helper, shadow_check and the helper it uses, get_light_amt. Can take an optional parameter to ignore red lights to make them scarier.

Makes skeltals not need atmos on account of not having lungs.

Fixes stalkers occasionally picking new_players as victims, makes them pick new victims if previous is dead (or nulled), along with safeguards against endless loops if they can't find it on lowpop. Normally only picks players with minds attached.

Admin magic can make the stalkers use a new behavior of making lights flicker around the victim by varediting a flickerlights var (whodda thunk).