### PR TITLE
Minor changes, the PR: Version 3

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -81,6 +81,10 @@
 		to_chat(user, "<span class='warning'>There is nobody on \the [src]. It would be pointless to turn the suppressor on.</span>")
 		return
 
+	if(stat & (NOPOWER|BROKEN))
+		to_chat(user, "<span class='warning'>You try to switch on the suppressor, yet nothing happens.</span>")
+		return
+
 	if(user != victim && !suppressing) // Skip checks if you're doing it to yourself or turning it off, this is an anti-griefing mechanic more than anything.
 		user.visible_message("<span class='warning'>\The [user] begins switching on \the [src]'s neural suppressor.</span>")
 		if(!do_after(user, 30, src) || !user || !src || user.incapacitated() || !user.Adjacent(src))
@@ -171,3 +175,8 @@
 		to_chat(usr, "<span class='notice'>Unbuckle \the [patient] first!</span>")
 		return 0
 	return 1
+
+/obj/machinery/optable/power_change()
+	. = ..()
+	if(stat & (NOPOWER|BROKEN))
+		suppressing = FALSE

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -265,6 +265,7 @@
 					return
 				else if(fast_clone)
 					if(debug || metal >= program["metal_cost"])
+						metal -= program["metal_cost"]
 						cloning = TRUE
 						print_program(usr)
 					else
@@ -273,6 +274,7 @@
 					if(metal < program["metal_cost"])
 						to_chat(usr, "<span class='warning'>You need [program["metal_cost"]] metal to build that!</span>")
 						return
+					metal -= program["metal_cost"]
 					var/cloning_time = round(program["metal_cost"] / 15)
 					cloning_time = min(cloning_time, MAX_CIRCUIT_CLONE_TIME)
 					cloning = TRUE

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -101,6 +101,7 @@
 				playsound(src, 'sound/items/crowbar.ogg', 50, TRUE)
 				if(EA.try_remove_component(IC, user, TRUE))
 					metal += IC.matter[DEFAULT_WALL_MATERIAL]
+					qdel(IC)
 			to_chat(user, "<span class='notice'>You recycle all the components[EA.assembly_components.len ? " you could " : " "]from [EA]!</span>")
 			playsound(src, 'sound/items/electronic_assembly_empty.ogg', 50, TRUE)
 			recycling = FALSE

--- a/code/modules/item_worth/reagents.dm
+++ b/code/modules/item_worth/reagents.dm
@@ -52,7 +52,7 @@
 	value = 1
 
 /datum/reagent/radium
-	value = 50 //Radium is crazy expensive, like 100k+ per gram. So probably a bit less expensive in the future.
+	value = 0.5 //Unfortunately, radium has become nearly worthless due to the flooding of the market from xenobotany departments everywhere.
 
 /datum/reagent/acid
 	value = 0.2

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -308,7 +308,7 @@
 */
 /mob/living/carbon/human/proc/apply_pressure(mob/living/user, var/target_zone)
 	var/obj/item/organ/external/organ = get_organ(target_zone)
-	if(!organ || !(organ.status & ORGAN_BLEEDING) || BP_IS_ROBOTIC(organ))
+	if(!organ || !(organ.status & ORGAN_BLEEDING || organ.status & ORGAN_ARTERY_CUT) || BP_IS_ROBOTIC(organ))
 		return 0
 
 	if(organ.applied_pressure)
@@ -337,26 +337,28 @@
 	if(!O || !user || !O.owner)
 		qdel(src)
 	O.applied_pressure = user
-	O.arterial_bleed_severity -= 0.5
 	applied = O
 	H = O.owner
 	name = "\proper[H == loc ? "[H.gender == "male" ? "his" : "her"]" : "[O.owner.name]'s"] [O.name]" //this will end as expected
 	START_PROCESSING(SSobj, src)
 
 /obj/item/pressure/Process()
-	if(!Adjacent(H))
+	if(loc != H)
 		if(!QDELETED(src))
 			qdel(src)
 
 /obj/item/pressure/Destroy()
 	STOP_PROCESSING(SSobj, src)
-	H.visible_message("<span class = 'notice'>\The [H] stops applying pressure to \his [applied.name]!", "You stop applying pressure to your [applied.name]!</span>")
+	H.visible_message("<span class = 'notice'>\The [H] stops applying pressure to \his [applied.name]!</span>", "<span class = 'notice'>You stop applying pressure to your [applied.name]!</span>")
 	applied.applied_pressure = null
+	applied = null
+	H = null
 	. = ..()
 
 /obj/item/pressure/dropped()
-	spawn(1)
-		H.drop_item(get_turf(loc))
-	applied.applied_pressure = null //just in case
-	applied.arterial_bleed_severity = initial(applied.arterial_bleed_severity)
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
+	. = ..()
+
+/obj/item/pressure/add_blood()
+	return

--- a/code/modules/mob/living/carbon/human/spawners.dm
+++ b/code/modules/mob/living/carbon/human/spawners.dm
@@ -90,13 +90,15 @@
 
 		if(damage["impale"])
 			var/turf/T = H.near_wall(dir,2)
-
-			if(T)
+			var/obj/item/organ/external/E = H.organs_by_name[damage["impale"]]
+			if(T && E && E.wounds.len)
 				var/obj/item/weapon/arrow/rod/R = new(H)
 				H.set_dir(GLOB.reverse_dir[dir])
 				H.loc = T
 				H.anchored = 1
 				H.pinned += R
+				var/datum/wound/W = E.wounds[1]
+				W.embedded_objects += R
 
 	var/turf/T = get_turf(src)
 	var/obj/structure/bed/B = locate() in T.contents

--- a/code/modules/organs/external/wounds/wound_types.dm
+++ b/code/modules/organs/external/wounds/wound_types.dm
@@ -78,6 +78,7 @@
 	desc = desc_list[current_stage]
 	min_damage = damage_list[current_stage]
 	damage = min(min_damage, damage)
+	autoheal_cutoff = initial(autoheal_cutoff)
 
 /datum/wound/cut/small
 	// link wound descriptions to amounts of damage

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -293,7 +293,7 @@ var/list/organ_cache = list()
 	if(alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")
 		to_chat(user, "<span class='notice'>You successfully repress your cannibalistic tendencies.</span>")
 		return
-	if(!user.unEquip(src))
+	if(QDELETED(src) || loc != user || !user.unEquip(src))
 		return
 	var/obj/item/weapon/reagent_containers/food/snacks/organ/O = new(get_turf(src))
 	O.SetName(name)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -247,6 +247,7 @@ other types of metals and chemistry for reagents).
 /datum/design/item/powercell/Fabricate()
 	var/obj/item/weapon/cell/C = ..()
 	C.charge = 0 //shouldn't produce power out of thin air.
+	C.update_icon()
 	return C
 
 /datum/design/item/powercell/basic
@@ -1041,6 +1042,11 @@ other types of metals and chemistry for reagents).
 	req_tech = list(TECH_POWER = 6, TECH_ENGINEERING = 4)
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 100)
 	build_path = /obj/item/inducer
+
+/datum/design/item/tool/inducer/Fabricate()
+	var/obj/item/inducer/I = ..()
+	QDEL_NULL(I.cell)
+	return I
 
 /datum/design/item/tool/price_scanner
 	name = "price scanner"

--- a/maps/away/noctis/noctis_jobs.dm
+++ b/maps/away/noctis/noctis_jobs.dm
@@ -53,7 +53,7 @@
 	hair_style = "Buzzcut 2"
 	facial_hair = "5 O'clock Shadow"
 	clothing = /decl/hierarchy/outfit/freightercap
-	damage = list(BP_HEAD = 27, BP_CHEST = 53, "impale" = TRUE)
+	damage = list(BP_HEAD = 27, BP_CHEST = 53, "impale" = BP_CHEST)
 	killed = TRUE
 
 /decl/hierarchy/outfit/freightercap

--- a/maps/away/noctis/noctis_jobs.dm
+++ b/maps/away/noctis/noctis_jobs.dm
@@ -35,7 +35,7 @@
 	uniform = /obj/item/clothing/under/frontier
 	shoes = /obj/item/clothing/shoes/workboots
 	belt = /obj/item/weapon/storage/belt/utility/full
-	id = /obj/item/weapon/card/id/noctis
+	id_type = /obj/item/weapon/card/id/noctis
 
 /obj/item/clothing/suit/armor/pcarrier/light/hijacker
 	color = "#ff0000"


### PR DESCRIPTION
It's that time again where I make all of the changes in a single PR.

- Radium's value on the market has crashed after xenobotany companies everywhere realized what they were missing out on.
- Cauterizing a wound ensures it's no longer surgical.
- Duplication of organs through snacking is fixed.
- Applying pressure to wounds is less buggy, and can now be done on limbs that don't have wounds, but are still bleeding arterially.
- Operating tables no longer function off pure medical anger, and require power to suppress their unworthy patients.
- Integrated circuit printers have lost their bluespace material printers and now function within reality.
- Circuit printers also figured out that to recycle something it needs to be destroyed.
- Making cells in R&D will now clearly show that they're empty, and the inducer will now obey this as well.
- Spawners that automatically impale people will now visually show that they're very impaled.
- Noctis crew no longer use two factor identification.