### PR TITLE
Additional medical balances and bugfixes

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -235,6 +235,15 @@
 	generate_window(user)
 	return
 
+/obj/machinery/body_scanconsole/attackby(var/obj/item/O, var/mob/user)
+	if(default_deconstruction_screwdriver(user, O))
+		return
+	if(default_deconstruction_crowbar(user, O))
+		return
+	if(default_part_replacement(user, O))
+		return
+	. = ..()
+
 /obj/machinery/body_scanconsole/OnTopic(mob/user, href_list)
 	if (href_list["print"])
 		if (!stored_scan)
@@ -370,9 +379,9 @@
 		else
 			table += "<td>"
 			if(E.brute_dam)
-				table += "[capitalize(get_wound_severity(E.brute_ratio))] ([E.brute_dam]) physical trauma"
+				table += "[capitalize(get_wound_severity(E.brute_ratio))] physical trauma ([E.brute_dam])"
 			if(E.burn_dam)
-				table += " [capitalize(get_wound_severity(E.burn_ratio))] ([E.burn_dam]) burns"
+				table += " [capitalize(get_wound_severity(E.burn_ratio))] burns ([E.burn_dam])"
 			if(E.brute_dam + E.burn_dam == 0)
 				table += "None"
 			table += "</td><td>[english_list(E.get_scan_results(), nothing_text = "", and_text = ", ")]</td></tr>"

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -138,7 +138,7 @@
 	if(occupant.getCloneLoss() == 0) // Rare case, but theoretically possible
 		return 100
 
-	return between(0, 100 * (occupant.health - occupant.maxHealth / 100) / (occupant.maxHealth * heal_level / 100), 100)
+	return between(0, 100 * (occupant.getCloneLoss() - occupant.maxHealth / 100) / (occupant.maxHealth * heal_level / 100), 100)
 
 //Grow clones to maturity then kick them out.  FREELOADERS
 /obj/machinery/clonepod/Process()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -218,9 +218,9 @@ proc/medical_scan_results(var/mob/living/carbon/human/H, var/verbose)
 			for(var/obj/item/organ/external/org in damaged)
 				var/limb_result = "[capitalize(org.name)][BP_IS_ROBOTIC(org) ? " (Cybernetic)" : ""]:"
 				if(org.brute_dam > 0)
-					limb_result = "[limb_result] \[<font color = 'red'><b>[get_wound_severity(org.brute_ratio, (org.limb_flags & ORGAN_FLAG_HEALS_OVERKILL))] ([org.brute_dam]) physical trauma</b></font>\]"
+					limb_result = "[limb_result] \[<font color = 'red'><b>[get_wound_severity(org.brute_ratio, (org.limb_flags & ORGAN_FLAG_HEALS_OVERKILL))] physical trauma ([org.brute_dam])</b></font>\]"
 				if(org.burn_dam > 0)
-					limb_result = "[limb_result] \[<font color = '#ffa500'><b>[get_wound_severity(org.burn_ratio, (org.limb_flags & ORGAN_FLAG_HEALS_OVERKILL))] ([org.burn_dam]) burns</b></font>\]"
+					limb_result = "[limb_result] \[<font color = '#ffa500'><b>[get_wound_severity(org.burn_ratio, (org.limb_flags & ORGAN_FLAG_HEALS_OVERKILL))] burns ([org.burn_dam])</b></font>\]"
 				if(org.status & ORGAN_BLEEDING)
 					limb_result = "[limb_result] \[<span class='danger'>bleeding</span>\]"
 				. += limb_result

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -6,9 +6,9 @@ Single Use Emergency Pouches
 	name = "emergency medical pouch"
 	desc = "For use in emergency situations only."
 	icon = 'icons/obj/med_pouch.dmi'
-	storage_slots = 7
+	storage_slots = 6
 	w_class = ITEM_SIZE_SMALL
-	max_w_class = ITEM_SIZE_SMALL
+	max_w_class = ITEM_SIZE_TINY
 
 	var/base_icon = "white"
 	var/injury_type = "generic"
@@ -56,8 +56,6 @@ Single Use Emergency Pouches
 	if(!opened)
 		user.visible_message("<span class='notice'>\The [user] tears open [src], breaking the vacuum seal!</span>", "<span class='notice'>You tear open [src], breaking the vacuum seal!</span>")
 		opened = 1
-		max_w_class = ITEM_SIZE_TINY
-		storage_slots = 4
 		update_icon()
 
 /obj/item/weapon/storage/med_pouch/open(mob/user as mob)
@@ -65,6 +63,7 @@ Single Use Emergency Pouches
 		. = ..()
 	else
 		break_seal(user)
+		. = ..()
 
 /obj/item/weapon/storage/med_pouch/trauma
 	name = "trauma pouch"

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -6,7 +6,7 @@ Single Use Emergency Pouches
 	name = "emergency medical pouch"
 	desc = "For use in emergency situations only."
 	icon = 'icons/obj/med_pouch.dmi'
-	storage_slots = 6
+	storage_slots = 8
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_TINY
 
@@ -74,7 +74,7 @@ Single Use Emergency Pouches
 	/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline,
 	/obj/item/weapon/reagent_containers/pill/pouch_pill/inaprovaline,
 	/obj/item/weapon/reagent_containers/pill/pouch_pill/paracetamol,
-	/obj/item/stack/medical/bruise_pack = 2,
+	/obj/item/stack/medical/bruise_pack/med_pouch = 2,
 		)
 	instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
@@ -96,7 +96,7 @@ Single Use Emergency Pouches
 	/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/deletrathol,
 	/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline,
 	/obj/item/weapon/reagent_containers/pill/pouch_pill/paracetamol,
-	/obj/item/stack/medical/ointment = 2,
+	/obj/item/stack/medical/ointment/med_pouch = 2,
 		)
 	instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
@@ -223,3 +223,10 @@ Single Use Emergency Pouches
 	name = "emergency adrenaline autoinjector"
 	amount_per_transfer_from_this = 8
 	starts_with = list(/datum/reagent/adrenaline = 8)
+
+//TODO: Just bring back real medkits, these things are worthless.
+/obj/item/stack/medical/bruise_pack/med_pouch
+	w_class = ITEM_SIZE_TINY
+
+/obj/item/stack/medical/ointment/med_pouch
+	w_class = ITEM_SIZE_TINY

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -186,7 +186,7 @@ obj/item/organ/internal/take_general_damage(var/amount, var/silent = FALSE)
 	. = ..()
 	var/scar_level = get_scarring_level()
 	if(scar_level > 0.01)
-		. += "[get_wound_severity(get_scarring_level())] scarring"
+		. += "[get_wound_severity(get_scarring_level())] scarring ([round(scar_level * 100)]%)"
 
 /obj/item/organ/internal/emp_act(severity)
 	if(!BP_IS_ROBOTIC(src))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -853,13 +853,14 @@
 
 /datum/reagent/latrazine/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed)
 	var/obj/item/organ/external/E = pick(M.bad_external_organs)
-	if(E.status & ORGAN_BROKEN)
+	if(E.status & ORGAN_BROKEN && prob(40))
 		E.status &= ~ORGAN_BROKEN
-		M.custom_pain("You suddenly feel EXCRUCIATING pain as your [E.name] <i>SNAPS</i> back into place.", 120, 1, E)
+		M.custom_pain("You suddenly feel <b>EXCRUCIATING</b> pain as your [E.name] <i>SNAPS</i> back into place.", 120, 1, E)
 
-	if(prob(5) && M.hallucination_duration < 10)
+	if(prob(10) && M.hallucination_power < 60)
 		to_chat(M, "<span class = 'danger'><font size = 3>Your vision of reality suddenly snaps!</font></span>")
-		M.adjust_hallucination(240)
+		M.adjust_hallucination(240,60)
+
 // Sleeping agent, produced by breathing N2O.
 /datum/reagent/nitrous_oxide
 	name = "Nitrous Oxide"

--- a/code/modules/urist/items/uristpills.dm
+++ b/code/modules/urist/items/uristpills.dm
@@ -118,7 +118,7 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	startswith = list(/obj/item/weapon/reagent_containers/pill/bloodloss = 14)
 
 /obj/item/weapon/storage/pill_bottle/peridaxon
-	name = "bottle of peridaxon pills"
+	name = "pill bottle (Peridaxon)"
 	desc = "Contains pills to regenerate organs."
 	startswith = list(/obj/item/weapon/reagent_containers/pill/peridaxon = 14)
 
@@ -133,6 +133,6 @@ Please keep it tidy, by which I mean put comments describing the item before the
 		)
 
 /obj/item/weapon/storage/pill_bottle/clonefix
-	name = "bottle of clonefix pills"
+	name = "pill bottle (Clonefix)"
 	desc = "Contains pills to repair cloning defaults."
 	startswith = list(/obj/item/weapon/reagent_containers/pill/clonefix = 7)


### PR DESCRIPTION
The body scanner console can now be deconstructed.
Numerical values have been placed at the end of wound readouts, personally I think it looks better.
Scarring level is now quantified in terms of the original max_damage.
Medical pouches are 10% less bug filled and 50% more spacious.
The cloning pod has had its sensors updated to not throw out broken clones, expect long wait times instead.
A few other fixes that aren't notable.