### PR TITLE
Rubbers and Flashrounds: Coming to a Nerva Near You

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2769,6 +2769,7 @@
 #include "code\modules\urist\gamemodes\vampire\vampire_powers.dm"
 #include "code\modules\urist\items\ai_modules.dm"
 #include "code\modules\urist\items\airlock_painter.dm"
+#include "code\modules\urist\items\ammo.dm"
 #include "code\modules\urist\items\cards.dm"
 #include "code\modules\urist\items\chairpainter.dm"
 #include "code\modules\urist\items\circuitboards.dm"

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -541,9 +541,33 @@ var/const/EXTRA_COST_FACTOR = 1.25
 	hidden = 1
 	category = "Arms and Ammunition"
 
+/datum/autolathe/recipe/magazine_c20r_rubber
+	name = "ammunition (10mm, rubber)"
+	path = /obj/item/ammo_magazine/a10mm/rubber
+	hidden = 1
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_c20r_flash
+	name = "ammunition (10mm, flash)"
+	path = /obj/item/ammo_magazine/a10mm/flash
+	hidden = 1
+	category = "Arms and Ammunition"
+
 /datum/autolathe/recipe/magazine_arifle
 	name = "ammunition (5.56mm)"
 	path = /obj/item/ammo_magazine/c556
+	hidden = 1
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_arifle_rubber
+	name = "ammunition (5.56mm, rubber)"
+	path = /obj/item/ammo_magazine/c556/rubber
+	hidden = 1
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_arifle_flash
+	name = "ammunition (5.56mm, flash)"
+	path = /obj/item/ammo_magazine/c556/flash
 	hidden = 1
 	category = "Arms and Ammunition"
 
@@ -556,6 +580,18 @@ var/const/EXTRA_COST_FACTOR = 1.25
 /datum/autolathe/recipe/magazine_carbine
 	name = "ammunition (7.62mm)"
 	path = /obj/item/ammo_magazine/a762
+	hidden = 1
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_carbine_flash
+	name = "ammunition (7.62mm, flash)"
+	path = /obj/item/ammo_magazine/a762/flash
+	hidden = 1
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/magazine_carbine_rubber
+	name = "ammunition (7.62mm, rubber)"
+	path = /obj/item/ammo_magazine/a762/rubber
 	hidden = 1
 	category = "Arms and Ammunition"
 

--- a/code/modules/urist/items/ammo.dm
+++ b/code/modules/urist/items/ammo.dm
@@ -1,0 +1,59 @@
+/obj/item/ammo_magazine/a10mm/rubber
+	name = "magazine (10mm, rubber)"
+	ammo_type = /obj/item/ammo_casing/a10mm/rubber
+
+/obj/item/ammo_magazine/a10mm/flash
+	name = "magazine (10mm, flash)"
+	ammo_type = /obj/item/ammo_casing/a10mm/flash
+
+/obj/item/ammo_magazine/a762/rubber
+	name = "magazine (7.62mm, rubber)"
+	ammo_type = /obj/item/ammo_casing/a762/rubber
+
+/obj/item/ammo_magazine/a762/flash
+	name = "magazine (7.62mm, flash)"
+	ammo_type = /obj/item/ammo_casing/a762/flash
+
+/obj/item/ammo_magazine/c556/rubber
+	name = "magazine (5.56mm, rubber)"
+	ammo_type = /obj/item/ammo_casing/a556/rubber
+
+/obj/item/ammo_magazine/c556/flash
+	name = "magazine (5.56mm, flash)"
+	ammo_type = /obj/item/ammo_casing/a556/flash
+
+/obj/item/ammo_casing/a10mm/rubber
+	desc = "A 10mm rubber bullet casing."
+	projectile_type = /obj/item/projectile/bullet/pistol/rubber
+
+/obj/item/ammo_casing/a10mm/flash
+	desc = "A 10mm flash shell casing."
+	projectile_type = /obj/item/projectile/energy/flash
+
+/obj/item/ammo_casing/a556/flash
+	desc = "A 5.56mm flash shell casing."
+	projectile_type = /obj/item/projectile/energy/flash
+
+/obj/item/ammo_casing/a556/rubber
+	desc = "A 5.56mm rubber bullet casing."
+	projectile_type = /obj/item/projectile/bullet/rifle/rubber
+
+/obj/item/ammo_casing/a762/flash
+	desc = "A 7.62mm flash shell casing."
+	projectile_type = /obj/item/projectile/energy/flash
+
+/obj/item/ammo_casing/a762/rubber
+	desc = "A 7.62mm rubber bullet casing."
+	projectile_type = /obj/item/projectile/bullet/rifle/rubber
+
+/obj/item/projectile/bullet/rifle/rubber //"rubber" bullets
+	name = "rubber rifle bullet"
+	check_armour = "melee"
+	damage = 7
+	agony = 40
+	embed = 0
+	sharp = 0
+
+/obj/item/ammo_magazine/hi2521smg9mm/rubber
+	name = "HI-2521-SMG magazine (9mm, rubber)"
+	ammo_type = /obj/item/ammo_casing/c9mm/rubber

--- a/code/modules/urist/items/guns.dm
+++ b/code/modules/urist/items/guns.dm
@@ -790,7 +790,8 @@ the sprite and make my own projectile -Glloyd*/
 	origin_tech = "combat=4;materials=1;syndicate=1"
 	slot_flags = SLOT_BELT
 	load_method = MAGAZINE
-	magazine_type = /obj/item/ammo_magazine/hi2521smg9mm
+	magazine_type = /obj/item/ammo_magazine/hi2521smg9mm/rubber
+	allowed_magazines = /obj/item/ammo_magazine/hi2521smg9mm
 	one_hand_penalty = 1
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 


### PR DESCRIPTION
Adds flashround and rubber variants for 5.56 mm, 7.62 mm and 10mm. Flashrounds use the default flash round all current pistol flashrounds use, 5.56 and 7.62 rubber variants use a new rubber rifle bullet that does +2 damage and +10 agony over regular pistol rubbers, so 7 damage and 40 agony.  10mm uses the default pistol rubber round. All these variants are added to the autolathe, only visible when hacked like the majority of pre-existing ballistics. Additionally, changes the HI2521 SMG (the white one in the armory) to spawn with 9mm rubber rounds by default, design rationale is the same as why the 9mm Sabre SMG from cargo starts with rubbers. Regular magazines can obviously still be slotted in from the ammunition locker. 

You might ask why this PR was made. Regular rounds are still indisputably better than rubber and flash rounds, it just adds more variation for LTL options for automatic weapons which previously didn't exist before. And to be honest it's really funny to fire 3 round bursts of flash rounds.