### PR TITLE
Allows warheads to be removed from torpedoes

### DIFF
--- a/code/modules/urist/modules/shipbattles/weapons.dm
+++ b/code/modules/urist/modules/shipbattles/weapons.dm
@@ -260,7 +260,7 @@
 		if(istype(user,/mob/living/silicon))
 			return
 		user.put_in_hands(warhead)
-		user << "<span class='notice'>You remove the torpedo warhead.</span>"
+		to_chat(user, "<span class='notice'>You remove the torpedo warhead.</span>")
 		warhead = null
 		loaded = 0
 		icon_state = "bigtorpedo-unloaded"

--- a/code/modules/urist/modules/shipbattles/weapons.dm
+++ b/code/modules/urist/modules/shipbattles/weapons.dm
@@ -247,6 +247,7 @@
 	icon = 'icons/urist/items/ship_projectiles48x48.dmi'
 	icon_state = "bigtorpedo-unloaded"
 	var/loaded = 0
+	var/obj/item/shipweapons/torpedo_warhead/warhead = null
 	matter = list(DEFAULT_WALL_MATERIAL = 2500)
 	dir = 4
 
@@ -254,15 +255,24 @@
 	..()
 	pixel_y = rand(-20,2)
 
+/obj/structure/shipammo/torpedo/attack_hand(mob/user as mob)
+	if(warhead)
+		if(istype(user,/mob/living/silicon))
+			return
+		user.put_in_hands(warhead)
+		user << "<span class='notice'>You remove the torpedo warhead.</span>"
+		warhead = null
+		loaded = 0
+		icon_state = "bigtorpedo-unloaded"
+
 /obj/structure/shipammo/torpedo/attackby(var/obj/item/I, mob/user as mob)
 	if(istype(I, /obj/item/shipweapons/torpedo_warhead))
-		if(!src.loaded)
+		if(!src.loaded && user.unEquip(I, src))
 
 			icon_state = "bigtorpedo"
 			loaded = 1
 
-			user.remove_from_mob(I)
-			qdel(I)
+			warhead = I
 
 			user << "<span class='notice'>You insert the torpedo warhead into the torpedo casing, arming the torpedo.</span>" //torpedo
 

--- a/code/modules/urist/modules/shipbattles/weapons.dm
+++ b/code/modules/urist/modules/shipbattles/weapons.dm
@@ -264,7 +264,7 @@
 		warhead = null
 		loaded = 0
 		icon_state = "bigtorpedo-unloaded"
-
+	. = ..()
 /obj/structure/shipammo/torpedo/attackby(var/obj/item/I, mob/user as mob)
 	if(istype(I, /obj/item/shipweapons/torpedo_warhead))
 		if(!src.loaded && user.unEquip(I, src))

--- a/code/modules/urist/modules/shipbattles/weapons.dm
+++ b/code/modules/urist/modules/shipbattles/weapons.dm
@@ -254,17 +254,9 @@
 /obj/structure/shipammo/torpedo/New()
 	..()
 	pixel_y = rand(-20,2)
+	if(ispath(warhead))
+		warhead = new warhead(src)
 
-/obj/structure/shipammo/torpedo/attack_hand(mob/user as mob)
-	if(warhead)
-		if(istype(user,/mob/living/silicon))
-			return
-		user.put_in_hands(warhead)
-		to_chat(user, "<span class='notice'>You remove the torpedo warhead.</span>")
-		warhead = null
-		loaded = 0
-		icon_state = "bigtorpedo-unloaded"
-	. = ..()
 /obj/structure/shipammo/torpedo/attackby(var/obj/item/I, mob/user as mob)
 	if(istype(I, /obj/item/shipweapons/torpedo_warhead))
 		if(!src.loaded && user.unEquip(I, src))
@@ -278,7 +270,13 @@
 
 		else
 			user << "<span class='notice'>This torpedo already has a warhead in it!</span>" //torpedo
-
+	else if(isCrowbar(I))
+		if(warhead)
+			warhead.dropInto(loc)
+			to_chat(user, "<span class='notice'>You remove the torpedo warhead.</span>")
+			warhead = null
+			loaded = 0
+			icon_state = "bigtorpedo-unloaded"
 	else
 		..()
 
@@ -287,6 +285,7 @@
 	loaded = 1
 	icon = 'icons/urist/items/ship_projectiles48x48.dmi'
 	icon_state = "bigtorpedo"
+	warhead = /obj/item/shipweapons/torpedo_warhead
 
 /obj/machinery/shipweapons/missile/torpedo
 	name = "torpedo launcher"


### PR DESCRIPTION
The glue stuck onto each and every warhead, both present and future, has finally been scraped off. Now you can remove them from their case prisons.