### PR TITLE
Disables Unathi Regen.

### DIFF
--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -68,11 +68,11 @@
 		"Your scales bristle against the cold."
 		)
 	breathing_sound = 'sound/voice/lizard.ogg'
-
+/*Urist Edit: Disables Unathi Regen.
 	base_auras = list(
 		/obj/aura/regenerating/human/unathi
 		)
-/*Urist Edit: Removes Unathi Regen.
+
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/diona_heal_toggle
 		)

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -72,11 +72,11 @@
 	base_auras = list(
 		/obj/aura/regenerating/human/unathi
 		)
-
+/*Urist Edit: Removes Unathi Regen.
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/diona_heal_toggle
 		)
-
+*/
 	prone_overlay_offset = list(-4, -4)
 
 	override_limb_types = list(BP_HEAD = /obj/item/organ/external/head/unathi)


### PR DESCRIPTION
🆑 
Unathi Regeneration ability is disabled now.
/ 🆑 
Inb4 those people who only play Unathi for the regen crawling out of the woodwork. Just watch.