### PR TITLE
Make Radioactivity mutation less stupid & empower Ryetalyn

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -409,7 +409,6 @@
 	overdose = REAGENTS_OVERDOSE
 
 /datum/reagent/ryetalyn/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.mutations = list()
 	M.disabilities = 0
 	M.sdisabilities = 0
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -409,16 +409,23 @@
 	overdose = REAGENTS_OVERDOSE
 
 /datum/reagent/ryetalyn/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	var/needs_update = M.mutations.len > 0
-
 	M.mutations = list()
 	M.disabilities = 0
 	M.sdisabilities = 0
 
-	// Might need to update appearance for hulk etc.
-	if(needs_update && ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.update_mutations()
+	// URIST EDIT 19-08-14 by Irra - Fix how Rye cleans muts from mobs
+	if (M.active_genes.len > 0 || M.mutations.len > 0)
+		for(var/gene in M.active_genes)
+			var/datum/dna/gene/G = locate(gene) in global.dna_genes
+			M.dna.SetSEState(G.block, 0)
+		M.mutations = list()
+		domutcheck(M, null, MUTCHK_FORCED)
+
+		// Might need to update appearance for hulk etc.
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			H.update_mutations()
+	// END URIST EDIT
 
 /datum/reagent/hyperzine
 	name = "Hyperzine"

--- a/code/modules/urist/modules/genetics/disabilities.dm
+++ b/code/modules/urist/modules/genetics/disabilities.dm
@@ -2,6 +2,13 @@
 // DISABILITIES //
 //////////////////
 
+//
+// CHANGELOG
+//
+//
+// 2019-08-14	Corrected how the radioactive mutation acted on its surroundings - Irra
+//
+
 //genetics disabilities, ported from vg who took them from goon, edited by UMcS
 
 ////////////////////////////////////////
@@ -38,10 +45,11 @@
 
 	OnMobLife(var/mob/owner)
 		owner.radiation = max(owner.radiation, 20)
-		for(var/mob/living/L in range(1, owner))
+		for(var/atom/L in range(1, owner))
 			if(L == owner) continue
-			L << "<span class='warning'> You are enveloped by a soft green glow emanating from [owner].</span>"
-			L.radiation += 5
+			if (istype(L, /mob/living))
+				L << "<span class='warning'> You are enveloped by a soft green glow emanating from [owner].</span>"
+			L.rad_act(5)
 		return
 
 	OnDrawUnderlays(var/mob/M,var/g,var/fat)


### PR DESCRIPTION
Previously, the radioactivity mutation worked directly on the `radiation` variable of mobs. Instead of using the `rad_act` function. This has been addressed.

Secondly, Ryetalyn couldn't fix all mutations, specially those that were granted from `active_genes` - a major source of 'unfixable' mutations that cannot be cured or nullifed by Ryetalyn. A part of this pull request proposes fixing this by making Ryetalyn more potent in deactivating genes.

----
#### Changes to ` code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm`
* Ryetalyn now deactivates the state of DNA blocks responsible for activating mutations and other powers. Successfully nullifying mutations and resetting genes back to their normal state. 
#### Changes to `code/modules/urist/modules/genetics/disabilities.dm`
* Radioactivity mutation now respects armour and affects more than just mobs. (using `atom` instead of `mob`)