### PR TITLE
Nerfs all alcohol strengths by a factor of 5, so your booze doesn't just kill your dudes.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -120,7 +120,7 @@
 
 /datum/reagent/ethanol/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	M.nutrition += nutriment_factor * removed
-	var/strength_mod = 1
+	var/strength_mod = 0.2 //Urist edit: Nerfs alcohol strength by a factor of 5. Original was 1.
 	if(alien == IS_SKRELL)
 		strength_mod *= 5
 	if(alien == IS_DIONA)


### PR DESCRIPTION
🆑 
Bar dwellers and drunkards rejoice, alcohol takes WAY more to just kill you outright. Exactly 5 times as much.
/ 🆑 

Holy fuck booze code is weird.

Edit: I'd like to change the ordering of those strength values, but whatever.