### PR TITLE
Tweaks organ decay treatment

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -392,6 +392,11 @@
 				H.drowsyness++
 				if(I.damage >= I.min_bruised_damage)
 					continue
+			if((I.status & ORGAN_DEAD) && I.can_recover())
+				I.death_time += 27 SECONDS * removed //Let's say its 45% effective if not directly applied
+				if(I.death_time >= world.time)
+					I.status &= ~ORGAN_DEAD
+
 			I.damage = max(I.damage - removed, 0)
 
 /datum/reagent/ryetalyn

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -459,9 +459,6 @@
 	if(!organ_to_fix.can_recover())
 		to_chat(user, "<span class='notice'>The [organ_to_fix.name] is necrotic and can't be saved, it will need to be replaced.</span>")
 		return 0
-	if(organ_to_fix.damage >= organ_to_fix.max_damage)
-		to_chat(user, "<span class='notice'>The [organ_to_fix.name] needs to be repaired before it is regenerated.</span>")
-		return 0
 
 	target.op_stage.current_organ = organ_to_fix
 
@@ -488,6 +485,7 @@
 	if (trans > 0)
 
 		if(rejuvenate)
+			affected.heal_damage(affected.max_damage/2)
 			affected.status &= ~ORGAN_DEAD
 			affected.owner.update_body(1)
 


### PR DESCRIPTION
Previously if you attempted to heal decaying organs it would either lead to a scarring level high enough to make it pointless, or immediately become decaying again. This changes it to make healing decaying organs through surgery an effective process given the equipment. In addition, peridaxon itself has been given the effects it has in surgery to a smaller degree.