### PR TITLE
Noctis fixes

### DIFF
--- a/maps/away/noctis/noctis-1.dmm
+++ b/maps/away/noctis/noctis-1.dmm
@@ -103,7 +103,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/noctis/apm)
 "au" = (
 /turf/simulated/floor/reinforced,
 /area/noctis/hangar)
@@ -140,7 +140,8 @@
 /area/noctis/hards)
 "aA" = (
 /obj/structure/table/rack/dark,
-/obj/item/clothing/mask/breath,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
 /turf/simulated/floor/tiled/monotile,
 /area/noctis/hards)
 "aB" = (
@@ -544,10 +545,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/noctis/battery)
-"bl" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall,
-/area/noctis/afth)
 "bm" = (
 /obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/plating,
@@ -1039,10 +1036,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/noctis/hangar)
-"cd" = (
-/obj/effect/paint/silver,
-/turf/simulated/wall,
-/area/noctis/hangar)
 "ce" = (
 /obj/effect/shuttle_landmark/nav_noctis/raptor_transit,
 /turf/space,
@@ -1203,10 +1196,10 @@
 /turf/simulated/floor/tiled/monotile,
 /area/noctis/hards)
 "cw" = (
-/obj/structure/table/rack/dark,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
 /obj/machinery/light/small/red,
+/obj/machinery/suit_cycler/engineering{
+	req_access = list(850)
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/noctis/hards)
 "cx" = (
@@ -1403,7 +1396,7 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
-/area/space)
+/area/noctis/exteriorl)
 "cS" = (
 /obj/effect/paint/black,
 /obj/structure/sign/warning/fire,
@@ -1622,9 +1615,9 @@
 	id_tag = "pirate_fp_vent"
 	},
 /obj/machinery/airlock_sensor{
-	id_tag = "pirate_fp_sensor";
+	id_tag = "pirate_con_sensor";
 	pixel_x = 24;
-	pixel_y = 12
+	pixel_y = -6
 	},
 /turf/simulated/floor/plating,
 /area/noctis/fairlock)
@@ -2533,7 +2526,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/space)
+/area/noctis/apm)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/cap/hidden{
@@ -2627,7 +2620,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/space)
+/area/noctis/apm)
 "eV" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/effect/paint/black,
@@ -2635,6 +2628,10 @@
 	dir = 8;
 	icon_state = "pdoor1";
 	id = "p_com_obs"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/noctis/combust)
@@ -2912,7 +2909,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
-/area/space)
+/area/noctis/exteriorl)
 "fx" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2944,7 +2941,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/space)
+/area/noctis/disposal)
 "fA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	icon_state = "intact";
@@ -3683,13 +3680,13 @@
 	icon_state = "term";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	icon_state = "intact";
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/noctis/raptor)
@@ -3834,7 +3831,7 @@
 /obj/machinery/meter,
 /obj/effect/paint/black,
 /turf/simulated/wall/titanium,
-/area/space)
+/area/noctis/exteriorl)
 "gW" = (
 /obj/structure/bed/chair/padded/black{
 	icon_state = "chair_preview";
@@ -4178,6 +4175,7 @@
 /obj/structure/table/standard,
 /obj/item/stack/cable_coil/blue,
 /obj/item/weapon/weldingtool/mini,
+/obj/item/weapon/tape_roll,
 /turf/simulated/floor/tiled/white,
 /area/noctis/medbay)
 "hH" = (
@@ -4430,6 +4428,9 @@
 	icon_state = "body_scanner_0";
 	dir = 2
 	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/noctis/cryo)
 "ie" = (
@@ -4569,6 +4570,8 @@
 /obj/item/weapon/reagent_containers/pill/hyronalin,
 /obj/item/weapon/reagent_containers/pill/hyronalin,
 /obj/item/weapon/reagent_containers/pill/hyronalin,
+/obj/item/weapon/reagent_containers/pill/hyronalin,
+/obj/item/weapon/storage/pill_bottle/antitox,
 /turf/simulated/wall/titanium,
 /area/noctis/medbay)
 "im" = (
@@ -5186,6 +5189,7 @@
 	icon_state = "intake";
 	name = "disposal chute"
 	},
+/obj/machinery/door/window/northleft,
 /turf/simulated/floor/plating,
 /area/noctis/disposal)
 "jv" = (
@@ -5193,6 +5197,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/random/closet,
+/obj/structure/window/reinforced{
+	icon_state = "rwindow";
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/noctis/disposal)
 "jw" = (
@@ -5269,6 +5277,7 @@
 	icon_state = "tube_map";
 	dir = 4
 	},
+/obj/item/organ/internal/liver,
 /turf/simulated/floor/tiled/white,
 /area/noctis/medbay)
 "jD" = (
@@ -5369,8 +5378,9 @@
 /area/noctis/exteriorl)
 "jO" = (
 /obj/machinery/atmospherics/tvalve/mirrored{
+	dir = 1;
 	icon_state = "map_tvalvem0";
-	dir = 1
+	initialize_directions = 11
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
@@ -5523,6 +5533,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/noctis/hangar)
+"mN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/noctis/disposal)
 "yX" = (
 /obj/effect/shuttle_landmark/automatic,
 /turf/space,
@@ -5567,6 +5585,21 @@
 /obj/effect/paint/black,
 /turf/simulated/wall/titanium,
 /area/space)
+"JD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/noctis/disposal)
+"PN" = (
+/obj/machinery/atmospherics/unary/engine{
+	icon_state = "nozzle";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/noctis/disposal)
 "Wj" = (
 /turf/space/transit/north,
 /area/space)
@@ -7994,11 +8027,11 @@ ej
 gp
 cs
 gV
-at
-at
-at
-at
-at
+PN
+PN
+PN
+PN
+PN
 hC
 gb
 aa
@@ -8095,11 +8128,11 @@ eh
 dv
 ho
 cs
-eM
-eU
-eU
-eU
-eU
+JD
+mN
+mN
+mN
+mN
 fz
 hC
 gc
@@ -9825,7 +9858,7 @@ ae
 ae
 ae
 dF
-bl
+ar
 ff
 ae
 hj
@@ -10335,7 +10368,7 @@ aa
 af
 af
 dK
-cd
+fo
 fl
 af
 af

--- a/maps/away/noctis/noctis-2.dmm
+++ b/maps/away/noctis/noctis-2.dmm
@@ -151,7 +151,6 @@
 /area/noctis/atmos)
 "ax" = (
 /obj/structure/catwalk,
-/obj/structure/lattice,
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 4;
@@ -162,7 +161,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/space)
 "ay" = (
 /obj/machinery/door/airlock/hatch,
@@ -184,15 +183,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/noctis/atmos)
-"aA" = (
-/obj/structure/lattice,
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/open,
-/area/space)
 "aB" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
@@ -246,26 +236,15 @@
 /obj/effect/floor_decal/industrial/warning/dust/corner,
 /turf/simulated/floor/reinforced,
 /area/space)
-"aG" = (
-/obj/structure/lattice,
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/open,
-/area/space)
 "aH" = (
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/blue,
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/space)
@@ -393,18 +372,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
-"aW" = (
-/obj/machinery/power/solar,
-/obj/structure/cable/blue{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/blue{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "aX" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/blue{
@@ -443,26 +410,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/noctis/gasestore)
-"bb" = (
-/obj/structure/lattice,
-/obj/structure/railing/mapped{
-	color = "#b95a00";
-	dir = 8;
-	icon_state = "railing0";
-	mapped_color = "#b95a00"
-	},
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/open,
-/area/space)
 "bc" = (
-/obj/structure/cable/blue{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/space)
@@ -480,7 +437,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	icon_state = "intact";
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/noctis/gasestore)
@@ -498,7 +455,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	icon_state = "intact";
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/noctis/gasestore)
@@ -1470,6 +1427,7 @@
 	icon_state = "intact";
 	dir = 6
 	},
+/obj/machinery/meter,
 /turf/simulated/wall/titanium,
 /area/noctis/combint)
 "dt" = (
@@ -1506,8 +1464,9 @@
 /area/space)
 "dx" = (
 /obj/machinery/atmospherics/tvalve/mirrored/bypass{
+	dir = 8;
 	icon_state = "map_tvalvem1";
-	dir = 8
+	initialize_directions = 14
 	},
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/blue{
@@ -1779,7 +1738,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/noctis/gasestore)
 "ec" = (
 /obj/structure/catwalk,
 /obj/machinery/light/colored/blue{
@@ -1973,8 +1932,9 @@
 /area/noctis/combint)
 "eB" = (
 /obj/machinery/atmospherics/tvalve{
+	dir = 4;
 	icon_state = "map_tvalve0";
-	dir = 4
+	initialize_directions = 14
 	},
 /turf/simulated/floor/plating,
 /area/noctis/combint)
@@ -2065,6 +2025,11 @@
 	tag_chamber_sensor = "pirate_con_sensor";
 	tag_exterior_door = "pirate_con_ext";
 	tag_interior_door = "pirate_con_int"
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "pirate_con_sensor";
+	pixel_x = 24;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plating,
 /area/noctis/extconn)
@@ -2195,22 +2160,22 @@
 	icon_state = "intact";
 	dir = 5
 	},
-/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/noctis/combint)
 "eZ" = (
 /obj/machinery/atmospherics/tvalve{
+	dir = 8;
 	icon_state = "map_tvalve0";
-	dir = 8
+	initialize_directions = 13
 	},
 /turf/simulated/floor/plating,
 /area/noctis/combint)
 "fa" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/cap/hidden/fuel{
 	icon_state = "cap";
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/noctis/combint)
 "fb" = (
@@ -2229,6 +2194,7 @@
 	d2 = 9;
 	icon_state = "2-9"
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/noctis/combint)
 "fc" = (
@@ -2818,6 +2784,7 @@
 /obj/structure/table/steel,
 /obj/prefab/bluespace_radio,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/noctis/bridge)
 "fX" = (
@@ -3709,6 +3676,9 @@
 	icon_state = "intact-supply";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/noctis/prismngt)
 "hH" = (
@@ -4078,8 +4048,9 @@
 /area/noctis/prismngt)
 "is" = (
 /obj/item/modular_computer/console/preset/merchant{
-	icon_state = "console";
-	dir = 1
+	computer_emagged = 1;
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/noctis/prismngt)
@@ -4404,6 +4375,15 @@
 	},
 /turf/simulated/open,
 /area/noctis/exteriorl)
+"uu" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/blue,
+/turf/simulated/floor/plating,
+/area/space)
 "wc" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/silver,
@@ -4431,6 +4411,14 @@
 /obj/effect/shuttle_landmark/automatic,
 /turf/space,
 /area/space)
+"BL" = (
+/obj/structure/cable/green,
+/obj/structure/cable/blue{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "Ci" = (
 /obj/machinery/light/small/red{
 	icon_state = "firelight1";
@@ -4447,6 +4435,13 @@
 	},
 /turf/space,
 /area/space)
+"Gm" = (
+/obj/machinery/atmospherics/unary/engine{
+	icon_state = "nozzle";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/noctis/asm)
 "Gv" = (
 /obj/structure/railing/mapped{
 	color = "#b95a00";
@@ -4515,8 +4510,31 @@
 	icon_state = "bulb_map";
 	dir = 4
 	},
-/turf/simulated/open,
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/noctis/exteriorl)
+"Ue" = (
+/obj/structure/catwalk,
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/space)
+"VY" = (
+/obj/structure/catwalk,
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "WR" = (
 /obj/machinery/light/small/d_green{
 	icon_state = "bulb_map";
@@ -6846,10 +6864,10 @@ eU
 eU
 eU
 dl
-eb
-eb
-eb
-eb
+Gm
+Gm
+Gm
+Gm
 ib
 aa
 aa
@@ -8973,10 +8991,10 @@ aa
 aa
 au
 aa
-aW
-ag
-ag
-aA
+aV
+dw
+dw
+dw
 eq
 br
 br
@@ -9072,19 +9090,19 @@ aa
 aa
 aa
 ad
-ag
+bO
 ax
 cU
-cU
-cU
+Ue
+VY
 TD
-aB
-cU
-cU
-cU
-cU
+VY
+VY
+VY
+VY
+uu
 bc
-bO
+BL
 bP
 fj
 cn
@@ -9180,11 +9198,11 @@ ag
 aX
 dw
 KY
-aG
-bb
-bb
-bb
-bb
+dw
+iM
+iM
+iM
+iM
 aH
 ep
 bW

--- a/maps/away/noctis/noctis.dm
+++ b/maps/away/noctis/noctis.dm
@@ -69,6 +69,17 @@
 	name = "bluespace radio"
 	prefab_type = /decl/prefab/ic_assembly/bluespace_radio
 
+/obj/prefab/bluespace_radio/Initialize() //The circuit verify absolutely hates this prefab
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/prefab/bluespace_radio/LateInitialize()
+	var/decl/prefab/prefab = decls_repository.get_decl(prefab_type)
+	prefab.create(loc)
+	qdel(src)
+
+/obj/structure/closet/secure_closet/engineering_electrical/noctis
+	req_access = access_noctis
+
 /obj/structure/closet/secure_closet/engineering_electrical/noctis/WillContain()
 	return list(
 		/obj/item/clothing/gloves/insulated = 1,
@@ -78,6 +89,9 @@
 		/obj/item/weapon/module/power_control = 2,
 		/obj/item/device/multitool = 2
 	)
+
+/obj/structure/closet/secure_closet/engineering_welding/noctis
+	req_access = access_noctis
 
 /obj/structure/closet/secure_closet/engineering_welding/noctis/WillContain()
 	return list(

--- a/maps/away/noctis/noctis_shuttle.dm
+++ b/maps/away/noctis/noctis_shuttle.dm
@@ -1,7 +1,7 @@
 /datum/shuttle/autodock/overmap/raptor
 	name = "Raptor"
-	warmup_time = 20
-	move_time = 45
+	warmup_time = 15
+	move_time = 50
 	shuttle_area = /area/noctis/raptor
 	current_location = "nav_noctis_raptor"
 	landmark_transition = "nav_noctis_transit"

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
@@ -52,7 +52,7 @@
 	..()
 	var/turf/simulated/T = get_turf(src)
 	if(istype(T))
-		T.fire_act(exposed_temperature = T0C + 3000)
+		T.fire_act(null, T0C + 3000)
 	return INITIALIZE_HINT_QDEL
 
 /obj/item/weapon/paper/marooned/


### PR DESCRIPTION
The place is still a death trap, just a slightly less buggy one.
- All of the engines have their areas properly set and will now stay online, hurrah.
- Tvalves and scrubber pipes have their vars set correctly. Expect 100% less swimming pools.
- The connector airlock is now functional.
- Electrical/welding supplies have Noctis access requirements set.
- Duct tape and dylovene pills are added to medical.
- The bluespace radio has phased back into reality and will now be available.
- The merchant computer has had its people selling setting enabled.
- Disposals got a small windoor to stop the crew from falling into it.
- Cryogenics has a management console now.
- Fixed the runtime introduced with the original PR.