### PR TITLE
Removes a bunch of powercreep from the Mercenary armory.

### DIFF
--- a/maps/nerva/nerva-5.dmm
+++ b/maps/nerva/nerva-5.dmm
@@ -13125,28 +13125,6 @@
 /area/syndicate_mothership)
 "Dy" = (
 /obj/structure/table/rack,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/weapon/gun/projectile/automatic/c20r,
-/obj/item/weapon/gun/projectile/automatic/c20r,
-/obj/item/weapon/gun/projectile/automatic/c20r,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"Dz" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/weapon/gun/projectile/silenced/knight,
-/obj/item/weapon/gun/projectile/silenced/knight,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -13960,15 +13938,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
-"Fi" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/belt/urist/military,
-/obj/item/weapon/storage/belt/urist/military,
-/obj/item/weapon/storage/belt/urist/military,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
 "Fj" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_s";
@@ -14157,9 +14126,6 @@
 /area/syndicate_mothership)
 "FA" = (
 /obj/structure/table/rack,
-/obj/item/weapon/gun/energy/gun,
-/obj/item/weapon/gun/energy/gun,
-/obj/item/weapon/gun/energy/gun,
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 32;
 	pixel_y = -3
@@ -15085,13 +15051,7 @@
 	},
 /area/syndicate_mothership)
 "HB" = (
-/obj/structure/table/rack,
-/obj/item/weapon/tank/jetpack/oxygen,
-/obj/item/weapon/tank/jetpack/oxygen,
-/obj/item/weapon/tank/jetpack/oxygen,
-/obj/item/weapon/tank/jetpack/oxygen,
-/obj/item/weapon/tank/jetpack/oxygen,
-/obj/item/weapon/tank/jetpack/oxygen,
+/obj/structure/dispenser/oxygen,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -15717,9 +15677,7 @@
 /turf/simulated/floor/shuttle/darkred,
 /area/syndicate_station/start)
 "IU" = (
-/obj/structure/closet/syndicate/suit{
-	name = "suit closet"
-	},
+/obj/structure/table/standard,
 /turf/simulated/floor/shuttle/darkred,
 /area/syndicate_station/start)
 "IV" = (
@@ -16684,11 +16642,7 @@
 /turf/simulated/floor/plating,
 /area/syndicate_station/start)
 "KT" = (
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/merc,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/head/helmet/space/void/merc,
+/obj/machinery/suit_storage_unit/merc,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -17662,7 +17616,6 @@
 "MR" = (
 /obj/structure/table/rack,
 /obj/item/weapon/rig/merc/empty,
-/obj/item/weapon/rig/merc/heavy/empty,
 /turf/unsimulated/floor{
 	icon_state = "vault";
 	dir = 8
@@ -17810,14 +17763,6 @@
 	},
 /turf/simulated/floor/shuttle/darkred,
 /area/syndicate_station/start)
-"Nj" = (
-/obj/structure/table/rack,
-/obj/item/device/suit_cooling_unit,
-/turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
-	},
-/area/syndicate_mothership)
 "Nk" = (
 /obj/machinery/suit_cycler/syndicate{
 	locked = 0
@@ -18082,6 +18027,29 @@
 	tag = "icon-gravsnow_corner (SOUTHWEST)";
 	icon_state = "gravsnow_corner";
 	dir = 10
+	},
+/area/syndicate_mothership)
+"TQ" = (
+/obj/structure/table/rack,
+/obj/item/weapon/gun/energy/gun,
+/obj/item/weapon/gun/energy/gun,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Us" = (
+/obj/structure/table/rack,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/turf/unsimulated/floor{
+	icon_state = "vault";
+	dir = 8
 	},
 /area/syndicate_mothership)
 
@@ -46762,7 +46730,7 @@ Dx
 Dx
 Dx
 Dx
-Nj
+Nk
 vY
 ab
 ab
@@ -46946,8 +46914,8 @@ vY
 vY
 vY
 vY
-Dz
-Dz
+Dy
+Dy
 Dx
 Fh
 Dx
@@ -47166,7 +47134,7 @@ Dx
 Dx
 Dx
 Dx
-Nj
+Nk
 vY
 ab
 ab
@@ -47367,7 +47335,7 @@ KT
 KT
 KT
 KT
-MR
+Us
 vY
 vY
 ab
@@ -47959,9 +47927,9 @@ vY
 DC
 DC
 ED
-Fi
+Dy
 FA
-FA
+TQ
 vY
 vY
 Io


### PR DESCRIPTION
🆑 
Removed most of the guns from the mercenary armory. Use your uplinks.
Removed the heavy hardsuits from the Mercenary armory. They were extremely OP, historically existing as a response to the crew having pulse rifles at roundstart way back when.
Removed the oxygen jetpacks from the mercenary armory, replaced it with a tank rack, encouraging Mercenaries to use the previously redundant CO2 jetpacks.
All the Red Voidsuits have been  replaced with Suit Storage Units that contain Red Suits. with the same contents. It just looks nicer.
Lowered the amount of Combat Rigs to 1. 
Replaced a closet containing an oxygen jetpack with a table.
Added a bunch of suit coolers, in case you feel like doing something insane like All-IPCs.
/ 🆑 
Look at the map diffs.

And feel free to shoot this down. I felt like Mercs needed a heavy nerf, and got a lot of positive responses on the topic.