### PR TITLE
Floorpainter bugfix.

### DIFF
--- a/code/game/objects/items/devices/floor_painter.dm
+++ b/code/game/objects/items/devices/floor_painter.dm
@@ -68,10 +68,9 @@
 		)
 
 
-/obj/item/device/floor_painter/resolve_attackby(var/atom/A, var/mob/user, proximity, params)
+/obj/item/device/floor_painter/afterattack(var/atom/A, var/mob/user, proximity, params)
 	if(!proximity)
 		return
-
 	add_fingerprint(user)
 
 	if(color_picker)


### PR DESCRIPTION
The floorpainter now works correctly with the quarterturf decal and precise directions.

The cause was a change to resolve_attackby().

@chaoko99 git blame says you break.