### PR TITLE
Reduce the explosion force of warhead IEDs 

### DIFF
--- a/code/modules/urist/modules/shipbattles/shipweapons/torpedo_warhead.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/torpedo_warhead.dm
@@ -116,15 +116,8 @@
 	if(safety && !forced)
 		visible_message("<span class='danger'>[src] beeps stubbornly, refusing to detonate!</span>")
 		playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 25, 0, 10)
-	if(forced)
-		visible_message("<span class='danger'>[src] pings, begining a short countdown!</span>")
-		playsound(src.loc, 'sound/machines/ping.ogg', 25, 0, 10)
-		playsound(src.loc, 'sound/items/countdown.ogg', 25, 0, 10)
-		spawn(4 SECONDS)
-			explosion(get_turf(src), 1, 3, 5)
-			qdel(src)
-	if(!safety)
-		if(prob(15)) // Small chance for the warhead's safeties to engage briefly.
+	if(!safety || forced)
+		if(!forced && prob(15)) // Small chance for the warhead's safeties to engage briefly.
 			visible_message("<span class='danger'>[src] beeps stubbornly, refusing to detonate!</span>")
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 25, 0, 10)
 			return
@@ -132,7 +125,7 @@
 		playsound(src.loc, 'sound/machines/ping.ogg', 25, 0, 10)
 		playsound(src.loc, 'sound/items/countdown.ogg', 25, 0, 10)
 		spawn(4 SECONDS)
-			if(safety) //if the madlads somehow disarm this thing BEFORE detonation ...
+			if(!forced && safety) //if the madlads somehow disarm this thing BEFORE detonation ...
 				visible_message("<span class='danger'>[src] beeps stubbornly, refusing to detonate!</span>")
 				playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 25, 0, 10)
 				return

--- a/code/modules/urist/modules/shipbattles/shipweapons/torpedo_warhead.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/torpedo_warhead.dm
@@ -129,7 +129,7 @@
 				visible_message("<span class='danger'>[src] beeps stubbornly, refusing to detonate!</span>")
 				playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 25, 0, 10)
 				return
-			explosion(get_turf(src), 1, 3, 5)
+			explosion(get_turf(src), 0, 2, 4)
 			qdel(src)
 
 /datum/wires/torpedowarhead


### PR DESCRIPTION
Increases the cohesion of the detonation code of the warhead IEDs. Additionally reduce the explosion force of them by one tile on all numbers. From `1,3,5` to `0,2,4` - about the middle-ground between a full welder tank and a half-full welder tank bomb.

Note that this was discussed by the administration and is a balance change. A discussion may be needed before this merged.

----

#### Changes to `code/modules/urist/modules/shipbattles/shipweapons/torpedo_warhead.dm `
- Minor refactorization to make the code less duplicated and easier to handle
- Reduce the force from `1,3,5` to `0,2,4`
