### PR TITLE
Disables clerical borgs. We aren't baystation.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,7 +1,7 @@
 var/global/list/robot_modules = list(
 	"Standard"		= /obj/item/weapon/robot_module/standard,
 	"Service" 		= /obj/item/weapon/robot_module/clerical/butler,
-	"Clerical" 		= /obj/item/weapon/robot_module/clerical/general,
+//	"Clerical" 		= /obj/item/weapon/robot_module/clerical/general,
 	"Research" 		= /obj/item/weapon/robot_module/research,
 	"Miner" 		= /obj/item/weapon/robot_module/miner,
 	"Crisis" 		= /obj/item/weapon/robot_module/medical/crisis,


### PR DESCRIPTION
🆑 
Clerical borgs are disabled.
/ 🆑 

Now here's a weird one! We're not baystation. We aren't paperwork memes. Please don't just join as a borg to waste a slot.