### PR TITLE
Big Huge Zombie Update + simplemob attack fix

### DIFF
--- a/code/game/gamemodes/godmode/god_structures.dm
+++ b/code/game/gamemodes/godmode/god_structures.dm
@@ -18,7 +18,7 @@
 /obj/structure/deity
 	icon = 'icons/obj/cult.dmi'
 	var/mob/living/deity/linked_god
-	var/health = 10
+	health = 10
 	var/power_adjustment = 1 //How much power we get/lose
 	var/build_cost = 0 //How much it costs to build this item.
 	var/deity_flags = DEITY_STRUCTURE_NEAR_IMPORTANT
@@ -50,7 +50,7 @@
 		)
 	take_damage(W.force)
 
-/obj/structure/deity/proc/take_damage(var/amount)
+/obj/structure/deity/take_damage(var/amount)
 	health -= amount
 	if(health < 0)
 		src.visible_message("\The [src] crumbles!")

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -61,7 +61,8 @@ for reference:
 	icon_state = "barricade"
 	anchored = 1.0
 	density = 1
-	var/health = 100
+	breakable = 1
+	health = 100
 	var/maxhealth = 100
 	var/material/material
 	atom_flags = ATOM_FLAG_CLIMBABLE

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/obj/structures.dmi'
 	w_class = ITEM_SIZE_NO_CONTAINER
 	layer = STRUCTURE_LAYER
+	var/health = 100
 	var/breakable
 	var/parts
 
@@ -128,3 +129,8 @@
 
 	connections = dirs_to_corner_states(dirs)
 	other_connections = dirs_to_corner_states(other_dirs)
+
+// Urist addition - stub proc to define the interface
+/obj/structure/proc/take_damage(damage)
+	src.health -= damage
+	return (src.health > 0)

--- a/code/game/objects/structures/alien/alien.dm
+++ b/code/game/objects/structures/alien/alien.dm
@@ -3,7 +3,7 @@
 	desc = "There's something alien about this."
 	icon = 'icons/mob/alien.dmi'
 	layer = ABOVE_OBJ_LAYER
-	var/health = 50
+	health = 50
 
 /obj/structure/alien/proc/healthcheck()
 	if(health <=0)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -17,7 +17,7 @@
 	var/welded = 0
 	var/large = 1
 	var/wall_mounted = 0 //never solid (You can always pass over it)
-	var/health = 100
+	health = 100
 	var/breakout = 0 //if someone is currently breaking out. mutex
 	var/storage_capacity = 2 * MOB_MEDIUM //This is so that someone can't pack hundreds of items in a locker/crate
 							  //then open it in a populated area to crash clients.

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -7,7 +7,7 @@
 	anchored = 1
 	unacidable = 1//Dissolving the case would also delete the gun.
 	alpha = 150
-	var/health = 14
+	health = 14
 	var/destroyed = 0
 
 /obj/structure/displaycase/Initialize()
@@ -41,7 +41,7 @@
 	..()
 	take_damage(Proj.get_structure_damage())
 
-/obj/structure/displaycase/proc/take_damage(damage)
+/obj/structure/displaycase/take_damage(damage)
 	health -= damage
 	if(health <= 0)
 		if (!destroyed)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -6,7 +6,7 @@
 	layer = BELOW_OBJ_LAYER
 	w_class = ITEM_SIZE_NO_CONTAINER
 	var/state = 0
-	var/health = 200
+	health = 200
 	var/cover = 50 //how much cover the girder provides against projectiles.
 	var/material/reinf_material
 	var/reinforcing = 0

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -8,7 +8,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	layer = BELOW_OBJ_LAYER
 	explosion_resistance = 1
-	var/health = 10
+	health = 10
 	var/destroyed = 0
 	var/rodpath = /obj/item/stack/rods //modularity
 	var/on_frame = FALSE

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -39,7 +39,7 @@
 	icon_state = "wall"
 
 	var/undeploy_path = null
-	var/health = 50.0
+	health = 50.0
 
 /obj/structure/inflatable/wall
 	name = "inflatable wall"

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -11,7 +11,7 @@
 
 	var/material/material
 	var/broken =    FALSE
-	var/health =    70
+	health =    70
 	var/maxhealth = 70
 	var/neighbor_status = 0
 
@@ -85,7 +85,7 @@
 			if(0.5 to 1.0)
 				to_chat(user, "<span class='notice'>It has a few scrapes and dents.</span>")
 
-/obj/structure/railing/proc/take_damage(amount)
+/obj/structure/railing/take_damage(amount)
 	health -= amount
 	if(health <= 0)
 		visible_message("<span class='danger'>\The [src] [material.destruction_desc]!</span>")

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -11,11 +11,11 @@
 	var/list/loot = list(/obj/item/weapon/cell,/obj/item/stack/material/iron,/obj/item/stack/rods)
 	var/lootleft = 1
 	var/emptyprob = 95
-	var/health = 40
+	health = 40
 	var/is_rummaging = 0
 
 /obj/structure/rubble/New()
-	if(prob(emptyprob)) 
+	if(prob(emptyprob))
 		lootleft = 0
 	..()
 
@@ -63,7 +63,7 @@
 		is_rummaging = 0
 	else
 		to_chat(user, "<span class='warning'>Someone is already rummaging here!</span>")
-		
+
 /obj/structure/rubble/attackby(var/obj/item/I, var/mob/user)
 	if (istype(I, /obj/item/weapon/pickaxe))
 		var/obj/item/weapon/pickaxe/P = I
@@ -74,7 +74,7 @@
 				var/obj/item/booty = pick(loot)
 				booty = new booty(loc)
 			qdel(src)
-	else 
+	else
 		..()
 		health -= I.force
 		if(health < 1)

--- a/code/game/objects/structures/showcase.dm
+++ b/code/game/objects/structures/showcase.dm
@@ -11,7 +11,7 @@
 	name = "Hyper Capacity Silicon Depolarization Quantum Relay"
 	desc = "You're not sure what this does, but it does something, probably."
 	icon_state = "relay"
-	var/health = 100
+	health = 100
 	var/obj/machinery/button/alternate/biohazard/reset_button
 
 /obj/structure/showcase/blob_hazard/Initialize()
@@ -19,7 +19,7 @@
 	var/area/A = loc
 	reset_button = locate(/obj/machinery/button/alternate/biohazard) in A
 
-/obj/structure/showcase/blob_hazard/proc/take_damage(var/damage)
+/obj/structure/showcase/blob_hazard/take_damage(var/damage)
 	health -= damage
 	if(health < 0)
 		reset_button.activate(null, TRUE)

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "nest"
 	buckle_pixel_shift = "x=0;y=6"
-	var/health = 100
+	health = 100
 
 /obj/structure/bed/nest/update_icon()
 	return

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -16,7 +16,7 @@
 
 	var/damage = 0
 	var/maxhealth = 10
-	var/health = 10
+	health = 10
 	var/stripe_color
 
 	blend_objects = list(/obj/machinery/door, /turf/simulated/wall) // Objects which to blend with
@@ -174,7 +174,7 @@
 	new /obj/item/stack/material/steel(get_turf(src))
 	qdel(src)
 
-/obj/structure/wall_frame/proc/take_damage(dam)
+/obj/structure/wall_frame/take_damage(dam)
 	if(dam)
 		damage = max(0, damage + dam)
 		update_damage()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -12,7 +12,6 @@
 	var/maxhealth = 14.0
 	var/maximal_heat = T0C + 100 		// Maximal heat before this window begins taking damage from fire
 	var/damage_per_fire_tick = 2.0 		// Amount of damage per fire tick. Regular windows are not fireproof so they might as well break quickly.
-	var/health
 	var/ini_dir = null
 	var/state = 2
 	var/reinf = 0
@@ -54,7 +53,7 @@
 /obj/structure/window/CanFluidPass(var/coming_from)
 	return (!is_full_window() && coming_from != dir)
 
-/obj/structure/window/proc/take_damage(var/damage = 0,  var/sound_effect = 1)
+/obj/structure/window/take_damage(var/damage = 0,  var/sound_effect = 1)
 	var/initialhealth = health
 
 	if(silicate)

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -46,9 +46,14 @@
 		return 0
 	return ..()
 
-/mob/living/simple_animal/hostile/scarybat/AttackingTarget()
+/mob/living/simple_animal/hostile/scarybat/UnarmedAttack(var/atom/A, var/proximity)
+	if(A && A == owner)
+		// No attacking the owner! Bad bat!
+		return 0
+
 	. =..()
-	var/mob/living/L = .
+
+	var/mob/living/L = A
 	if(istype(L))
 		if(prob(15))
 			L.Stun(1)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -44,9 +44,9 @@
 	if(.)
 		custom_emote(1,"nashes at [.]")
 
-/mob/living/simple_animal/hostile/carp/AttackingTarget()
+/mob/living/simple_animal/hostile/carp/UnarmedAttack(var/atom/A, var/proximity)
 	. =..()
-	var/mob/living/L = .
+	var/mob/living/L = A
 	if(istype(L))
 		if(prob(15))
 			L.Weaken(3)

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -35,9 +35,9 @@
 	if(.)
 		audible_emote("wails at [.]")
 
-/mob/living/simple_animal/hostile/faithless/AttackingTarget()
+/mob/living/simple_animal/hostile/faithless/UnarmedAttack(var/atom/A, var/proximity)
 	. =..()
-	var/mob/living/L = .
+	var/mob/living/L = A
 	if(istype(L))
 		if(prob(12))
 			L.Weaken(3)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -72,20 +72,20 @@
 	get_light_and_color(parent)
 	..()
 
-/mob/living/simple_animal/hostile/giant_spider/AttackingTarget()
+/mob/living/simple_animal/hostile/giant_spider/UnarmedAttack(var/atom/A, var/proximity)
 	. = ..()
-	if(isliving(.))
-		var/mob/living/L = .
+	if(isliving(A))
+		var/mob/living/L = A
 		if(L.reagents)
 			L.reagents.add_reagent(/datum/reagent/toxin, poison_per_bite)
 			if(prob(poison_per_bite))
 				to_chat(L, "<span class='warning'>You feel a tiny prick.</span>")
 				L.reagents.add_reagent(poison_type, 5)
 
-/mob/living/simple_animal/hostile/giant_spider/nurse/AttackingTarget()
+/mob/living/simple_animal/hostile/giant_spider/nurse/UnarmedAttack(var/atom/A, var/proximity)
 	. = ..()
-	if(ishuman(.))
-		var/mob/living/carbon/human/H = .
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
 		if(prob(poison_per_bite))
 			var/obj/item/organ/external/O = pick(H.organs)
 			if(!BP_IS_ROBOTIC(O))

--- a/code/modules/mob/living/simple_animal/hostile/hostile2.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile2.dm
@@ -200,9 +200,13 @@
 		return 1
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget()
-	target.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
-	playsound(src, attack_sound, 100, 1) //what the shit, how come nobody noticed no melee attack sounds were playing in not one
-                                         //but two separate versions of hostile mob code?!
+	// AI wrapper around actual attack logic.
+	// Do NOT put effects directly in here or they won't work when human-controlled.
+	// Override/decorate UnarmedAttack instead!
+	if(UnarmedAttack(target))
+		return target
+	return
+
 
 /mob/living/simple_animal/hostile/proc/Aggro()
 	vision_range = aggro_vision_range

--- a/code/modules/mob/living/simple_animal/hostile/hostile2.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile2.dm
@@ -76,6 +76,7 @@
 /mob/living/simple_animal/hostile/proc/FindTarget()//Step 2, filter down possible targets to things we actually care about
 	var/list/Targets = list()
 	var/Target
+
 	for(var/atom/A in ListTargets())
 		if(Found(A))//Just in case people want to override targetting
 			var/list/FoundTarget = list()
@@ -85,6 +86,7 @@
 		if(CanAttack(A))//Can we attack it?
 			Targets += A
 			continue
+
 	Target = PickTarget(Targets)
 	return Target //We now have a target
 
@@ -92,29 +94,39 @@
 	return
 
 /mob/living/simple_animal/hostile/proc/PickTarget(var/list/Targets)//Step 3, pick amongst the possible, attackable targets
+
 	if(target != null)//If we already have a target, but are told to pick again, calculate the lowest distance between all possible, and pick from the lowest distance targets
 		for(var/atom/A in Targets)
 			var/target_dist = get_dist(src, target)
 			var/possible_target_distance = get_dist(src, A)
 			if(target_dist < possible_target_distance)
 				Targets -= A
+
 	if(!Targets.len)//We didnt find nothin!
 		return
+
 	var/chosen_target = pick(Targets)//Pick the remaining targets (if any) at random
+
 	return chosen_target
 
 /mob/living/simple_animal/hostile/proc/CanAttack(var/atom/the_target)//Can we actually attack a possible target?
 	if(see_invisible < the_target.invisibility)//Target's invisible to us, forget it
 		return 0
+
 	if(isliving(the_target) && search_objects < 2)
 		var/mob/living/L = the_target
+
 		if(L.stat > stat_attack || L.stat != stat_attack && stat_exclusive == 1)
 			return 0
+
 		if(L.faction == src.faction && !attack_same || L.faction != src.faction && attack_same == 2 || L.faction != attack_faction && attack_faction)
 			return 0
+
 		if(L in friends)
 			return 0
+
 		return 1
+
 	if(isobj(the_target))
 		//if(the_target.type in wanted_objects)
 		if(is_type_in_list(the_target,wanted_objects))
@@ -135,23 +147,29 @@
 
 /mob/living/simple_animal/hostile/proc/MoveToTarget()//Step 5, handle movement between us and our target
 	stop_automated_movement = 1
+
 	if(!target || !CanAttack(target))
 		LoseTarget()
 		return
+
 	if(target in ListTargets())
 		var/target_distance = get_dist(src,target)
+
 		if(ranged)//We ranged? Shoot at em
 			if(target_distance >= 2 && ranged_cooldown <= 0)//But make sure they're a tile away at least, and our range attack is off cooldown
 				OpenFire(target)
-		if(retreat_distance != null)//If we have a retreat distance, check if we need to run from our target
-			if(target_distance <= retreat_distance)//If target's closer than our retreat distance, run
-				walk_away(src,target,retreat_distance,move_to_delay)
-			else
-				Goto(target,move_to_delay,minimum_distance)//Otherwise, get to our minimum distance so we chase them
+
+		if(retreat_distance != null && (target_distance <= retreat_distance))
+			//If we have a retreat distance, check if we need to run from our target
+			//If target's closer than our retreat distance, run
+			walk_away(src,target,retreat_distance,move_to_delay)
 		else
+			//Otherwise, get to our minimum distance so we chase them
 			Goto(target,move_to_delay,minimum_distance)
+
 		if(isturf(loc) && target.Adjacent(src))	//If they're next to us, attack
 			AttackingTarget()
+
 		return 1
 
 	if(target.loc != null && get_dist(src, target.loc) <= vision_range)//We can't see our target, but he's in our vision range still
@@ -159,7 +177,7 @@
 			var/atom/A = target.loc
 			Goto(A,move_to_delay,minimum_distance)
 			if(A.Adjacent(src))
-				A.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext, damage_type)
+				src.UnarmedAttack(A, 1)
 			return
 		else
 			LostTarget()
@@ -168,8 +186,10 @@
 
 /mob/living/simple_animal/hostile/proc/Goto(var/atom/target, var/delay, var/minimum_distance)
 	if(get_dist(src, target.loc) > minimum_distance)
-		step_towards(src, target) //weird but necessary so they try to bump openable obstacles
-	walk_to(src, target, minimum_distance, delay)
+		if(step_towards(src, target)) //weird but necessary so they try to bump openable obstacles
+			walk_to(src, target, minimum_distance, delay)
+		else
+			DestroySurroundings(directions=list(get_dir(src,target)))
 
 /mob/living/simple_animal/hostile/adjustBruteLoss(var/damage)
 	..(damage)
@@ -177,10 +197,12 @@
 		if(search_objects)//Turn off item searching and ignore whatever item we were looking at, we're more concerned with fight or flight
 			search_objects = 0
 			target = null
+
 		if(stance == HOSTILE_STANCE_IDLE)//If we took damage while idle, immediately attempt to find the source of it so we find a living target
 			Aggro()
 			var/new_target = FindTarget()
 			GiveTarget(new_target)
+
 		if(stance == HOSTILE_STANCE_ATTACK)//No more pulling a mob forever and having a second player attack it, it can switch targets now if it finds a more suitable one
 			if(target != null && prob(25))
 				var/new_target = FindTarget()
@@ -244,7 +266,8 @@
 	stop_automated_movement = 1 //so the mobs don't run into own bullets
 
 	var/shots = 0
-	while(1) //always true, we'll terminate manually to unstop movement
+
+	while(src) //always true, we'll terminate manually to unstop movement
 		shottimer += 3
 		spawn(shottimer)
 			if(target)
@@ -273,38 +296,56 @@
 			var/def_zone = get_exposed_defense_zone(target)
 			A.launch(target, def_zone)
 
-/mob/living/simple_animal/hostile/proc/DestroySurroundings()
-	if(environment_smash && prob(break_stuff_probability))
+/mob/living/simple_animal/hostile/proc/DestroySurroundings(var/forced=0, var/list/directions=null, var/special_attacktext=null)
+	if(environment_smash && (forced || prob(break_stuff_probability)))
+		var/attackmsg = special_attacktext || src.attacktext
+
 		EscapeConfinement()
-		for(var/dir in GLOB.cardinal)
+
+		var/list/breakdirs = GLOB.cardinal
+		if(directions)
+			breakdirs = directions
+
+		for(var/dir in breakdirs)
 			var/turf/T = get_step(src, dir)
+
 			if(istype(T, /turf/simulated/wall) && T.Adjacent(src))
-				T.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
+				T.attack_generic(src, rand(melee_damage_lower,melee_damage_upper), "[src] has [attackmsg] \the [T]")
+
 			for(var/atom/A in T)
-				if(!A.Adjacent(src))
+				if(A == src)
 					continue
-				if(istype(A, /obj/structure/window) || istype(A, /obj/structure/closet) || istype(A, /obj/structure/table) || istype(A, /obj/structure/grille) || istype(A, /obj/machinery/door/window))
-					A.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
 
-				if(istype(A, /obj/structure/wall_frame))
-					T = get_turf(A)
-					var/obj/structure/struct = locate(/obj/structure/window) in T
-					if(!struct)
-						struct = locate(/obj/structure/grille) in T
-					if(struct)
-						struct.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
-						return
-					A.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
+				if(A.density < 1)
+					continue
 
+				if(istype(A, /obj/structure))
+					var/obj/structure/struct = A
+					var/damage = rand(melee_damage_lower, melee_damage_upper)
 
+					// the code below is a horrible hack, but so is the attack handling on structures -_-
+					if(struct.breakable && damage > struct.health)
+						struct.attack_generic(src, damage, attackmsg, 1)
+					else
+						struct.take_damage(damage)
+						src.do_attack_animation(struct)
+						src.visible_message("[src] has [attackmsg] \the [A]")
+						if(loc && attack_sound)
+							playsound(loc, attack_sound, 50, 1, 1)
+					return
+
+				if(src.UnarmedAttack(A, 1))
+					return
 	return
 
 /mob/living/simple_animal/hostile/proc/EscapeConfinement()
 	if(buckled)
-		buckled.attack_generic(src)
+		src.UnarmedAttack(buckled, 1)
+
 	if(!isturf(src.loc) && src.loc != null)//Did someone put us in something?
 		var/atom/A = src.loc
-		A.attack_generic(src)//Bang on it till we get out
+		src.UnarmedAttack(A, 1)//Bang on it till we get out
+
 	return
 
 /mob/living/simple_animal/hostile/proc/FindHidden(var/atom/hidden_target)

--- a/code/modules/mob/living/simple_animal/hostile/hostile2.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile2.dm
@@ -51,12 +51,10 @@
 				GiveTarget(new_target)
 
 			if(HOSTILE_STANCE_ATTACK)
-				MoveToTarget()
-				DestroySurroundings()
+				MoveToTarget() || DestroySurroundings()
 
 			if(HOSTILE_STANCE_ATTACKING)
-				AttackTarget()
-				DestroySurroundings()
+				AttackTarget() || DestroySurroundings()
 
 
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////
@@ -85,9 +83,6 @@
 			Targets = FoundTarget
 			break
 		if(CanAttack(A))//Can we attack it?
-			//if(istype(src, /mob/living/simple_animal/hostile/scarybat))
-			//	if(A == src.owner)
-			//		continue
 			Targets += A
 			continue
 	Target = PickTarget(Targets)
@@ -157,7 +152,8 @@
 			Goto(target,move_to_delay,minimum_distance)
 		if(isturf(loc) && target.Adjacent(src))	//If they're next to us, attack
 			AttackingTarget()
-		return
+		return 1
+
 	if(target.loc != null && get_dist(src, target.loc) <= vision_range)//We can't see our target, but he's in our vision range still
 		if(FindHidden(target) && environment_smash)//Check if he tried to hide in something to lose us
 			var/atom/A = target.loc
@@ -168,6 +164,7 @@
 		else
 			LostTarget()
 	LostTarget()
+	return
 
 /mob/living/simple_animal/hostile/proc/Goto(var/atom/target, var/delay, var/minimum_distance)
 	if(get_dist(src, target.loc) > minimum_distance)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -126,10 +126,10 @@ var/global/list/protected_objects = list(/obj/machinery,
 	if(destroy_objects)
 		..()
 
-/mob/living/simple_animal/hostile/mimic/AttackingTarget()
+/mob/living/simple_animal/hostile/mimic/UnarmedAttack(var/atom/A, var/proximity)
 	. =..()
 	if(knockdown_people)
-		var/mob/living/L = .
+		var/mob/living/L = A
 		if(istype(L))
 			if(prob(15))
 				L.Weaken(1)

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -36,7 +36,7 @@
 	if(.)
 		audible_emote("growls at [.]")
 
-/mob/living/simple_animal/hostile/tree/AttackingTarget()
+/mob/living/simple_animal/hostile/tree/UnarmedAttack(var/atom/A, var/proximity)
 	. =..()
 	var/mob/living/L = .
 	if(istype(L))

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -96,10 +96,10 @@
 		set_light(0.2, 0.1, 3)
 		move_to_delay = 2
 
-/mob/living/simple_animal/hostile/vagrant/AttackingTarget()
+/mob/living/simple_animal/hostile/vagrant/UnarmedAttack(var/atom/A, var/proximity)
 	. = ..()
-	if(ishuman(.))
-		var/mob/living/carbon/human/H = .
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
 		if(gripping == H)
 			H.Weaken(3)
 			H.Stun(3)

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -60,10 +60,10 @@ Small, little HP, poisonous.
 	chest.embed(holder,0,"\The [src] latches itself onto \the [H]!")
 	holder.sync(src)
 
-/mob/living/simple_animal/hostile/voxslug/AttackingTarget()
+/mob/living/simple_animal/hostile/voxslug/UnarmedAttack(var/atom/A, var/proximity)
 	. = ..()
-	if(istype(., /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = .
+	if(istype(A, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = A
 		if(prob(H.getBruteLoss()/2))
 			attach(H)
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -656,7 +656,7 @@
 	level = 1			// underfloor only
 	var/dpdir = 0		// bitmask of pipe directions
 	dir = 0				// dir will contain dominant direction for junction pipes
-	var/health = 10 	// health points 0-10
+	health = 10 	// health points 0-10
 	alpha = 192 // Plane and alpha modified for mapping, reset to normal on spawn.
 	plane = ABOVE_TURF_PLANE
 	layer = DISPOSALS_PIPE_LAYER

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -276,7 +276,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 				available_cultural_info[token] = list()
 			available_cultural_info[token] |= additional_available_cultural_info[token]
 
-		else if(!LAZYLEN(available_cultural_info[token]))
+		else if(!available_cultural_info || !LAZYLEN(available_cultural_info[token]))
 			var/list/map_systems = GLOB.using_map.available_cultural_info[token]
 			available_cultural_info[token] = map_systems.Copy()
 

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -4,6 +4,7 @@
 	icon_state = "frame"
 	desc = "It's a table, for putting things on. Or standing on, if you really want to."
 	density = 1
+	breakable = 1
 	anchored = 1
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	obj_flags = OBJ_FLAG_SURGICAL
@@ -11,7 +12,7 @@
 	throwpass = 1
 	var/flipped = 0
 	var/maxhealth = 10
-	var/health = 10
+	health = 10
 
 	// For racks.
 	var/can_reinforce = 1
@@ -46,7 +47,7 @@
 
 	health += maxhealth - old_maxhealth
 
-/obj/structure/table/proc/take_damage(amount)
+/obj/structure/table/take_damage(amount)
 	// If the table is made of a brittle material, and is *not* reinforced with a non-brittle material, damage is multiplied by TABLE_BRITTLE_MATERIAL_MULTIPLIER
 	if(material && material.is_brittle())
 		if(reinforced)

--- a/code/modules/urist/gamemodes/assault/human_equipment.dm
+++ b/code/modules/urist/gamemodes/assault/human_equipment.dm
@@ -96,7 +96,7 @@
 	desc = "The shield generator for the station. Protect it with your life. Repair it with a welding torch."
 	icon = 'icons/obj/power.dmi'
 	icon_state = "bbox_on"
-	var/health = 300
+	health = 300
 	var/maxhealth = 300
 	anchored = 1
 	density = 1

--- a/code/modules/urist/mob/humanhostiles.dm
+++ b/code/modules/urist/mob/humanhostiles.dm
@@ -144,7 +144,9 @@
 
 /mob/living/simple_animal/hostile/urist/cultist/death()
 	..()
-	new /obj/effect/effect/smoke/bad(loc)
+	var/datum/effect/effect/system/smoke_spread/bad/deathsmoke = new
+	deathsmoke.set_up(5,0,src.loc,null)
+	deathsmoke.start()
 	qdel(src)
 
 //Spess Jason Bourne

--- a/code/modules/urist/mob/humanhostiles.dm
+++ b/code/modules/urist/mob/humanhostiles.dm
@@ -168,9 +168,9 @@
 	attack_sound = 'sound/weapons/punch3.ogg' //overridden in AttackTarget!
 	attack_same = 0
 
-/mob/living/simple_animal/hostile/urist/stalker/ntis/AttackingTarget()
+/mob/living/simple_animal/hostile/urist/stalker/ntis/UnarmedAttack(var/atom/A, var/proximity)
 	attack_sound = pick('sound/weapons/bladeslice.ogg','sound/weapons/genhit1.ogg','sound/weapons/genhit2.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/smash.ogg')
-	..()
+	. = ..()
 
 //terran
 

--- a/code/modules/urist/mob/spoopymobs.dm
+++ b/code/modules/urist/mob/spoopymobs.dm
@@ -24,7 +24,7 @@
 	environment_smash = 1
 	var/plague = 0 //whether biting dead people spawns new zombies
 	var/regen = 0 //if true, they won't stay down, but revive after a delay
-	var/regen_delay = 900 //delay for regen revive
+	var/regen_delay = 90 //delay for regen revive
 
 /datum/reagent/xenomicrobes/uristzombie
 	metabolism = REM
@@ -164,13 +164,15 @@
 /mob/living/simple_animal/hostile/urist/zombie/death()
 	. = ..()
 
+	src.transform = null
+	var/matrix/N = matrix()
+	N.Turn(90)
+	src.transform = N
+
 	if(regen)
-		to_chat(src, "You begin to regenerate. This will take about [regen_delay/600] minutes.")
-		spawn(regen_delay)
-			var/matrix/N = matrix()
-			N.Turn(270)
-			src.transform = N
-			rejuvenate()
+		to_chat(src, "You begin to regenerate. This will take about [regen_delay/60] minutes.")
+		to_chat(src, "If you ghost, you can re-enter the mob assuming it still exists.")
+		addtimer(CALLBACK(src, /mob/living/simple_animal/hostile/urist/zombie/proc/deathregen), regen_delay SECONDS, TIMER_STOPPABLE)
 
 	if(src.contents)
 		var/inv_size = contents.len
@@ -182,10 +184,11 @@
 		update_icons()
 
 /mob/living/simple_animal/hostile/urist/zombie/ghostize(var/can_reenter_corpse=1)
-	if(can_reenter_corpse)
-		if(src.client)
-			to_chat(src.client, "You can re-enter the mob as long as it still exists.")
-	. = ..(max(1, can_reenter_corpse)) // always re-enterable
+	return ..(max(1, can_reenter_corpse)) // always re-enterable
+
+/mob/living/simple_animal/hostile/urist/zombie/proc/deathregen()
+	src.transform = null
+	rejuvenate()
 	return
 
 /mob/living/simple_animal/hostile/urist/zombie/Destroy()

--- a/code/modules/urist/mob/spoopymobs.dm
+++ b/code/modules/urist/mob/spoopymobs.dm
@@ -21,13 +21,14 @@
 	move_to_delay = 7
 	stat_attack = 1
 	ranged = 0
+	environment_smash = 1
 	var/plague = 0 //whether biting dead people spawns new zombies
 	var/regen = 0 //if true, they won't stay down, but revive after a delay
 	var/regen_delay = 900 //delay for regen revive
 
-/datum/reagent/toxin/zombie/uristzombie
+/datum/reagent/xenomicrobes/uristzombie
 	metabolism = REM
-	target_organ = BP_BRAIN
+	var/target_organ = BP_BRAIN
 
 	var/symptom_msgs = list(
 		"Your teeth feel loose.",
@@ -56,10 +57,10 @@
 		"Your tongue swells up and turns black."
 	)
 
-/datum/reagent/toxin/zombie/uristzombie/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/xenomicrobes/uristzombie/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	affect_blood(M, alien, removed * 0.5)
 
-/datum/reagent/toxin/zombie/uristzombie/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/xenomicrobes/uristzombie/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/true_dose = H.chem_doses[type] + volume
@@ -112,9 +113,9 @@
 							H.uZombify(1, 1, transformation_msgs)
 		else
 			// almost straight copy of plain reagent/toxin/affect_blood()
-			if(strength && alien != IS_DIONA)
-				M.add_chemical_effect(CE_TOXIN, strength)
-				var/dam = (1 + rand(5))
+			if(alien != IS_DIONA)
+				M.add_chemical_effect(CE_TOXIN, 5)
+				var/dam = 0.05 * rand(1, 20)
 				if(target_organ)
 					var/obj/item/organ/internal/I = H.internal_organs_by_name[target_organ]
 					if(I)
@@ -147,6 +148,10 @@
 		if(prob(Clamp(5+true_dose, 0, 20)))
 			H.make_jittery(5)
 
+/mob/living/simple_animal/hostile/urist/zombie/Aggro()
+	if(prob(35))
+		playsound(src.loc, pick('sound/hallucinations/wail.ogg', 'sound/hallucinations/screech.ogg', 'sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg', 'sound/hallucinations/growl3.ogg'))
+	..()
 
 /mob/living/simple_animal/hostile/urist/zombie/say()
 	var/acount = rand(2,8)
@@ -216,8 +221,8 @@
 
 			if(victim.reagents)
 				var/biosafety = victim.getarmor(null, "bio")
-				if(prob(Clamp(100-biosafety, 0, 100)))
-					victim.reagents.add_reagent(/datum/reagent/toxin/zombie/uristzombie, rand(5, 10))
+				if(!prob(Clamp(biosafety, 0, 100)))
+					victim.reagents.add_reagent(/datum/reagent/xenomicrobes/uristzombie, rand(5, 10))
 
 			uZombieInfect(victim)
 
@@ -332,7 +337,14 @@
 		else
 			drop_from_inventory(W)
 	new_mob.update_icons()
-	playsound(src.loc, 'sound/hallucinations/wail.ogg')
+
+	playsound(src.loc, pick(
+		'sound/hallucinations/wail.ogg',
+		'sound/hallucinations/screech.ogg',
+		'sound/hallucinations/growl1.ogg',
+		'sound/hallucinations/growl2.ogg',
+		'sound/hallucinations/growl3.ogg')
+	)
 
 	spawn()
 		qdel(src)

--- a/code/modules/urist/modules/jungle/jungle_animals.dm
+++ b/code/modules/urist/modules/jungle/jungle_animals.dm
@@ -218,7 +218,7 @@
 	if(.)
 		emote("nashes at [.]")
 
-/mob/living/simple_animal/hostile/huntable/panther/AttackingTarget()
+/mob/living/simple_animal/hostile/huntable/panther/UnarmedAttack(var/atom/A, var/proximity)
 	. =..()
 	var/mob/living/L = .
 	if(istype(L))
@@ -276,10 +276,10 @@
 	if(.)
 		emote("hisses wickedly")
 
-/mob/living/simple_animal/hostile/snake/AttackingTarget()
+/mob/living/simple_animal/hostile/snake/UnarmedAttack(var/atom/A, var/proximity)
 	. =..()
-	if(istype(target, /mob/living/carbon))
-		var/mob/living/carbon/L = target
+	if(istype(A, /mob/living/carbon))
+		var/mob/living/carbon/L = A
 		bite(L)
 
 /mob/living/simple_animal/hostile/snake/proc/bite(var/mob/living/L)

--- a/code/modules/urist/structures/emplacements.dm
+++ b/code/modules/urist/structures/emplacements.dm
@@ -31,7 +31,7 @@
 	density = 1
 	anchored = 0
 	atom_flags = ATOM_FLAG_CHECKS_BORDER
-	var/health = 500
+	health = 500
 
 /obj/structure/emplacement/AT
 	name = "anti-tank gun"

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -84,7 +84,7 @@
 	anchored = 1
 	plane = ABOVE_TURF_PLANE//on the floor
 	layer = CATWALK_LAYER//probably? Should cover cables, pipes and the rest of objects that are secured on the floor
-	var/health = 100
+	health = 100
 
 obj/structure/net/Initialize(var/mapload)
 	. = ..()

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,8 +31,8 @@ exactly 19 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 79 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 54 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 1369 "<< uses" '(?<!<)<<(?!<)' -P
-exactly 324 "incorrect indentations" '^( {4,})' -P
+exactly 1366 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 323 "incorrect indentations" '^( {4,})' -P
 exactly 29 "text2path uses" 'text2path'
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 


### PR DESCRIPTION
Unfortunately the SA fixes and the zombie update got slightly tangled up together.

- Un-awfuls the hostile simplemob click/attack logic. Current implementation put attack effect handling literally _in the AI code_, so player-controlled and NPC mobs used separate logic for the same thing for no reason.
- Also un-awfuls simplemob priorities; they would attempt to perform two actions per tick, and so would magically be able to attack both the environment and the mob in one tick. We do not abide by such haxxorz, and as such they now first try to eat your face, and try to smash their way towards you only if the face proves temporarily unavailable.
- Restores Urist zombification procs; to prevent conflicts with upstream, I used the wonky uCamelCase (u for Urist) naming convention for procs. It's ugly, but Bay would have to actively try to make it conflict that way.
- Reworks plague zombies. Building on the first point, the special transformation verb for PCs is now removed; PC and NPC zombies automagically apply it by simply attacking the target.
- Furthermore, the transformation is now gradual and reagent-based. A bite transforms a fairly small random volume of a very evil reagent, which will try to zombify the victim. Upon a bite, the transformation is preventable, and small quantities may just be metabolized away, but since the reagent has a chance of multiplying, it requires either urgent advanced medical care, or more... drastic measures.