### PR TITLE
Make the ore processor more safe

### DIFF
--- a/code/modules/mining/machinery/mineral_processor.dm
+++ b/code/modules/mining/machinery/mineral_processor.dm
@@ -37,14 +37,14 @@
 
 	//Grab some more ore to process this tick.
 	if(input_turf)
-		for(var/obj/item/I in recursive_content_check(input_turf, sight_check = FALSE, include_mobs = FALSE))
+		for(var/obj/item/weapon/ore/I in recursive_content_check(input_turf, sight_check = FALSE, include_mobs = FALSE))
 			if(QDELETED(I) || !I.simulated || I.anchored)
 				continue
 			if(LAZYLEN(I.matter))
 				for(var/o_material in I.matter)
 					if(!isnull(ores_stored[o_material]))
 						ores_stored[o_material] += I.matter[o_material]
-			qdel(I)
+						qdel(I)
 
 	if(!active)
 		return


### PR DESCRIPTION
Fixes #653 

Proposed changes:
* Changed the for-each type from `/obj/item` to `/obj/item/weapon/ore`
* Changed indentation of `qdel` so it now does only delete when there is a holder available and if the item contains material