### PR TITLE
TEG Refactor

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -144,7 +144,7 @@
 						playsound(src.loc, 'sound/effects/meteorimpact.ogg', 50, 1, -3)
 						for(var/mob/living/M in view(7, src))
 							shake_camera(M, 1, 2)
-						spawn(5)
+						spawn(0.5 SECONDS)
 							SM.start()
 							playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 	//Power

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -138,7 +138,7 @@
 				var/malfsound = pick(soundlist)
 				playsound(src.loc, malfsound, 50, 0, 10)
 				if(prob(20))
-					var/datum/effect/effect/system/smoke_spread/SS = new /datum/effect/effect/system/smoke_spread
+					var/datum/effect/effect/system/smoke_spread/SS = new()
 					SS.set_up(5, 0, src.loc)
 					playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 50, 1, -3)
 					spawn(2 SECONDS)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -7,6 +7,7 @@
 
 	use_power = 1
 	idle_power_usage = 100 //Watts, I hope.  Just enough to do the computer and display things.
+	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 
 	var/max_power = 500000
 	var/thermal_efficiency = 0.65
@@ -22,14 +23,25 @@
 	var/lastgen2 = 0
 	var/effective_gen = 0
 	var/lastgenlev = 0
+	var/lubricated = 0
 
 	var/datum/effect_system/sparks/spark_system
 
+	var/list/soundverb = list("shudders violently", "rumbles brutally", "vibrates disturbingly", "shakes with a deep rumble", "bangs and thumps")
+	var/list/soundlist = list('sound/ambience/ambigen9.ogg','sound/effects/meteorimpact.ogg','sound/effects/caution.ogg')
+
 /obj/machinery/power/generator/New()
+	create_reagents(120)
 	..()
 	desc = initial(desc) + " Rated for [round(max_power/1000)] kW."
 	spawn(1)
 		reconnect()
+
+/obj/machinery/power/generator/examine(mob/user)
+	..()
+	to_chat(user, "Auxilary tank shows [reagents.total_volume]u of liquid in it.")
+	if(reagents.total_volume == 0)
+		to_chat(user, "It seems to be in need of oiling.")
 
 //generators connect in dir and reverse_dir(dir) directions
 //mnemonic to determine circulator/generator directions: the cirulators orbit clockwise around the generator
@@ -113,12 +125,29 @@
 		circ2.network2.update = 1
 
 	//Exceeding maximum power leads to some power loss
-	if(effective_gen > max_power && prob(5))
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(2, 1, src)
-		s.start()
-		stored_energy *= 0.5
-
+	//exceeding max power is supposed to be bad, have there be a small chance of some visual and audio effects to stress this
+	//remember to lubricate your engines kiddos
+	if(!lubricated)
+		if(effective_gen > max_power && prob(5))
+			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+			s.set_up(2, 1, src)
+			s.start()
+			stored_energy *= 0.5
+			if(prob(55))
+				visible_message("<span class='danger'>[src] [pick(soundverb)]!</span>")
+				var/malfsound = pick(soundlist)
+				playsound(src.loc, malfsound, 50, 0, 10)
+				if(prob(20))
+					var/datum/effect/effect/system/smoke_spread/SS = new /datum/effect/effect/system/smoke_spread
+					SS.set_up(5, 0, src.loc)
+					playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 50, 1, -3)
+					spawn(2 SECONDS)
+						playsound(src.loc, 'sound/effects/meteorimpact.ogg', 50, 1, -3)
+						for(var/mob/living/M in view(7, src))
+							shake_camera(M, 1, 2)
+						spawn(5)
+							SS.start()
+							playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 	//Power
 	last_circ1_gen = circ1.return_stored_energy()
 	last_circ2_gen = circ2.return_stored_energy()
@@ -135,6 +164,13 @@
 		lastgenlev = genlev
 		update_icon()
 	add_avail(effective_gen)
+	if(reagents.has_reagent(/datum/reagent/lube/oil))
+		reagents.remove_any(0.01)
+		thermal_efficiency = 0.80
+		lubricated = 1
+	if(!reagents.has_reagent(/datum/reagent/lube/oil))
+		thermal_efficiency = 0.65
+		lubricated = 0
 
 /obj/machinery/power/generator/attack_ai(mob/user)
 	attack_hand(user)
@@ -152,6 +188,15 @@
 		else
 			disconnect_from_network()
 		reconnect()
+	if(istype(W, /obj/item/weapon/reagent_containers))
+		var/obj/item/weapon/reagent_containers/R = W
+		if(!R.reagents.has_reagent(/datum/reagent/lube/oil))
+			audible_message("<span class='warning'>[src] blips in disappointment</span>")
+			playsound(get_turf(src), 'sound/machines/synth_no.ogg', 50, 0)
+			return
+		R.standard_pour_into(user, src)
+		audible_message("<span class='notice'>[src] blips happily</span>")
+		playsound(get_turf(src),'sound/machines/synth_yes.ogg', 50, 0)
 	else
 		..()
 


### PR DESCRIPTION
🆑 
The oil in Engineering's Roboco vendor now has a use. You can lubricate to prevent overloads.
Lubricating the TEGs increases thermal efficiency by 15%. 

Overloads now, functionally, are the same. However, they have some 'scary' aesthetic effects.
When a TEG overloads, it'll make a grumpy message and a noise. There's a chance it'll go a step farther, make a loud BANG, a warning buzzer, shake the camera of anyone in view, and make some smoke.

.... It's perfectly harmless, however!
🆑 
