### PR TITLE
adds a little fade effect to lasers and muzzle flashes.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -386,8 +386,10 @@
 			M.pixel_x = round(location.pixel_x, 1)
 			M.pixel_y = round(location.pixel_y, 1)
 			if(!hitscan) //Bullets don't hit their target instantly, so we can't link the deletion of the muzzle flash to the bullet's Destroy()
+				animate(M, alpha = 0, time = 1, flags = ANIMATION_PARALLEL)//Urist edit
 				QDEL_IN(M,1)
 			else
+				animate(M, alpha = 0, time = SEGMENT_DELETION_DELAY, flags = ANIMATION_PARALLEL) //Urist edit, this was the only way to make this effect work.
 				segments |= M
 
 /obj/item/projectile/proc/tracer_effect(var/matrix/M)
@@ -399,8 +401,10 @@
 			P.pixel_x = round(location.pixel_x, 1)
 			P.pixel_y = round(location.pixel_y, 1)
 			if(!hitscan)
+				animate(P, alpha = 0, time = 1, flags = ANIMATION_PARALLEL)
 				QDEL_IN(M,1)
 			else
+				animate(P, alpha = 0, time = SEGMENT_DELETION_DELAY, flags = ANIMATION_PARALLEL)//Urist Edit. Gross.
 				segments |= P
 
 /obj/item/projectile/proc/impact_effect(var/matrix/M)
@@ -411,6 +415,7 @@
 			P.set_transform(M)
 			P.pixel_x = round(location.pixel_x, 1)
 			P.pixel_y = round(location.pixel_y, 1)
+			animate(P, alpha = 0, time = SEGMENT_DELETION_DELAY, flags = ANIMATION_PARALLEL) //Urist edit kill me
 			segments |= P
 
 //"Tracing" projectile


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

There really is no purpose to this, anything relating to the results of the effect are purely incidental.

https://streamable.com/6duuc

https://streamable.com/vxr26