### PR TITLE
Restores forehead graffiti removal

### DIFF
--- a/code/_helpers/washing.dm
+++ b/code/_helpers/washing.dm
@@ -87,3 +87,7 @@
 		if(H.belt.clean_blood())
 			H.update_inv_belt(0)
 	H.clean_blood(washshoes)
+	var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
+	if(istype(head))
+		head.forehead_graffiti = null
+		head.graffiti_style = null

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -429,6 +429,10 @@
 	if(user.get_active_hand() != I) return		//Person has switched hands or the item in their hands
 
 	O.clean_blood()
+	if(istype(O, /obj/item/organ/external/head))
+		var/obj/item/organ/external/head/head = O
+		head.forehead_graffiti = null
+		head.graffiti_style = null
 	user.visible_message( \
 		"<span class='notice'>[user] washes \a [I] using \the [src].</span>", \
 		"<span class='notice'>You wash \a [I] using \the [src].</span>")


### PR DESCRIPTION
You can now get writing on your forehead removed by taking a shower or washing a cut-off head again. Shouldn't have needed restoring in the first place, but apparently bay screws up even the stupidest and simplest of things.