### PR TITLE
Double doors to engineering.

### DIFF
--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -1630,11 +1630,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Access";
-	req_access = newlist();
-	req_one_access = list(11,24)
-	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "dc" = (
@@ -2162,9 +2157,9 @@
 /area/engineering/bdportengine)
 "dV" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/multi_tile/engineering{
+	dir = 8;
 	name = "Engine Access";
-	req_access = newlist();
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/reinforced,
@@ -13059,11 +13054,6 @@
 /area/engineering/bdstarengine)
 "wj" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Access";
-	req_access = newlist();
-	req_one_access = list(11,24)
-	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "wk" = (
@@ -13563,9 +13553,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/multi_tile/engineering{
+	dir = 8;
 	name = "Engine Access";
-	req_access = newlist();
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/reinforced,

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -1630,6 +1630,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Access";
+	req_one_access = list(11,24)
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "dc" = (
@@ -2152,15 +2156,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/engineering/bdportengine)
-"dV" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/engineering{
-	dir = 8;
-	name = "Engine Access";
-	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -13052,10 +13047,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
-"wj" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced,
-/area/engineering/bdstarengine)
 "wk" = (
 /obj/machinery/telecomms/relay/preset/fourthdeck,
 /turf/simulated/floor/plating,
@@ -13553,8 +13544,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/multi_tile/engineering{
-	dir = 8;
+/obj/machinery/door/airlock/engineering{
 	name = "Engine Access";
 	req_one_access = list(11,24)
 	},
@@ -21149,6 +21139,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
+"OF" = (
+/obj/machinery/atmospherics/valve/digital{
+	frequency = 1447;
+	id = "fuelmode"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	tag = "icon-warning (EAST)";
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/bdstarengine)
 "OI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21236,6 +21238,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
+"Pu" = (
+/obj/machinery/atmospherics/valve/digital{
+	frequency = 1447;
+	id = "fuelmode"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	tag = "icon-warning (EAST)";
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/bdportengine)
 "Pw" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -36067,7 +36081,7 @@ aa
 bw
 bw
 da
-dS
+Pu
 eF
 bw
 bw
@@ -36091,7 +36105,7 @@ nR
 nR
 nR
 vi
-wg
+OF
 wW
 nR
 nR
@@ -36269,7 +36283,7 @@ aa
 bw
 bw
 db
-dV
+bw
 bw
 bw
 bw
@@ -36293,7 +36307,7 @@ nR
 nR
 nR
 nR
-wj
+nR
 wX
 nR
 nR

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -7148,11 +7148,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
 "amw" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Secure Storage";
-	req_access = list(11);
-	secured_wires = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7168,14 +7163,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/multi_tile/engineering{
+	req_access = list(11)
+	},
 /turf/simulated/floor/plating,
 /area/engineering/securestorage)
 "amx" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Secure Storage";
-	req_access = list(11);
-	secured_wires = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -9750,23 +9743,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
 "aqK" = (
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Storage";
-	req_access = list(32)
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/multi_tile/glass/engineering{
+	req_access = list(10)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
 "aqL" = (
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Storage";
-	req_access = list(32)
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -10374,10 +10362,6 @@
 /area/engineering/tool)
 "arG" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Workshop";
-	req_access = list(10)
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -10540,10 +10524,6 @@
 	opacity = 0;
 	density = 0;
 	id = "Engineering Lockdown"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access = list(10)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -11861,14 +11841,15 @@
 /area/engineering/tool)
 "atb" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Workshop";
-	req_access = list(10)
-	},
 /obj/effect/floor_decal/corner/yellow{
 	tag = "icon-corner_white (SOUTHWEST)";
 	icon_state = "corner_white";
 	dir = 10
+	},
+/obj/machinery/door/airlock/multi_tile/glass/engineering{
+	dir = 8;
+	name = "Workshop";
+	req_access = list(10)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -11954,7 +11935,8 @@
 	density = 0;
 	id = "Engineering Lockdown"
 	},
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/multi_tile/glass/engineering{
+	dir = 8;
 	name = "Engineering Access";
 	req_access = list(10)
 	},
@@ -12691,10 +12673,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/lobby)
 "aut" = (
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Workshop";
-	req_access = list(10)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -12718,14 +12696,14 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
+/obj/machinery/door/airlock/multi_tile/glass/engineering{
+	name = "Workshop";
+	req_access = list(10)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/lobby)
 "auu" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Workshop";
-	req_access = list(10)
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -17656,10 +17634,6 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/genstorage)
 "aCY" = (
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Storage";
-	req_access = list(32)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
@@ -17674,13 +17648,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 2
 	},
+/obj/machinery/door/airlock/multi_tile/glass/engineering{
+	name = "Engineering Storage";
+	req_access = list(10)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
 "aCZ" = (
-/obj/machinery/door/airlock/glass/engineering{
-	name = "Engineering Storage";
-	req_access = list(32)
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
@@ -18036,10 +18010,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
 "aDB" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access = list(10)
-	},
 /obj/effect/floor_decal/corner/yellow{
 	tag = "icon-corner_white (NORTHEAST)";
 	icon_state = "corner_white";
@@ -18810,10 +18780,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
 "aEQ" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access = list(10)
-	},
 /obj/effect/floor_decal/corner/yellow{
 	tag = "icon-corner_white (SOUTHWEST)";
 	icon_state = "corner_white";
@@ -18830,6 +18796,11 @@
 	opacity = 0;
 	density = 0;
 	id = "Engineering Lockdown"
+	},
+/obj/machinery/door/airlock/multi_tile/glass/engineering{
+	dir = 8;
+	name = "Engineering Storage";
+	req_access = list(10)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -386,6 +386,33 @@
 /obj/item/weapon/paper,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
+"bd" = (
+/turf/simulated/open,
+/obj/machinery/atmospherics/pipe/zpipe/down/fuel{
+	tag = "icon-down (WEST)";
+	icon_state = "down";
+	dir = 8
+	},
+/obj/structure/lattice,
+/obj/structure/disposalpipe/down{
+	tag = "icon-pipe-d (WEST)";
+	icon_state = "pipe-d";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	tag = "icon-down-supply (WEST)";
+	icon_state = "down-supply";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	tag = "icon-down-scrubbers (WEST)";
+	icon_state = "down-scrubbers";
+	dir = 8
+	},
+/turf/simulated/open{
+	initial_gas = null
+	},
+/area/maintenance/second_deck/afp)
 "be" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/fuelbay)
@@ -518,33 +545,6 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/second_deck/afp)
-"bu" = (
-/turf/simulated/open,
-/obj/machinery/atmospherics/pipe/zpipe/down/fuel{
-	tag = "icon-down (WEST)";
-	icon_state = "down";
-	dir = 8
-	},
-/obj/structure/lattice,
-/obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
-	icon_state = "pipe-d";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (WEST)";
-	icon_state = "down-supply";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (WEST)";
-	icon_state = "down-scrubbers";
-	dir = 8
-	},
-/turf/simulated/open{
-	initial_gas = null
-	},
 /area/maintenance/second_deck/afp)
 "bv" = (
 /obj/item/weapon/circuitboard/aiupload,
@@ -7756,6 +7756,9 @@
 	dir = 8;
 	name = "Engineering Access";
 	req_access = list(10)
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -32547,7 +32550,7 @@ as
 aw
 aO
 bi
-bu
+bd
 bI
 bX
 cv

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -5181,9 +5181,6 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "kK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 5
-	},
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
 	dir = 8
@@ -5193,24 +5190,20 @@
 	icon_state = "warning";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/meter,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "kL" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "kM" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
-	},
 /obj/machinery/button/remote/blast_door{
 	id = "d1centrenacelle";
 	name = "combustion chamber blast door controll";
@@ -5218,9 +5211,8 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
 	icon_state = "warning";
-	dir = 5
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5847,8 +5839,16 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "lM" = (
+/obj/machinery/atmospherics/valve/digital{
+	frequency = 1447;
+	id = "fuelmode"
+	},
 /obj/effect/floor_decal/industrial/warning{
-	dir = 10
+	icon_state = "warning";
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5862,6 +5862,13 @@
 	name = "Engine Access";
 	req_access = newlist();
 	req_one_access = list(11,24)
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -6278,37 +6285,20 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
-"mE" = (
-/obj/machinery/meter,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/button/ignition{
-	id = "engines";
-	pixel_y = -26
-	},
-/turf/simulated/floor/reinforced,
-/area/engineering/fdengine)
 "mF" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/obj/machinery/meter,
+/obj/effect/floor_decal/industrial/warning{
+	tag = "icon-warning (EAST)";
+	icon_state = "warning";
 	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -6328,38 +6318,16 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
-"mH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/door/airlock/multi_tile/engineering{
-	dir = 8;
-	name = "Engine Access";
-	req_access = list(11,24)
-	},
-/turf/simulated/floor/reinforced,
-/area/engineering/fdengine)
 "mI" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "mJ" = (
@@ -6812,7 +6780,6 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "nA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -6822,6 +6789,12 @@
 	locked = 0;
 	name = "Engine Access";
 	req_one_access = list(11,24)
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/engineering/break_room)
@@ -7326,6 +7299,15 @@
 	icon_state = "intact-supply";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
 "oA" = (
@@ -7341,6 +7323,15 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
 "oB" = (
@@ -7358,13 +7349,31 @@
 /obj/machinery/camera/network/engineering{
 	c_tag = "Atmospherics Hallway"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/break_room)
 "oC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/engineering/break_room)
 "oD" = (
@@ -14393,10 +14402,6 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"OO" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced,
-/area/engineering/fdengine)
 "Pg" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14424,6 +14429,13 @@
 "Ph" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/substation/atmos)
+"PE" = (
+/obj/machinery/button/ignition{
+	id = "engines";
+	pixel_y = -26
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/fdengine)
 "PM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -14774,6 +14786,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/counselor)
+"Vw" = (
+/turf/simulated/floor/reinforced,
+/area/engineering/fdengine)
 "VN" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/reinforced,
@@ -30124,7 +30139,7 @@ jc
 jO
 kK
 lM
-mE
+mG
 ej
 oy
 pj
@@ -30527,8 +30542,8 @@ ej
 ej
 ej
 kM
-lL
-mG
+Vw
+PE
 ej
 oA
 pl
@@ -30729,8 +30744,8 @@ ib
 ej
 ej
 ej
-OO
-mH
+ej
+ej
 eZ
 oB
 pm

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -760,11 +760,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "bX" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_access = list(23);
-	secured_wires = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
@@ -1033,10 +1028,10 @@
 /area/maintenance/second_deck/afp)
 "cv" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_access = list(23);
-	secured_wires = 1
+/obj/machinery/door/airlock/multi_tile/engineering{
+	dir = 8;
+	name = "Engineering Access";
+	req_access = list(23)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/techstorage)
@@ -2453,10 +2448,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "fC" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access = list(10)
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
 	tag = "icon-corner_white (NORTHEAST)";
@@ -3379,10 +3370,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "gF" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access = list(10)
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
 	tag = "icon-corner_white (SOUTHWEST)";
@@ -3397,6 +3384,11 @@
 	opacity = 0;
 	density = 0;
 	id = "Engineering Lockdown"
+	},
+/obj/machinery/door/airlock/multi_tile/engineering{
+	dir = 8;
+	name = "Engineering Access";
+	req_access = list(10)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -6341,17 +6333,17 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Access";
-	req_access = newlist();
-	req_one_access = list(11,24)
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0;
 	tag = ""
+	},
+/obj/machinery/door/airlock/multi_tile/engineering{
+	dir = 8;
+	name = "Engine Access";
+	req_access = list(11,24)
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -7348,10 +7340,6 @@
 	icon_state = "intact-supply";
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access = list(10)
-	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
@@ -7390,10 +7378,6 @@
 	tag = "icon-intact-supply (EAST)";
 	icon_state = "intact-supply";
 	dir = 4
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access = list(10)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7737,7 +7721,8 @@
 /area/engineering/atmospherics)
 "pl" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/multi_tile/engineering{
+	dir = 8;
 	name = "Engineering Access";
 	req_access = list(10)
 	},
@@ -7758,13 +7743,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/break_room)
 "po" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/multi_tile/engineering{
+	dir = 8;
 	name = "Engineering Access";
 	req_access = list(10)
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7800,10 +7782,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "pt" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering Access";
-	req_access = list(10)
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
 	tag = "icon-corner_white (NORTHEAST)";
@@ -14415,6 +14393,10 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"OO" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/reinforced,
+/area/engineering/fdengine)
 "Pg" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30747,7 +30729,7 @@ ib
 ej
 ej
 ej
-lO
+OO
 mH
 eZ
 oB


### PR DESCRIPTION
🆑 
Added double-doors to relevant areas of Engineering. Some of them are glass.
Narrowed the size of the Nacelle doors, as the space allowed was insufficient for double-doors.
Removed redundant nacelle airlock.
/ 🆑 
Someone remind me later to add a multi-tile check to the door-direction logic.