### PR TITLE
Guncargo Enhancements

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -35,7 +35,7 @@
 					/obj/item/weapon/storage/box/flashbangs,
 					/obj/item/weapon/storage/box/teargas)
 	cost = 40
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/weapon
 	containername = "\improper Weapons crate"
 	access = access_security
 
@@ -46,7 +46,7 @@
 					/obj/item/weapon/gun/projectile/shotgun/doublebarrel/flare,
 					/obj/item/weapon/storage/box/flashshells)
 	cost = 25
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/weapon
 	containername = "\improper Flare gun crate"
 	access = access_security
 
@@ -57,7 +57,7 @@
 					/obj/item/weapon/shield/energy = 2,
 					/obj/item/clothing/suit/armor/laserproof = 2)
 	cost = 125
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/weapon
 	containername = "\improper Advanced Energy Weapons crate"
 	access = access_heads
 
@@ -98,7 +98,7 @@
 	name = "Energy weapons crate"
 	contains = list(/obj/item/weapon/gun/energy/laser = 3)
 	cost = 50
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/weapon
 	containername = "\improper energy weapons crate"
 	access = access_armory
 
@@ -109,7 +109,7 @@
 					/obj/item/weapon/storage/box/shotgunshells,
 					/obj/item/weapon/gun/projectile/shotgun/pump/combat = 2)
 	cost = 65
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/weapon
 	containername = "\improper Shotgun crate"
 	access = access_armory
 
@@ -118,7 +118,7 @@
 	contains = list(/obj/item/clothing/suit/armor/laserproof = 2,
 					/obj/item/weapon/gun/energy/sniperrifle = 2)
 	cost = 90
-	containertype = /obj/structure/closet/crate/secure/gear
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/gear
 	containername = "\improper Energy marksman crate"
 	access = access_armory
 
@@ -127,7 +127,7 @@
 	contains = list(/obj/item/weapon/storage/box/shotgunammo = 2,
 					/obj/item/weapon/storage/box/shotgunshells = 2)
 	cost = 60
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/weapon
 	containername = "\improper ballistic ammunition crate"
 	access = access_armory
 
@@ -136,7 +136,7 @@
 	contains = list(/obj/item/weapon/gun/energy/ionrifle = 2,
 					/obj/item/weapon/storage/box/emps)
 	cost = 50
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/weapon
 	containername = "\improper electromagnetic weapons crate"
 	access = access_armory
 
@@ -146,7 +146,7 @@
 	contains = list(/obj/item/weapon/gun/projectile/automatic/wt550,
 					/obj/item/weapon/gun/projectile/automatic/z8)
 	cost = 90
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/weapon
 	containername = "\improper Automatic weapon crate"
 	access = access_armory
 	supply_method = /decl/supply_method/randomized
@@ -158,7 +158,7 @@
 					/obj/item/ammo_magazine/mc9mmt/rubber,
 					/obj/item/ammo_magazine/a556)
 	cost = 20
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/weapon
 	containername = "\improper Automatic weapon ammunition crate"
 	access = access_armory
 	supply_method = /decl/supply_method/randomized
@@ -168,7 +168,7 @@
 	contains = list(/obj/item/clothing/suit/armor/laserproof = 2,
 					/obj/item/weapon/gun/energy/gun = 2)
 	cost = 50
-	containertype = /obj/structure/closet/crate/secure/gear
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/gear
 	containername = "\improper Experimental energy gear crate"
 	access = access_armory
 
@@ -179,7 +179,7 @@
 					/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/suit/armor/riot)
 	cost = 35
-	containertype = /obj/structure/closet/crate/secure/gear
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/gear
 	containername = "\improper Experimental armor crate"
 	access = access_armory
 
@@ -411,6 +411,6 @@
 					/obj/item/clothing/shoes/tactical,
 					/obj/item/clothing/gloves/tactical)
 	cost = 45
-	containertype = /obj/structure/closet/crate/secure/gear
+	containertype = /obj/structure/closet/crate/secure/boobytrapped/gear
 	containername = "\improper Tactical Suit Locker"
 	access = access_armory

--- a/code/modules/urist/structures/crates.dm
+++ b/code/modules/urist/structures/crates.dm
@@ -46,3 +46,71 @@ All crates that cannot be ordered go here. Please keep it tidy, by which I mean 
 			else
 				del Cat2
 		..()
+
+
+/* Boobytrapped secure crates, only legit access to disarm. */
+
+/obj/structure/closet/crate/secure/boobytrapped
+	var/trapped = 1
+	var/obj/trap //a mine, grenade or other physical effect; otherwise just kaboom
+	var/triggered = 0 //insert tumblr joke here
+	var/trap_delete_on_open = 1 //for balance, so Sec doesn't get free frags
+
+/obj/structure/closet/crate/secure/boobytrapped/New()
+	..()
+	if(trapped && trap)
+		trap = new trap(src)
+
+/obj/structure/closet/crate/secure/boobytrapped/proc/trigger_trap()
+	if(trapped && !(triggered))
+		triggered = 1
+		src.visible_message("<span class='warning'>[src] emits a quiet raising whine...</span>", "<span class='warning'>[src] emits a quiet raising whine...</span>", 5)
+		sleep(10)
+		if(trap)
+			if(istype(trap, /obj/effect/mine))
+				var/obj/effect/mine/M = trap
+				M.explode2()
+			else if(istype(trap, /obj/item/weapon/grenade))
+				var/obj/item/weapon/grenade/G = trap
+				G.detonate()
+		else
+			explosion(loc, 0, 2, 4, 5)
+
+/obj/structure/closet/crate/secure/boobytrapped/ex_act(severity)
+	trigger_trap()
+	..()
+
+/obj/structure/closet/crate/secure/boobytrapped/open()
+	if(!(triggered))
+		triggered = 1
+		if(trap)
+			if(istype(trap, /obj) && trap_delete_on_open)
+				qdel(trap) //no frags for you!
+	..()
+
+/obj/structure/closet/crate/secure/boobytrapped/damage(var/damage)
+	/* full override since I'd rather not touch qdel(), keep this updated with closet's damage() */
+	health -= damage
+	if(health <= 0)
+		trigger_trap()
+		for(var/atom/movable/A in src)
+			A.forceMove(src.loc)
+		qdel(src)
+
+/obj/structure/closet/crate/secure/boobytrapped/weapon
+	name = "weapons crate"
+	desc = "A secure weapons crate outfitted with an anti-tamper trap."
+	icon_state = "weaponcrate"
+	icon_opened = "weaponcrateopen"
+	icon_closed = "weaponcrate"
+	trap = /obj/item/weapon/grenade/frag/high_yield
+	trap_delete_on_open = 1
+
+/obj/structure/closet/crate/secure/boobytrapped/gear
+	name = "gear crate"
+	desc = "A secure gear crate outfitted with an anti-tamper trap."
+	icon_state = "secgearcrate"
+	icon_opened = "secgearcrateopen"
+	icon_closed = "secgearcrate"
+	trap = /obj/item/weapon/grenade/frag/high_yield
+	trap_delete_on_open = 1

--- a/code/modules/urist/structures/crates.dm
+++ b/code/modules/urist/structures/crates.dm
@@ -76,10 +76,6 @@ All crates that cannot be ordered go here. Please keep it tidy, by which I mean 
 		else
 			explosion(loc, 0, 2, 4, 5)
 
-/obj/structure/closet/crate/secure/boobytrapped/ex_act(severity)
-	trigger_trap()
-	..()
-
 /obj/structure/closet/crate/secure/boobytrapped/open()
 	if(!(triggered))
 		triggered = 1


### PR DESCRIPTION
Adds boobytrapped secure crate subtype. Attempting to break them open (with lasers or explosions) triggers a trap, either a grenade, a mine, or if none set, a 0,2,4,5 explosion. If a var is set, the trap item is deleted once the trap is disarmed so that there's no free frags.

Changes all the murderboney Cargo Sec crates to use those crates. Emagging and EMPing works as normal, so antag QM can still get weapons, but regular guncargo will appreciate the term 'secure crate' painfully.

By default both types will use fragbombs, so the effect will be painful, but not stationfucky. If you want to peer pressure certain crates from guncargo extra hard, use the trap = null variant.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
