### PR TITLE
Removes the last holdouts from the skill-effect purge.

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -249,7 +249,7 @@
 		if (!istype(connected.occupant))
 			to_chat(user, "\icon[src]<span class='warning'>The body scanner cannot scan that lifeform.</span>")
 			return TOPIC_REFRESH
-		stored_scan = connected.occupant.get_medical_data(user.get_skill_value(SKILL_MEDICAL))
+		stored_scan = connected.occupant.get_medical_data()
 		stored_scan_subject = connected.occupant
 		user.visible_message("<span class='notice'>\The [user] performs a scan of \the [connected.occupant] using \the [connected].</span>")
 		generate_window(user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -508,8 +508,6 @@ var/list/global/slot_flags_enumeration = list(
 
 /obj/item/proc/get_parry_chance(mob/user)
 	. = base_parry_chance
-	if(user)
-		. += 15 * (user.get_skill_value(SKILL_COMBAT) - SKILL_BASIC)
 
 /obj/item/proc/get_loc_turf()
 	var/atom/L = loc

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -89,7 +89,7 @@
 	if(istype(A, /obj))
 		O = A
 	if(C)
-		var/length = 10
+		var/length = 15
 		var/done_any = FALSE
 		var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
 		sparks.set_up(1, 1, user.loc)
@@ -101,10 +101,6 @@
 		user.visible_message("\The [user] starts recharging \the [A] with \the [src].","<span class='notice'>You start recharging \the [A] with \the [src].</span>")
 		if (istype(A, /obj/item/weapon/gun/energy))
 			length = 30
-			if (user.get_skill_value(SKILL_WEAPONS) <= SKILL_ADEPT)
-				length += rand(10, 30)
-		if (user.get_skill_value(SKILL_ELECTRICAL) < SKILL_ADEPT)
-			length += rand(40, 60)
 		while(C.charge < C.maxcharge)
 			if(MyC.charge > max(0, MyC.charge*failsafe) && do_after(user, length, target = user))
 				sparks.start()

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -43,7 +43,7 @@
 /obj/structure/plasticflaps/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W) && !anchored)
 		user.visible_message("<span class='notice'>\The [user] begins deconstructing \the [src].</span>", "<span class='notice'>You start deconstructing \the [src].</span>")
-		if(user.do_skilled(3 SECONDS, SKILL_CONSTRUCTION, src))
+		if(do_after(user, 3 SECONDS, src))
 			user.visible_message("<span class='warning'>\The [user] deconstructs \the [src].</span>", "<span class='warning'>You deconstruct \the [src].</span>")
 			qdel(src)
 	else ..()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -517,11 +517,6 @@
 	health = (istype(S, /obj/item/seeds/cutting) ? round(seed.get_trait(TRAIT_ENDURANCE)/rand(2,5)) : seed.get_trait(TRAIT_ENDURANCE))
 	lastcycle = world.time
 
-	var/needed_skill = seed.mysterious ? SKILL_ADEPT : SKILL_BASIC
-	if(prob(user.skill_fail_chance(SKILL_BOTANY, 40, needed_skill)))
-		dead = 1
-		health = 0
-
 	qdel(S)
 	check_health()
 

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -391,7 +391,7 @@
 		if(istype(loc, /turf) && (IC_FLAG_ANCHORABLE & circuit_flags))
 			user.visible_message("\The [user] wrenches \the [src]'s anchoring bolts [anchored ? "back" : "into position"].")
 			playsound(get_turf(user), 'sound/items/Ratchet.ogg',50)
-			if(user.do_skilled(5 SECONDS, SKILL_CONSTRUCTION, src))
+			if(do_after(user, 5 SECONDS, src))
 				anchored = !anchored
 	else if(istype(I, /obj/item/integrated_circuit))
 		if(!user.canUnEquip(I))

--- a/code/modules/reagents/reagent_containers/food/fish.dm
+++ b/code/modules/reagents/reagent_containers/food/fish.dm
@@ -18,9 +18,6 @@
 		if(istype(M) && !M.unEquip(src))
 			return
 
-		var/toxin_amt = reagents.get_reagent_amount(/datum/reagent/toxin/carpotoxin)
-		if(toxin_amt && !prob(user.skill_fail_chance(SKILL_COOKING, 100, SKILL_PROF)))
-			reagents.remove_reagent(/datum/reagent/toxin/carpotoxin, toxin_amt)
 		user.visible_message("<span class='notice'>\The [user] slices \the [src] into thin strips.</span>")
 
 		var/transfer_amt = Floor(reagents.total_volume * 0.3)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -589,10 +589,9 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 				target.visible_message("<span class='danger'>[target]'s [W] goes off during the struggle!</span>")
 				return W.afterattack(shoot_to,target)
 
-	var/skill_mod = 10 * attacker.get_skill_difference(SKILL_COMBAT, target)
 	var/state_mod = attacker.melee_accuracy_mods() - target.melee_accuracy_mods()
 
-	var/randn = rand(1, 100) - skill_mod + state_mod
+	var/randn = rand(1, 100) + state_mod
 	if(!(species_flags & SPECIES_FLAG_NO_SLIP) && randn <= 25)
 		var/armor_check = target.run_armor_check(affecting, "melee")
 		target.apply_effect(3, WEAKEN, armor_check)


### PR DESCRIPTION
There were a few left, here's a list:
- There was an irrelevant reference to SKILL_MEDICAL in the Advanced Body Scanner.
- Melee accuracy was based on you and your target's opposing SKILL_COMBAT.
- Parry chance was being based on SKILL_COMBAT.
- The inducer was taking longer to charge things, based on SKILL_WEAPONS for laser guns, and SKILL_ELECTRICAL for everything else.
- Plastic Flaps took longer to deconstruct if SKILL_CONSTRUCTION was low.
- Anchorable Electronic Assemblies took longer to anchor if SKILL_CONSTRUCTION was low.
- Plants would have a chance to instantly die upon planting if SKILL_BOTANY was low.