### PR TITLE
Autolathe queues no longer refresh when an item is added.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -252,8 +252,6 @@
 			return
 		addToQueue(making)
 		to_chat(user, "<span class='notice'>[src] chimes, '[making.name] added to queue!' </span>")
-	if(. == TOPIC_REFRESH)
-		interact(user)
 
 /obj/machinery/autolathe/update_icon()
 	icon_state = (panel_open ? "autolathe_t" : "autolathe")


### PR DESCRIPTION
🆑 
Autolathe UI does not refresh when you add an item to be produced.
🆑 

By request of SkyeAuroline.