### PR TITLE
Fixes issue with MMI holder objects

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -885,11 +885,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 			new /obj/effect/decal/cleanable/ash(get_turf(victim))
 
 			// URIST EDIT BY IRRA, 2019-05-25
+			// EDITED AGAIN BY IRRA, 2019-06-13
 			for(var/obj/item/organ/O in internal_organs)
 				if(!O.can_disintegrate())
-					O.owner = victim
-					O.removed()
-					internal_organs -= O
+					O.drop_organ(victim, src)
 			// END URIST EDIT
 
 			for(var/obj/item/I in src)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -914,8 +914,14 @@ Note that amputating the affected organ does in fact remove the infection from t
 			gore.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 
 			for(var/obj/item/organ/I in internal_organs)
-				I.owner = victim
-				I.removed()
+				// URIST EDIT BY IRRA 2019-07-06
+				// - Old code -
+				//I.owner = victim
+				//I.removed()
+				//
+				// - New code -
+				I.drop_organ(victim, src)
+				// END URIST EDIT
 				if(istype(loc,/turf))
 					I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),30)
 			internal_organs = null //Let's just not take chances

--- a/code/modules/urist/modules/organs/disintegratable.dm
+++ b/code/modules/urist/modules/organs/disintegratable.dm
@@ -1,7 +1,8 @@
 /*
  *	disintegratable.dm - modules/urist/modules/organs
  *
- * 	can_disintegrate is used in _external.dm in modules/organs/external
+ * 	can_disintegrate and drop_organ are used in _external.dm in modules/organs/external
+ *
  *
  * 	can_disintegrate is defined in this file returns 1 by default
  *
@@ -10,8 +11,37 @@
  *		* MMI holders for FBPs			(modules/organs/internal/species/fbp.dm)
  *		* Synthetic brains for IPCs		(modules/organs/internal/species/ipc.dm)
  *
+ *
+ *  drop_organ is defined in this and by default removes the organ from owner and onto location of owner
+ *
+ *	Currently used mainly to fix a mind-transfer issue related to mmi_holders
+ *
  * 	Created in 2019-05-25 by Irra
+ *	Edited	in 2019-06-13 by Irra 	- Added 'drop_organ'
  */
+
+/obj/item/organ/proc/drop_organ(var/mob/living/carbon/human/past_owner = null, var/obj/item/organ/external/parent = null)
+	if (past_owner)
+		owner = past_owner
+
+	// Null safe-check
+	if (!owner)
+		return
+
+	// If parent hadn't been provided, try to find the one anyways
+	if (!parent)
+		parent = owner.get_organ(parent_organ)
+	if(istype(parent))
+		parent.internal_organs -= src
+
+	removed()
+
+// Special override for MMI holder organ objects
+/obj/item/organ/internal/mmi_holder/drop_organ()
+	..()
+	var/obj/item/device/mmi/M = transfer_and_delete()
+	M.loc = src.loc
+
 
 /obj/item/organ/proc/can_disintegrate()
 	return 1

--- a/code/modules/urist/modules/organs/disintegratable.dm
+++ b/code/modules/urist/modules/organs/disintegratable.dm
@@ -39,9 +39,10 @@
 // Special override for MMI holder organ objects
 /obj/item/organ/internal/mmi_holder/drop_organ()
 	..()
+	// This line has to be always be run before the function below. Otherwise, you risk working with null references.
+	var/turf/T = get_turf(src)
 	var/obj/item/device/mmi/M = transfer_and_delete()
-	M.loc = src.loc
-
+	M.forceMove(T)
 
 /obj/item/organ/proc/can_disintegrate()
 	return 1


### PR DESCRIPTION
Title. Beware, this is a fix I've made after a long sleep-deprived night. While it is my responsibility to test the code and that it does indeed compile, I need help to test for validation of its intended function.

* Have a FBP player, and a non-synthetic player in the same session. The goal is to ash the FBP's head and transfer their mind into the MMI that eventually lands on the ground.
* A conscious and alive MMI should be able to talk. Or if the FBP becomes a ghost, they should be able to transfer back into the MMI by double-clicking on it.
* The best way to achieve this is using an ion rifle directly on FBP
* Additionally, check if ashing a laced player's head will still drop the lace.

I'll conduct my own testing when I have the time.