### PR TITLE
[WIP][DMN] Ship AI Overhaul

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2885,6 +2885,7 @@
 #include "code\modules\urist\modules\resourcetech\hunter.dm"
 #include "code\modules\urist\modules\resourcetech\planer.dm"
 #include "code\modules\urist\modules\resourcetech\tools.dm"
+#include "code\modules\urist\modules\shipbattles\ai_personalities.dm"
 #include "code\modules\urist\modules\shipbattles\combatcomputer.dm"
 #include "code\modules\urist\modules\shipbattles\component_weapons.dm"
 #include "code\modules\urist\modules\shipbattles\components.dm"

--- a/code/modules/urist/modules/shipbattles/ai_personalities.dm
+++ b/code/modules/urist/modules/shipbattles/ai_personalities.dm
@@ -1,0 +1,106 @@
+#define PERSONALITY_STEADY "Steady"
+#define PERSONALITY_AGGRESSIVE "Aggressive"
+#define PERSONALITY_COWARD "Coward"
+#define PERSONALITY_AI "AI"
+#define PERSONALITY_RECKLESS "Reckless"
+#define PERSONALITY_ALIEN "Alien"
+
+GLOBAL_LIST_INIT(global_ship_personalities, list(
+	"Steady" = list(datum/ship_personality),
+	"Aggressive" = list(/datum/ship_personality/aggressive),
+	"Coward" = list(/datum/ship_personality/coward),
+	"AI" = list(/datum/ship_personality/AI),
+	"Reckless" = list(/datum/ship_personality/reckless),
+	"Alien" = list(/datum/ship_personality/alien)
+))
+
+//SHIP NAME GENERATION
+/datum/ship_name
+	name = "Default Naming scheme"
+	var/list/prefixes = list("IMV", "ICS", "ICV", "CS")
+	var/list/ship_names = list("Kestrel", "Starhawk", "Voyager", "Enterprise", "Unstoppable", "Undefeatable", "Clear Skies", "Skyranger", "Big Sky", "Menace")
+
+/mob/living/simple_animal/hostile/overmapship/proc/get_name_and_personality()
+	switch(hiddenfaction)
+		if("pirate")
+			if(prob(50)
+				personality = PERSONALITY_STEADY
+			else
+				personality = PERSONALITY_AGGRESSIVE
+		if("alien")
+			if(prob(50))
+				personality = PERSONALITY_AGGRESSIVE
+			else
+				personality = PERSONALITY_RECKLESS
+		if("nanotrasen")
+			if(prob(75))
+				personality = PERSONALITY_COWARD
+			else
+				personality = PERSONALITY_STEADY
+		if("terran")
+			personality = PERSONALITY_STEADY
+		if("rebel")
+			personality = PERSONALITY_RECKLESS
+
+
+
+//SHIP AI PERSONALITIES
+
+/datum/ship_personality //base type
+	name = "Default"
+	var/personality = PERSONALITY_STEADY
+	var/aggressiveness = 1 //Aggressive AIs are more likely to attack.
+	var/cowardice = 1 //Cowardly AIs will try to avoid combat, and dodge shots.
+	var/reckless = 0 //Recklessness means the AI has zero regard for survival, and will attack at all costs.
+	var/datum/ship_taunts/taunt_datum = datum/ship_taunts
+	var/datum/ship_name/ship_names = datum/ship_name
+
+/datum/ship_personality/aggressive
+	personality = PERSONALITY_AGGRESSIVE
+	aggressiveness = 2
+	cowardice = 0
+//	taunt_datum =
+//	ship_names =
+
+/datum/ship_personality/coward
+	personality = PERSONALITY_COWARD
+	aggressiveness = 1
+	cowardice = 2
+
+/datum/ship_personality/reckless
+	personality = PERSONALITY_RECKLESS
+	reckless = 1
+
+/datum/ship_personality/AI //AIs have weird gibberish for taunts.
+	personality = PERSONALITY_AI
+	reckless = 1
+
+/datum/ship_personality/alien //Aliens don't taunt.
+	personality = PERSONALITY_ALIEN
+	reckless = 1
+
+//TAUNTS FOR AI PERSONALITIES
+
+/datum/ship_taunts
+	name = "Default Taunts"
+	var/list/normal_taunts = list(
+	"Power down your weapons and shields, and surrender.", "You can't hope to defeat me. You're outmatched.", "The more you fight, the less likely i'm to let the survivors live.",
+	"We're both out here to make some money, I just intend to make it by destroying you.", "It's a dangerous world. And i'm the danger.", "Keep struggling. It's fun to watch you panic.") //What it says normally.
+
+	var/list/on_damage = list(
+	"Gah! Damn, you scratched my paint.", "Holy smokes, that one took out Deck Three! And I left my wallet on Deck Three...", "Is it just me, or do i smell burning toast?",
+	"Main deflectors are holding, you'll have to try harder than that!", "Is that the best you've got?", "Grr, that was my favorite part of the ship!") //What it says when taking damage.
+
+	var/list/on_retreat = list(
+	"Alright alright, I overestimated you!", "Engines to flank speed, get us the hell out of here!", "It'll be easier on you if you let us live!",
+	"Okay, okay! How much do you want to STOP SHOOTING AT US?!", "Holy crap, my insurance is going to kill me for this...", "Oscar Mike Foxtrot Golf, we're trying to get the fuck out of here!") //What it says while attempting to retreat.
+
+	var/list/on_weapons_fire = list("All guns, fire!", "Take that!", "Let's see how you like this.", "I spent good money on these guns. Money well spent.", "Keep firing.") //What it says after firing one of it's weapons.
+
+	var/list/on_component_destroyed = list("Gah! You'll pay for that!", "That won't stop us. Keep firing!", "You may have damaged my ship, but i'l kill you all!", "Do you know how ANGRY you're making me?"
+	"This isn't over until I say it's over!", "Amusing. You might actually put up a decent  fight!")
+	) //What it says when something critical has been destroyed.
+
+	var/list/on_defeat = list("The Captain goes down with the ship.", "All hands, abandon ship, they beat us!", "Damn you all to hell!", "NOOOOOOO!",
+	"The reactor is breach-ZZZZZZ!", "Our weapons are fused and hull damage is critical, all hands abandon ship!") //What it says when the ship is destroyed.
+

--- a/code/modules/urist/modules/shipbattles/ai_personalities.dm
+++ b/code/modules/urist/modules/shipbattles/ai_personalities.dm
@@ -6,7 +6,7 @@
 #define PERSONALITY_ALIEN "Alien" //Lactera.
 
 GLOBAL_LIST_INIT(global_ship_personalities, list(
-	"Steady" = list(datum/ship_personality),
+	"Steady" = list(/datum/ship_personality),
 	"Aggressive" = list(/datum/ship_personality/aggressive),
 	"Coward" = list(/datum/ship_personality/coward),
 	"AI" = list(/datum/ship_personality/AI),
@@ -16,14 +16,13 @@ GLOBAL_LIST_INIT(global_ship_personalities, list(
 
 //SHIP NAME GENERATION
 /datum/ship_name
-	name = "Default Naming scheme"
 	var/list/prefixes = list("IMV", "ICS", "ICV", "CS")
 	var/list/ship_names = list("Kestrel", "Starhawk", "Voyager", "Enterprise", "Unstoppable", "Undefeatable", "Clear Skies", "Skyranger", "Big Sky", "Menace")
 
 /mob/living/simple_animal/hostile/overmapship/proc/get_name_and_personality()
 	switch(hiddenfaction)
 		if("pirate")
-			if(prob(50)
+			if(prob(50))
 				personality_define = PERSONALITY_STEADY
 			else
 				personality_define = PERSONALITY_AGGRESSIVE
@@ -48,19 +47,18 @@ GLOBAL_LIST_INIT(global_ship_personalities, list(
 			get_name_and_personality() //Call it again and move on.
 			return
 	//Personality picked. Generate our name now.
-	name = "[pick(personality.ship_names.prefixes)] [pick(personality.ship_names.shipnames)] - [ship_category]"
+	name = "[pick(personality.ship_names.prefixes)] [pick(personality.ship_names.ship_names)] - [ship_category]"
 
 
 //SHIP AI PERSONALITIES
 
 /datum/ship_personality //base type
-	name = "Default"
 	var/personality = PERSONALITY_STEADY
 	var/aggressiveness = 1 //Aggressive AIs are more likely to attack.
 	var/cowardice = 1 //Cowardly AIs will try to avoid combat, and dodge shots.
 	var/reckless = 0 //Recklessness means the AI has zero regard for survival, and will attack at all costs.
-	var/datum/ship_taunts/taunt_datum = datum/ship_taunts
-	var/datum/ship_name/ship_names = datum/ship_name
+	var/datum/ship_taunts/taunt_datum = /datum/ship_taunts
+	var/datum/ship_name/ship_names = /datum/ship_name
 	var/faction = null //Is this one related to a specific faction? It won't be picked if the ship's hiddenfaction isn't the same.
 
 /datum/ship_personality/aggressive
@@ -89,7 +87,6 @@ GLOBAL_LIST_INIT(global_ship_personalities, list(
 //TAUNTS FOR AI PERSONALITIES
 
 /datum/ship_taunts
-	name = "Default Taunts"
 	var/list/normal_taunts = list(
 	"Power down your weapons and shields, and surrender.", "You can't hope to defeat me. You're outmatched.", "The more you fight, the less likely i'm to let the survivors live.",
 	"We're both out here to make some money, I just intend to make it by destroying you.", "It's a dangerous world. And i'm the danger.", "Keep struggling. It's fun to watch you panic.") //What it says normally.
@@ -104,9 +101,9 @@ GLOBAL_LIST_INIT(global_ship_personalities, list(
 
 	var/list/on_weapons_fire = list("All guns, fire!", "Take that!", "Let's see how you like this.", "I spent good money on these guns. Money well spent.", "Keep firing.") //What it says after firing one of it's weapons.
 
-	var/list/on_component_destroyed = list("Gah! You'll pay for that!", "That won't stop us. Keep firing!", "You may have damaged my ship, but i'l kill you all!", "Do you know how ANGRY you're making me?"
+	var/list/on_component_destroyed = list("Gah! You'll pay for that!", "That won't stop us. Keep firing!", "You may have damaged my ship, but i'l kill you all!", "Do you know how ANGRY you're making me?",
 	"This isn't over until I say it's over!", "Amusing. You might actually put up a decent  fight!")
-	) //What it says when something critical has been destroyed.
+	 //What it says when something critical has been destroyed.
 
 	var/list/on_defeat = list("The Captain goes down with the ship.", "All hands, abandon ship, they beat us!", "Damn you all to hell!", "NOOOOOOO!",
 	"The reactor is breach-ZZZZZZ!", "Our weapons are fused and hull damage is critical, all hands abandon ship!") //What it says when the ship is destroyed.

--- a/code/modules/urist/modules/shipbattles/ai_personalities.dm
+++ b/code/modules/urist/modules/shipbattles/ai_personalities.dm
@@ -1,9 +1,9 @@
-#define PERSONALITY_STEADY "Steady"
-#define PERSONALITY_AGGRESSIVE "Aggressive"
-#define PERSONALITY_COWARD "Coward"
-#define PERSONALITY_AI "AI"
-#define PERSONALITY_RECKLESS "Reckless"
-#define PERSONALITY_ALIEN "Alien"
+#define PERSONALITY_STEADY "Steady" //Steady. Balance of aggression and cowardice.
+#define PERSONALITY_AGGRESSIVE "Aggressive" //Aggressive. No retreat, generally.
+#define PERSONALITY_COWARD "Coward" //Wants to AVOID fighting you at all costs.
+#define PERSONALITY_AI "AI" //Special AI Type, reckless and spouts nonsense. Not implemented.
+#define PERSONALITY_RECKLESS "Reckless" //WAAAAAGH!
+#define PERSONALITY_ALIEN "Alien" //Lactera.
 
 GLOBAL_LIST_INIT(global_ship_personalities, list(
 	"Steady" = list(datum/ship_personality),
@@ -24,24 +24,31 @@ GLOBAL_LIST_INIT(global_ship_personalities, list(
 	switch(hiddenfaction)
 		if("pirate")
 			if(prob(50)
-				personality = PERSONALITY_STEADY
+				personality_define = PERSONALITY_STEADY
 			else
-				personality = PERSONALITY_AGGRESSIVE
+				personality_define = PERSONALITY_AGGRESSIVE
 		if("alien")
 			if(prob(50))
-				personality = PERSONALITY_AGGRESSIVE
+				personality_define = PERSONALITY_AGGRESSIVE
 			else
-				personality = PERSONALITY_RECKLESS
+				personality_define = PERSONALITY_RECKLESS
 		if("nanotrasen")
 			if(prob(75))
-				personality = PERSONALITY_COWARD
+				personality_define = PERSONALITY_COWARD
 			else
-				personality = PERSONALITY_STEADY
+				personality_define = PERSONALITY_STEADY
 		if("terran")
 			personality = PERSONALITY_STEADY
 		if("rebel")
 			personality = PERSONALITY_RECKLESS
-
+	personality = pick(GLOB.global_ship_personalities[personality_define])
+	//Sanity check to make sure we're not picking a personality we shouldn't be.
+	if(personality.faction)
+		if(hiddenfaction != personality.faction)
+			get_name_and_personality() //Call it again and move on.
+			return
+	//Personality picked. Generate our name now.
+	name = "[pick(personality.ship_names.prefixes)] [pick(personality.ship_names.shipnames)] - [ship_category]"
 
 
 //SHIP AI PERSONALITIES
@@ -54,13 +61,12 @@ GLOBAL_LIST_INIT(global_ship_personalities, list(
 	var/reckless = 0 //Recklessness means the AI has zero regard for survival, and will attack at all costs.
 	var/datum/ship_taunts/taunt_datum = datum/ship_taunts
 	var/datum/ship_name/ship_names = datum/ship_name
+	var/faction = null //Is this one related to a specific faction? It won't be picked if the ship's hiddenfaction isn't the same.
 
 /datum/ship_personality/aggressive
 	personality = PERSONALITY_AGGRESSIVE
 	aggressiveness = 2
 	cowardice = 0
-//	taunt_datum =
-//	ship_names =
 
 /datum/ship_personality/coward
 	personality = PERSONALITY_COWARD
@@ -78,6 +84,7 @@ GLOBAL_LIST_INIT(global_ship_personalities, list(
 /datum/ship_personality/alien //Aliens don't taunt.
 	personality = PERSONALITY_ALIEN
 	reckless = 1
+	taunt_datum = null
 
 //TAUNTS FOR AI PERSONALITIES
 


### PR DESCRIPTION
The goal of this PR is three things:
1. Add name generation for AI overmap combat ships, based on faction.
2. Add random personalities for AI overmap combat ships, based on factions.
3. Add in-combat taunts triggered by various events. 

Personalities should ideally govern retreating from combat, jumping out, etc! 

Anyone else is of course free to contribute to this, and I welcome assistance given some of this may be over my head.