### PR TITLE
Smarter airlock initialization

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -7,6 +7,7 @@
 	var/global/global_uid = 0
 	var/uid
 	var/area_flags
+	var/list/req_access = list()
 
 /area/New()
 	icon_state = ""

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1333,6 +1333,11 @@ About the new airlock wires panel:
 			brace.electronics.conf_access = req_one_access
 			brace.electronics.one_access = 1
 		update_icon()
+	var/area/doorarea = get_area(src)
+	if(name == initial(name)) //auto-rename based on area.
+		name = "[doorarea.name]"
+		if(doorarea.req_access)
+			req_access += doorarea.req_access
 	. = ..()
 
 /obj/machinery/door/airlock/Destroy()


### PR DESCRIPTION
Last PR of the night.
🆑 
Airlocks now pull name and access from area if name is not defined on initialize.
Areas now have a req_access variable you can set, so you don't have to worry about setting that either, if it's configured in the area!
🆑 