### PR TITLE
Random Venom Snakes

### DIFF
--- a/code/modules/urist/mob/uristanimals.dm
+++ b/code/modules/urist/mob/uristanimals.dm
@@ -115,3 +115,47 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	name = "Mule"
 	desc = "The QuarterMaster's turtle. Look out for bites!"
 
+/*holds a random chem for animal venom
+  should be used WITH copy=1 on transfer */
+/obj/item/venom_sac
+	name = "venom sac"
+	desc = "A sac something evolved to store venom in."
+	icon = 'icons/obj/surgery.dmi'
+	icon_state = "roro core"
+	var/chem_type_amt = 3 //should def it probably; max chem types
+
+	//blacklist; warning: extended on creation for typesof access!
+	var/list/banned_chems = list(
+		"adminordrazine",
+		"oxyphoron",
+		"holy_water",
+		"hell_water",
+		"nutriment"
+		)
+
+//pretty basic random chem picker; blacklist overriden and picks from 1 to argument chem types
+/obj/item/venom_sac/proc/generate_venom(var/maxchems = 3)
+	var/list/mix = list()
+	var/new_chem = null
+	var/max_chemtypes = rand(1, maxchems)
+
+	while (mix.len < max_chemtypes)
+		new_chem = pick(chemical_reagents_list)
+		if(new_chem in banned_chems)
+			new_chem = null
+		mix += new_chem
+
+	for(var/ingredient in mix)
+		if(!(src.reagents))
+			src.create_reagents(chem_type_amt * 15)
+		src.reagents.add_reagent(ingredient, 10, null, 0)
+
+/obj/item/venom_sac/New()
+	..()
+
+	banned_chems += typesof(/datum/reagent/drink)
+	banned_chems += typesof(/datum/reagent/crayon_dust)
+
+	if(!reagents)
+		create_reagents(chem_type_amt * 10)
+	generate_venom(chem_type_amt)

--- a/code/modules/urist/modules/jungle/jungle_animals.dm
+++ b/code/modules/urist/modules/jungle/jungle_animals.dm
@@ -286,9 +286,12 @@
 
 /mob/living/simple_animal/hostile/snake/AttackingTarget()
 	. =..()
-	var/mob/living/L = .
-	if(istype(L))
-		L.apply_damage(rand(3,12), TOX)
+	if(istype(target, /mob/living/carbon))
+		var/mob/living/carbon/L = target
+		bite(L)
+
+/mob/living/simple_animal/hostile/snake/proc/bite(var/mob/living/L)
+	L.apply_damage(rand(3,12), TOX)
 
 /mob/living/simple_animal/hostile/snake/AttackTarget()
 	..()
@@ -297,6 +300,24 @@
 		if(stalk_tick_delay <= 0)
 			src.loc = get_step_towards(src, target)
 			stalk_tick_delay = 3
+
+/mob/living/simple_animal/hostile/snake/randvenom
+	icon_state = "snake_brown"
+	icon_living = "snake_brown"
+	icon_dead = "snake_brown_dead"
+	desc = "A sinuously coiled, venomous looking reptile. This one looks rather exotic."
+	melee_damage_upper = 5
+	var/bite_vol = 5
+	var/obj/item/venom_sac/venomsac
+
+/mob/living/simple_animal/hostile/snake/randvenom/New()
+	..()
+	if(!venomsac)
+		venomsac = new /obj/item/venom_sac(src)
+
+/mob/living/simple_animal/hostile/snake/randvenom/bite(var/mob/living/L)
+	if(L && venomsac)
+		venomsac.reagents.trans_to_mob(L, bite_vol, CHEM_BLOOD, copy=1)
 
 //******//
 // Deer //


### PR DESCRIPTION
Adds a venom sac item. It's a pseudo-organ item; I'd have made it a proper organ but then it wouldn't play nice with being in simple_animals. It generates 10u amount of each random (with blacklist) chem on initialization, from one up to the specified number of chem types.

Refactors snakes' AttackingTarget to *actually get the mob's target rather than always null* thus making generic snakes' toxin work; also moves that toxin effect to a separate proc called in AttackingTarget, bite(), which handles bite effects.

Adds brown-colored snakes that use the above changes to spawn with random venom that is injected with each bite into a victim, provided it's a carbon-type. Robit armor stronk I guess.

However, since the venom is NOT used up, and can be nearly any chem, this has some abuse potential; nonetheless, so do the jungle fruits - probably moreso. Also, ATM the blacklist doesn't always trigger properly for the typesof-added elements for some reason.