### PR TITLE
Pulse Rifle Fixes

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -112,14 +112,6 @@
 /obj/item/projectile/beam/pulse/heavy
 	name = "heavy pulse laser"
 	icon_state = "pulse1_bl"
-	var/life = 20
-
-	Bump(atom/A)
-		A.bullet_act(src, def_zone)
-		src.life -= 10
-		if(life <= 0)
-			qdel(src)
-		return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser
 	name = "\improper PBT \"Pacifier\" mounted taser"


### PR DESCRIPTION
Removes the portion of code that made heavy pulse beams (the one the uplink pulse rifle use) to use very hacky projectile code that made firing at people on the ground impossible. Should also now let pulse rifle attacks be seen in admin logs. Apparently the original intent was to make the pulse rifle able to destroy walls without damaging it first? which probably isn't a valuable trade off for how buggy it seems when normal beam projectiles work fine.

