### PR TITLE
Allows air alarms to change their vents' direction. Updates admin.txt

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -659,6 +659,7 @@
 					return 1
 
 				if( "power",
+					"direction",
 					"adjust_external_pressure",
 					"checks",
 					"o2_scrub",

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -20,6 +20,7 @@ Zty8212000 - Game Master
 Lyeos - Game Master
 
 Scrdest - Coder
+Nyxodile - Coder
 
 Licton15 - Moderator
 greatorder - Moderator

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -128,7 +128,8 @@ Used In File(s): \code\game\machinery\alarm.dm
 					Operation Mode:
 				</div>
 				<div class="itemContent">
-					{{:value.direction == "siphon" ? 'Siphoning' : 'Pressurizing'}}
+					{{:helper.link('Siphon', null, { 'id_tag' : value.id_tag, 'command' : 'direction', 'val' : value.direction^0}, null, value.direction == "siphon" ? 'selected' : null)}}
+					{{:helper.link('Pressurize', null, { 'id_tag' : value.id_tag, 'command' : 'direction', 'val' : value.direction^1}, null, value.direction == "release" ? 'selected' : null)}}
 				</div>
 			</div>
 			<div class="item">


### PR DESCRIPTION
Allows air alarms to set vents' direction.
Panic siphon already does this, this is just for engineering projects.
Also updates admins.txt
Edit: I forgot to actually link a screenshot
![2017-05-06_01-21-37](https://cloud.githubusercontent.com/assets/16085952/25770090/7f1c0978-31fa-11e7-845f-efa9f4eee676.png)
