### PR TITLE
Too Spooky

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2190,6 +2190,7 @@
 #include "code\modules\urist\modules\breaking_news.dm"
 #include "code\modules\urist\modules\donate.dm"
 #include "code\modules\urist\modules\gear.dm"
+#include "code\modules\urist\modules\ghost_powers.dm"
 #include "code\modules\urist\modules\mining.dm"
 #include "code\modules\urist\modules\supplycrates.dm"
 #include "code\modules\urist\modules\uristlanguages.dm"

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -894,6 +894,9 @@ proc/generate_image(var/tx as num, var/ty as num, var/tz as num, var/range as nu
 			if(istype(A, /atom/movable/lighting_overlay) && lighting) //Special case for lighting
 				atoms.Add(A)
 				continue
+			if(prob(90) && istype(A, /mob/observer/ghost) && round_is_spooky())
+				atoms.Add(A)
+				continue
 			if(A.invisibility) continue
 			atoms.Add(A)
 	//Lines below actually render all colected data

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -185,6 +185,13 @@ var/global/photo_count = 0
 			mob_detail = "You can see [A] on the photo[A:health < 75 ? " - [A] looks hurt":""].[holding ? " [holding]":"."]. "
 		else
 			mob_detail += "You can also see [A] on the photo[A:health < 75 ? " - [A] looks hurt":""].[holding ? " [holding]":"."]."
+	if(round_is_spooky())
+		for(var/mob/observer/ghost/OG in the_turf)
+			if(!mob_detail)
+				mob_detail = "You can see a wispy shape resembling [OG] on the photo."
+			else
+				mob_detail += "You can also see a wispy shape resembling [OG] on the photo."
+
 	return mob_detail
 
 /obj/item/device/camera/afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)

--- a/code/modules/urist/modules/ghost_powers.dm
+++ b/code/modules/urist/modules/ghost_powers.dm
@@ -1,0 +1,26 @@
+/* Various attack_ghost definitions for extra spoopy */
+
+/obj/item/device/taperecorder/attack_ghost(mob/observer/ghost/user as mob)
+	. = ..()
+	if(round_is_spooky())
+		if(recording)
+			var/msg = input(user, "Whisper what into the radio?", "Radio whisper") as text
+			if(msg)
+				timestamp += timerecorded
+				storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] Something whispers, \"[msg]\""
+				log_admin("[key_name(user)] has radio-whispered: [msg].")
+
+/obj/structure/window/attack_ghost(mob/observer/ghost/user as mob)
+	. = ..()
+	playsound(src.loc, 'sound/effects/glassknock.ogg', 80, 1)
+	user.visible_message("Something knocks on the [src.name].",
+							"You knock on the [src.name].",
+							"You hear a knocking sound.")
+
+/mob/living/carbon/attack_ghost(mob/observer/ghost/user as mob)
+	. = ..()
+	if(src.sleeping && src.client && round_is_spooky())
+		var/dream = input(user, "Enter someone's dreams", "Dream") as text
+		if(dream)
+			to_chat(src, "\blue <i>... [dream] ...</i>")
+			log_admin("[key_name(user)] has dream-whispered: [dream] to [key_name(src)].")


### PR DESCRIPTION
More ghost spookiness with thin veil - ghosts can:
- appear on photographs (10% chance to not appear),
- knock on windows, 
- whisper into tape recorders 
- whisper to sleeping carbon mobs w/client (formatted as a normal dream).

Some hooking into native photo procs was necessary, but it's non-critical if it gets overwritten.