### PR TITLE
Allows IPCs and FBPs to have stuff put in new heads

### DIFF
--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -13,6 +13,7 @@
 	encased = "skull"
 	artery_name = "carotid artery"
 	cavity_name = "cranial"
+	cavity_max_w_class = 2
 
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_GENDERED_ICON | ORGAN_FLAG_HEALS_OVERKILL | ORGAN_FLAG_CAN_BREAK
 


### PR DESCRIPTION
No longer will you need to fear being hit by ions and rendered permanently blind and out of commission without admin intervention. Now, if a roboticist can manage to put a new head on you they'll be able to actually insert new eyes from the prosthetic organ printer.