### PR TITLE
HE pipes now check space area/turf instead of just turf

### DIFF
--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -66,7 +66,7 @@ obj/machinery/atmospherics/pipe/simple/heat_exchanging/Process()
 				environment_temperature = environment.temperature
 			if(abs(environment_temperature-pipe_air.temperature) > minimum_temperature_difference)
 				parent.temperature_interact(loc, volume, thermal_conductivity)
-		else if(istype(loc, /turf/space/))
+		else if(istype(loc, /turf/space/) || istype(get_area(src), /area/space))
 			parent.radiate_heat_to_space(surface, 1)
 
 		if(buckled_mob)


### PR DESCRIPTION
🆑 
Space radiators now check for being in the space area and turf, instead of just turf. They will still work if they are in the space turf but a different area.
🆑 