### PR TITLE
Medical balance and tweaks

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -276,7 +276,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 /obj/item/organ/external/proc/sever_artery()
 	if(species && species.has_organ[BP_HEART])
 		var/obj/item/organ/internal/heart/O = species.has_organ[BP_HEART]
-		if(!BP_IS_ROBOTIC(src) && !(status & ORGAN_ARTERY_CUT) && !initial(O.open))
+		if(!BP_IS_ROBOTIC(src) && !(status & ORGAN_ARTERY_CUT) && !initial(O.open) && !(encased && !(status & ORGAN_BROKEN)))
 			status |= ORGAN_ARTERY_CUT
 			return TRUE
 	return FALSE

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -168,7 +168,7 @@
 		failed_inhale = 1
 		breath_fail_ratio = Clamp(0,(1 - inhale_efficiency + breath_fail_ratio)/2,1)
 	else
-		breath_fail_ratio = Clamp(0,breath_fail_ratio/2,1)
+		breath_fail_ratio = Clamp(0,breath_fail_ratio-0.15,1)
 
 	owner.oxygen_alert = failed_inhale * 2
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -36,7 +36,8 @@
 
 /datum/reagent/bicaridine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(6 * removed, 0)
+		var/logistic_healing = 6/(1+200*2.71828**(-0.05*M.getBruteLoss())) //This is a logistic function that effectively doubles the healing rate as brute amounts get to around 200. Any injury below 60 is essentially unaffected and there's a scaling inbetween.
+		M.heal_organ_damage((6+logistic_healing) * removed, 0)
 		M.add_chemical_effect(CE_PAINKILLER, 10)
 
 /datum/reagent/bicaridine/overdose(var/mob/living/carbon/M, var/alien)
@@ -45,7 +46,7 @@
 		M.add_chemical_effect(CE_BLOCKAGE, (15 + volume - overdose)/100)
 		var/mob/living/carbon/human/H = M
 		for(var/obj/item/organ/external/E in H.organs)
-			if(E.status & ORGAN_ARTERY_CUT && prob(2))
+			if(E.status & ORGAN_ARTERY_CUT && prob(2 + volume / overdose))
 				E.status &= ~ORGAN_ARTERY_CUT
 
 /datum/reagent/kelotane

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -322,8 +322,8 @@
 /datum/chemical_reaction/potassium_chlorophoride
 	name = "Potassium Chlorophoride"
 	result = /datum/reagent/toxin/potassium_chlorophoride
-	required_reagents = list(/datum/reagent/toxin/potassium_chloride = 1, /datum/reagent/toxin/phoron = 1, /datum/reagent/chloralhydrate = 1)
-	result_amount = 4
+	required_reagents = list(/datum/reagent/toxin/potassium_chloride = 1, /datum/reagent/toxin/phoron = 1, /datum/reagent/toxin/carpotoxin = 1)
+	result_amount = 3
 
 /datum/chemical_reaction/zombiepowder
 	name = "Zombie Powder"

--- a/code/modules/urist/items/uristmed.dm
+++ b/code/modules/urist/items/uristmed.dm
@@ -37,7 +37,7 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 
 /obj/item/weapon/storage/firstaid/tactical
 	name = "tactical medicine kit"
-	desc = "Contains experimental medicine and advanced tools."
+	desc = "Contains experimental medicines and advanced tools."
 	icon = 'icons/urist/items/misc.dmi'
 	item_icons = URIST_ALL_ONMOBS
 	icon_state = "tactical"
@@ -117,7 +117,8 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 
 /obj/item/weapon/reagent_containers/glass/beaker/stabilization
 	name = "Stabilization mix"
-	desc = "Inaprovaline | Dexalin Plus 1|1"
+	desc = "A label on the side reads 'Inaprovaline | Dexalin Plus 1|1'."
+	icon_state = "bottle-3"
 
 /obj/item/weapon/reagent_containers/glass/beaker/stabilization/New()
 	..()
@@ -127,7 +128,8 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 
 /obj/item/weapon/reagent_containers/glass/beaker/brute
 	name = "Brute treatment mix"
-	desc = "Bicaridine | Tricordrazine 3|1"
+	desc = "A label on the side reads 'Bicaridine | Tricordrazine 3|1'."
+	icon_state = "bottle-3"
 
 /obj/item/weapon/reagent_containers/glass/beaker/brute/New()
 	..()
@@ -137,7 +139,8 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 
 /obj/item/weapon/reagent_containers/glass/beaker/burns
 	name = "Burn treatment mix"
-	desc = "Kelotane | Dermaline 1|1"
+	desc = "A label on the side reads 'Kelotane | Dermaline 1|1'."
+	icon_state = "bottle-3"
 
 /obj/item/weapon/reagent_containers/glass/beaker/burns/New()
 	..()
@@ -147,7 +150,8 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 
 /obj/item/weapon/reagent_containers/glass/beaker/radiation
 	name = "Radiation treatment mix"
-	desc = "Arithrazine | Hyronalin | Dylovene 2|1|1"
+	desc = "A label on the side reads 'Arithrazine | Hyronalin | Dylovene 2|1|1'."
+	icon_state = "bottle-3"
 
 /obj/item/weapon/reagent_containers/glass/beaker/radiation/New()
 	..()
@@ -158,7 +162,8 @@ Space for all Urist-done, non-pill medical items. Please keep it tidy, as usual.
 
 /obj/item/weapon/reagent_containers/glass/beaker/painkiller
 	name = "Painkillers"
-	desc = "Oxycodone | Dexalin Plus 3|1"
+	desc = "A label on the side reads 'Oxycodone | Dexalin Plus 3|1'."
+	icon_state = "bottle-3"
 
 /obj/item/weapon/reagent_containers/glass/beaker/painkiller/New()
 	..()

--- a/code/modules/urist/items/uristpills.dm
+++ b/code/modules/urist/items/uristpills.dm
@@ -46,20 +46,21 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	icon_state = "pill12"
 	New()
 		..()
-		reagents.add_reagent(/datum/reagent/nutriment, 30)
+		reagents.add_reagent(/datum/reagent/nutriment, 15)
+		reagents.add_reagent(/datum/reagent/nanoblood, 15)
 		reagents.add_reagent(/datum/reagent/iron, 15)
 		reagents.add_reagent(/datum/reagent/sugar, 15)
 
 /obj/item/weapon/reagent_containers/pill/peridaxon
-	name = "Peridaxon pill"
-	desc = "Rapidly regenerates internal organs."
+	name = "Peridaxon (10u)"
+	desc = "Regenerates internal organs and reverses organ decay."
 	icon_state = "pill8"
 	New()
 		..()
 		reagents.add_reagent(/datum/reagent/peridaxon, 10)
 
 /obj/item/weapon/reagent_containers/pill/rezadone
-	name = "Emergency recovery pill"
+	name = "Rezadone (15u)"
 	desc = "Only to be used in absolute emergencies."
 	icon_state = "pill18"
 	New()
@@ -75,7 +76,7 @@ Please keep it tidy, by which I mean put comments describing the item before the
 		reagents.add_reagent(/datum/reagent/spaceacillin, 45)
 
 /obj/item/weapon/reagent_containers/pill/exbicaridine
-	name = "Extreme bicaridine pill"
+	name = "Bicaridine (45u)"
 	desc = "For arterial bleeding cases only."
 	icon_state = "pill10"
 	New()
@@ -83,7 +84,7 @@ Please keep it tidy, by which I mean put comments describing the item before the
 		reagents.add_reagent(/datum/reagent/bicaridine, 45)
 
 /obj/item/weapon/reagent_containers/pill/latrazine
-	name = "latrazine pill"
+	name = "Latrazine (5u)"
 	desc = "WARNING: Unstable mixture. Do not consume under normal conditions. Only for use in critical non-compound fractures."
 	icon_state = "pill2"
 	New()


### PR DESCRIPTION
Makes it so arterial bleeding cannot occur in encased regions (head, chest) until the bones there are broken.
Re-balances lung recovery rates to be significantly faster.
Puts potassium chlorophoride behind carpotoxin as they both deal with stopping the heart.
Brings everything in the tactical medkit into line with standard naming conventions.
Gives bicaridine a buff to deal with cases of extreme damage (100~ to 200~) in a semi-timely fashion.