### PR TITLE
Generic bugfixes

### DIFF
--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -109,9 +109,9 @@
 		if(AWAITING_ACTIVATION)
 			icon_state = initial(icon_state)
 		if(CURRENTLY_ACTIVE)
-			icon_state = "sflash2"
+			icon_state = "sflash_on"
 		if(HAS_BEEN_ACTIVATED)
-			icon_state = "flashburnt"
+			icon_state = "sflash_burnt"
 
 /obj/item/device/uplink_service/proc/enable(var/mob/user = usr)
 	return TRUE

--- a/code/game/antagonist/station/cult_god.dm
+++ b/code/game/antagonist/station/cult_god.dm
@@ -94,7 +94,7 @@ GLOBAL_DATUM_INIT(godcult, /datum/antagonist/godcultist, new)
 	for(var/m in GLOB.deity.current_antagonists)
 		var/datum/mind/mind = m
 		var/mob/living/deity/god = mind.current
-		if(god.is_follower(player.current,1))
+		if(god && god.is_follower(player.current,1))
 			return god
 
 /mob/living/proc/dpray(var/msg as text)

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -56,7 +56,7 @@
 	name = "\improper PDA"
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. Functionality determined by a preprogrammed ROM cartridge."
 	icon = 'icons/obj/pda.dmi'
-	icon_state = "pda"
+	icon_state = "pai"
 	item_state = "electronic"
 
 	w_class = ITEM_SIZE_SMALL

--- a/code/modules/events/viral_outbreak.dm
+++ b/code/modules/events/viral_outbreak.dm
@@ -13,7 +13,7 @@ datum/event/viral_outbreak/announce()
 datum/event/viral_outbreak/start()
 	var/list/candidates = list()	//list of candidate keys
 	for(var/mob/living/carbon/human/G in GLOB.player_list)
-		if(G.client && G.stat != DEAD)
+		if(G.client && G.stat != DEAD && !G.full_prosthetic)
 			candidates += G
 	if(!candidates.len)	return
 	candidates = shuffle(candidates)//Incorporating Donkie's list shuffle

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -51,6 +51,9 @@
 	connected_zlevels = GetConnectedZlevels(z)
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/Process()
+	if(!seed)
+		qdel(src)
+		return
 	if(z in GLOB.using_map.station_levels) //plants on station always tick
 		return ..()
 	if(living_observers_present(connected_zlevels))
@@ -67,12 +70,6 @@
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/die()
 	qdel(src)
-
-/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/Process()
-	if(!seed)
-		qdel(src)
-		return
-	..()
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/Destroy()
 	// Check if we're masking a decal that needs to be visible again.

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -104,7 +104,7 @@
 					icon_state = "ed209_legs"
 
 		if(2)
-			if(istype(W, /obj/item/clothing/suit/storage/vest) || istype(W, /obj/item/clothing/suit/armor/pcarrier) || istype(W, /obj/item/clothing/accessory/armorplate))
+			if(istype(W, /obj/item/clothing/suit/storage/vest) || istype(W, /obj/item/clothing/suit/armor/pcarrier) || istype(W, /obj/item/clothing/accessory/armorplate) || istype(W, /obj/item/clothing/suit/urist/armor/nerva/sec))
 				if(istype(W, /obj/item/clothing/suit/armor/pcarrier))
 					if(!locate(/obj/item/clothing/accessory/armorplate) in W.contents)
 						to_chat(user, "There's no armor plates on this [W].")
@@ -156,7 +156,7 @@
 				return
 
 		if(7)
-			if(istype(W, /obj/item/weapon/gun/energy/taser))
+			if(istype(W, /obj/item/weapon/gun/energy/taser) || istype(W, /obj/item/weapon/gun/energy/gun/small))
 				SetName("taser ED-209 assembly")
 				build_step++
 				to_chat(user, "<span class='notice'>You add [W] to [src].</span>")

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -11,7 +11,7 @@
 	joint = "jaw"
 	amputation_point = "neck"
 	encased = "skull"
-	artery_name = "cartoid artery"
+	artery_name = "carotid artery"
 	cavity_name = "cranial"
 
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_GENDERED_ICON | ORGAN_FLAG_HEALS_OVERKILL | ORGAN_FLAG_CAN_BREAK

--- a/code/modules/organs/external/wounds/wound_types.dm
+++ b/code/modules/organs/external/wounds/wound_types.dm
@@ -100,7 +100,7 @@
 		"deep cut" = 15,
 		"clotted cut" = 8,
 		"scab" = 2,
-		"fresh skin" = 0
+		"fresh patch of skin" = 0
 		)
 
 /datum/wound/cut/flesh
@@ -111,7 +111,7 @@
 		"flesh wound" = 25,
 		"blood soaked clot" = 15,
 		"large scab" = 5,
-		"fresh skin" = 0
+		"fresh patch of skin" = 0
 		)
 
 /datum/wound/cut/gaping
@@ -228,7 +228,7 @@ datum/wound/puncture/massive
 		"ripped burn" = 10,
 		"moderate burn" = 5,
 		"healing moderate burn" = 2,
-		"fresh skin" = 0
+		"fresh patch of skin" = 0
 		)
 
 /datum/wound/burn/large
@@ -236,7 +236,7 @@ datum/wound/puncture/massive
 		"ripped large burn" = 20,
 		"large burn" = 15,
 		"healing large burn" = 5,
-		"fresh skin" = 0
+		"fresh patch of skin" = 0
 		)
 
 /datum/wound/burn/severe

--- a/code/modules/organs/internal/stack.dm
+++ b/code/modules/organs/internal/stack.dm
@@ -75,3 +75,4 @@
 	if(default_language) owner.default_language = default_language
 	owner.languages = languages.Copy()
 	to_chat(owner, "<span class='notice'>Consciousness slowly creeps over you as your new body awakens.</span>")
+	to_chat(owner, "<span class='warning'>All memories from 5 minutes before your death to the moment you died have been lost.</span>")

--- a/code/modules/persistence/filth.dm
+++ b/code/modules/persistence/filth.dm
@@ -6,6 +6,7 @@
 	random_icon_states = list("mfloor1", "mfloor2", "mfloor3", "mfloor4", "mfloor5", "mfloor6", "mfloor7")
 	color = "#464f33"
 	persistent = TRUE
+	anchored = TRUE
 
 /obj/effect/decal/cleanable/filth/Initialize()
 	. = ..()

--- a/code/modules/virus2/antibodyanalyser.dm
+++ b/code/modules/virus2/antibodyanalyser.dm
@@ -38,7 +38,7 @@
 
 	if(scanning)
 		scanning -= 1
-		if(scanning == 0)
+		if(scanning <= 0)
 			if(!container.reagents.has_reagent(/datum/reagent/antibodies)) //if there are no antibody reagents, return false
 				return 0
 

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -40,7 +40,7 @@
 	harm_intent_damage = 8
 	melee_damage_lower = 30
 	melee_damage_upper = 35
-	attacktext = "evisceratds"
+	attacktext = "eviscerates"
 	attack_sound = 'sound/weapons/slash.ogg'
 	var/attack_mode = FALSE
 

--- a/maps/nerva/Loadout/loadout_suit.dm
+++ b/maps/nerva/Loadout/loadout_suit.dm
@@ -45,7 +45,6 @@
 /datum/gear/suit/wintercoat/hydro
 	display_name = "winter coat, hydroponics"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/hydro
-	allowed_roles = list(/datum/job/hydro)
 
 /datum/gear/suit/wintercoat/cargo
 	display_name = "winter coat, cargo"

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -18647,10 +18647,7 @@
 	dir = 6
 	},
 /obj/structure/table/standard,
-/obj/item/device/integrated_circuit_printer{
-	anchored = 1;
-	density = 1
-	},
+/obj/item/device/integrated_circuit_printer,
 /turf/simulated/floor/tiled/white,
 /area/logistics/advwork)
 "XZ" = (

--- a/maps/nerva/nerva_define.dm
+++ b/maps/nerva/nerva_define.dm
@@ -172,6 +172,14 @@
 	base_floor_area = /area/maintenance/exterior
 	post_round_safe_areas = list(/area/shuttle/escape_pod1,/area/shuttle/escape_pod2,/area/shuttle/escape_pod3)
 
+	species_to_job_blacklist = list(
+		/datum/species/unathi  = list(/datum/job/captain),
+		/datum/species/skrell  = list(/datum/job/captain),
+		/datum/species/machine = list(/datum/job/captain),
+		/datum/species/diona   = list(/datum/job/captain),
+		/datum/species/teshari = list(/datum/job/captain)
+	)
+
 /datum/map/nerva/setup_map()
 	..()
 	system_name = generate_system_name()

--- a/maps/nerva/nerva_define.dm
+++ b/maps/nerva/nerva_define.dm
@@ -170,6 +170,7 @@
 
 	base_floor_type = /turf/simulated/floor/reinforced/airless
 	base_floor_area = /area/maintenance/exterior
+	post_round_safe_areas = list(/area/shuttle/escape_pod1,/area/shuttle/escape_pod2,/area/shuttle/escape_pod3)
 
 /datum/map/nerva/setup_map()
 	..()


### PR DESCRIPTION
Handles a majority of the bug reports from Discord.
Antag service items, and the spy camera monitor now have sprites.
Deity is closer to working when done in add_antag.
The major virus event will no longer try and infect metal with viruses.
Invisible soil patches will recognize that processing constantly is a bad idea.
ED209 construction might actually work for a change.
Spelling fixes for various things related to medical.
The hydroponics winter coat can now be selected.
You can now use the integrated circuit printer in cargo.
Aliens can no longer become captain.
The unofficial, official memory loss on resleeving is now mentioned. 