### PR TITLE
Spare lace & silicon brains from limb ashing/disintegration

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2876,6 +2876,7 @@
 #include "code\modules\urist\modules\newtrading\trade\trade_items\crops.dm"
 #include "code\modules\urist\modules\newtrading\trade\trade_items\food.dm"
 #include "code\modules\urist\modules\newtrading\trade\trade_items\tools.dm"
+#include "code\modules\urist\modules\organs\disintegratable.dm"
 #include "code\modules\urist\modules\resourcetech\hunter.dm"
 #include "code\modules\urist\modules\resourcetech\planer.dm"
 #include "code\modules\urist\modules\resourcetech\tools.dm"

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -880,12 +880,24 @@ Note that amputating the affected organ does in fact remove the infection from t
 				if(src && istype(loc,/turf))
 					throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 				dir = 2
+
 		if(DROPLIMB_BURN)
 			new /obj/effect/decal/cleanable/ash(get_turf(victim))
+
+			// URIST EDIT BY IRRA, 2019-05-25
+			for(var/obj/item/organ/O in internal_organs)
+				if(!O.can_disintegrate())
+					O.owner = victim
+					O.removed()
+					internal_organs -= O
+			// END URIST EDIT
+
 			for(var/obj/item/I in src)
 				if(I.w_class > ITEM_SIZE_SMALL && !istype(I,/obj/item/organ))
 					I.loc = get_turf(src)
+
 			qdel(src)
+
 		if(DROPLIMB_BLUNT)
 			var/obj/gore
 			if(BP_IS_CRYSTAL(src))

--- a/code/modules/urist/modules/organs/disintegratable.dm
+++ b/code/modules/urist/modules/organs/disintegratable.dm
@@ -1,0 +1,30 @@
+/*
+ *	disintegratable.dm - modules/urist/modules/organs
+ *
+ * 	can_disintegrate is used in _external.dm in modules/organs/external
+ *
+ * 	can_disintegrate is defined in this file returns 1 by default
+ *
+ * 	Currently used mainly to nerf disintegration of certain essential player organs like;
+ *		* Neural lace					(modules/organs/internal/stack.dm)
+ *		* MMI holders for FBPs			(modules/organs/internal/species/fbp.dm)
+ *		* Synthetic brains for IPCs		(modules/organs/internal/species/ipc.dm)
+ *
+ * 	Created in 2019-05-25 by Irra
+ */
+
+/obj/item/organ/proc/can_disintegrate()
+	return 1
+
+#define URIST_ESSENTIAL_ORGAN_DISINTEGRATABLE 0
+
+/obj/item/organ/internal/posibrain/can_disintegrate()
+	return URIST_ESSENTIAL_ORGAN_DISINTEGRATABLE
+
+/obj/item/organ/internal/mmi_holder/can_disintegrate()
+	return URIST_ESSENTIAL_ORGAN_DISINTEGRATABLE
+
+/obj/item/organ/internal/stack/can_disintegrate()
+	return URIST_ESSENTIAL_ORGAN_DISINTEGRATABLE
+
+#undef URIST_ESSENTIAL_ORGAN_DISINTEGRATABLE


### PR DESCRIPTION
Pull request proposing changes to how laces and brains (MMI holders and posibrains) are affected when the head has been disintegrated from `DROPLIMB_BURN` event in `droplimb` proc.

----

#### Changes `modules/organs/external/_external.dm`
* Added code to spare organs that return 0 from `can_disintegrate` proc

#### ~~Changes `modules/organs/organs.dm`~~
* ~~Added `can_disintegrate` definition, returns 1 by default~~
As per request by @scrdest, this change was moved to the file below

#### Adds `modules/urist/modules/organs/disintegratable.dm`
* Spares those following organs (and its subtype children) from disintegration
    * Added `can_disintegrate` definition, returns 1 by default (request by @scrdest)
    * Neural lace (`/obj/item/organ/internal/stack`)
    * MMI holders (`/obj/item/organ/internal/mmi_holder`)
    * Posibrain (`/obj/item/organ/internal/posibrain`)