### PR TITLE
Fashionista! - Add more items to loadout

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2840,6 +2840,8 @@
 #include "code\modules\urist\modules\donate.dm"
 #include "code\modules\urist\modules\ghost_powers.dm"
 #include "code\modules\urist\modules\mining.dm"
+#include "code\modules\urist\modules\client\preference_setup\loadout\lists\loadout_feet.dm"
+#include "code\modules\urist\modules\client\preference_setup\loadout\lists\loadout_hands.dm"
 #include "code\modules\urist\modules\constructable\constructable_circuits.dm"
 #include "code\modules\urist\modules\constructable\constructable_designs.dm"
 #include "code\modules\urist\modules\events\break.dm"

--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -112,3 +112,25 @@
 	display_name = "blindfold"
 	path = /obj/item/clothing/glasses/sunglasses/blindfold
 	flags = GEAR_HAS_COLOR_SELECTION
+
+/*
+ * URIST EDIT BY IRRA IN 2019-08-18
+ *
+ * Fashionista!!
+ */
+/datum/gear/eyes/welding
+	display_name = "welding goggles"
+	path = /obj/item/clothing/glasses/welding
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/engineer, /datum/job/qm,/datum/job/cargo_tech)
+
+/datum/gear/eyes/welding/superior
+	display_name = "welding goggles, superior"
+	path = /obj/item/clothing/glasses/welding/superior
+	allowed_roles = list(/datum/job/chief_engineer)
+
+/datum/gear/eyes/security/goggles
+	display_name = "Security HUD Goggles"
+	path = /obj/item/clothing/glasses/sunglasses/sechud/goggles
+/*
+ * END URIST EDIT
+ */

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -429,7 +429,7 @@ BLIND     // can't see anything
 
 /obj/item/clothing/head/get_mob_overlay(mob/user_mob, slot)
 	var/image/ret = ..()
-	ret.overlays.Cut()
+	// ret.overlays.Cut() -- URIST EDIT BY IRRA IN 2019-08-19 - Seriously, whose fucking idea was /this/? No wonder why Bay's shit's broke as fuck
 	if(on && slot == slot_head_str)
 		if(ishuman(user_mob))
 			var/mob/living/carbon/human/user_human = user_mob

--- a/code/modules/urist/modules/client/preference_setup/loadout/lists/loadout_feet.dm
+++ b/code/modules/urist/modules/client/preference_setup/loadout/lists/loadout_feet.dm
@@ -1,0 +1,12 @@
+
+/datum/gear/shoes/leather
+	display_name = "workboots, leather"
+	path = /obj/item/clothing/shoes/urist/leather
+	cost = 2
+
+	allowed_roles = list(/datum/job/qm,/datum/job/cargo_tech, /datum/job/chief_engineer, /datum/job/engineer)
+
+/datum/gear/shoes/winter
+	display_name = "winter boots"
+	path = /obj/item/clothing/shoes/urist/winter
+	cost = 1

--- a/code/modules/urist/modules/client/preference_setup/loadout/lists/loadout_hands.dm
+++ b/code/modules/urist/modules/client/preference_setup/loadout/lists/loadout_hands.dm
@@ -1,0 +1,6 @@
+
+/datum/gear/gloves/leather
+	display_name = "gloves, leather"
+	path = /obj/item/clothing/gloves/urist/leather
+	cost = 1 // a high cost would be rather discriminatory if it was a job-restricted item
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/engineer)

--- a/maps/glloydstation/Loadout/loadout_suit.dm
+++ b/maps/glloydstation/Loadout/loadout_suit.dm
@@ -21,6 +21,8 @@
 	allowed_roles = list(/datum/job/captain)
 
 /datum/gear/suit/wintercoat/security
+	display_name = "winter coat, security"
+	path = /obj/item/clothing/suit/storage/hooded/wintercoat/security
 	allowed_roles = list(/datum/job/officer, /datum/job/hos, /datum/job/warden, /datum/job/detective)
 
 /datum/gear/suit/wintercoat/medical

--- a/maps/nerva/Loadout/loadout_hands.dm
+++ b/maps/nerva/Loadout/loadout_hands.dm
@@ -1,0 +1,2 @@
+/datum/gear/gloves/leather
+	allowed_roles = list(/datum/job/qm,/datum/job/cargo_tech, /datum/job/chief_engineer, /datum/job/engineer)

--- a/maps/nerva/Loadout/loadout_suit.dm
+++ b/maps/nerva/Loadout/loadout_suit.dm
@@ -20,6 +20,8 @@
 	allowed_roles = list(/datum/job/captain)
 
 /datum/gear/suit/wintercoat/security
+	display_name = "winter coat, security"
+	path = /obj/item/clothing/suit/storage/hooded/wintercoat/security
 	allowed_roles = list(/datum/job/officer, /datum/job/hos, /datum/job/warden, /datum/job/detective)
 
 /datum/gear/suit/wintercoat/medical
@@ -55,3 +57,4 @@
 	display_name = "winter coat, mining"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/miner
 	allowed_roles = list(/datum/job/mining)
+

--- a/maps/nerva/Loadout/loadout_suit.dm
+++ b/maps/nerva/Loadout/loadout_suit.dm
@@ -58,3 +58,13 @@
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/miner
 	allowed_roles = list(/datum/job/mining)
 
+/*
+ * Loadout definitions unique to NERVA
+ */
+
+/datum/gear/suit/cloak_security
+	display_name = "cloak, security"
+	path = /obj/item/clothing/suit/storage/hooded/seccloak
+	allowed_roles = list(/datum/job/officer, /datum/job/hos, /datum/job/warden, /datum/job/detective)
+
+

--- a/maps/nerva/Loadout/loadout_uniform.dm
+++ b/maps/nerva/Loadout/loadout_uniform.dm
@@ -36,3 +36,12 @@
 		var/obj/item/clothing/under/pants/urist/pant_type = pant
 		pants[initial(pant_type.name)] = pant_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(pants))
+
+/*
+ * Loadout definitions unique to NERVA
+ */
+
+/datum/gear/uniform/nervasecfield
+	display_name = "uniform, field (Security)"
+	path = /obj/item/clothing/under/urist/nerva/secfield
+	allowed_roles = list(/datum/job/officer,/datum/job/hos,/datum/job/warden)

--- a/maps/nerva/nerva.dm
+++ b/maps/nerva/nerva.dm
@@ -25,6 +25,7 @@
 
 	#include "loadout/loadout_accessories.dm"
 	#include "loadout/loadout_eyes.dm"
+	#include "loadout/loadout_hands.dm"
 	#include "loadout/loadout_head.dm"
 	#include "loadout/loadout_suit.dm"
 	#include "loadout/loadout_uniform.dm"

--- a/maps/wyrm/Loadout/loadout_suit.dm
+++ b/maps/wyrm/Loadout/loadout_suit.dm
@@ -20,6 +20,8 @@
 	allowed_roles = list(/datum/job/captain)
 
 /datum/gear/suit/wintercoat/security
+	display_name = "winter coat, security"
+	path = /obj/item/clothing/suit/storage/hooded/wintercoat/security
 	allowed_roles = list(/datum/job/officer, /datum/job/hos, /datum/job/warden, /datum/job/detective)
 
 /datum/gear/suit/wintercoat/medical


### PR DESCRIPTION
As this proposal says, it is a series of commits that adds Urist-unique items to the loadout. As well add the two welding goggles (the normal ones used by engineering and cargo, plus the chief engineer-exclusive superior one) and SecHUD goggles to the eyewear section.

This pull request also contains a minor fix that fixes an issue with overlays not being applied to head items proper. Plus a fix on missing loadout data for the security variety of winter coat.

----

#### New files:
- `baystation12.dme` changed to include:
    - `code/modules/urist/modules/client/preference_setup/loadout/lists/loadout_feet.dm`
        - Added (Urist) leather boots
        - Added (Urist) winter boots
    - ` code/modules/urist/modules/client/preference_setup/loadout/lists/loadout_hands.dm`
        - Added (Urist) leather gloves
- `maps/nerva/nerva.dm` changed to include:
    - `maps/nerva/loadout/loadout_hands.dm`

#### Changes to `code/modules/client/preference_setup/loadout/lists/eyegear.dm`
- Loadout changes:
    - Added welding goggles
    - Added superior welding goggles
    - Added sechud goggles

#### Changes to `code/modules/clothing/clothing.dm`
- A minor bugfix related to overlays on head items

#### Changes to ` maps/nerva/Loadout/loadout_uniform.dm`
- Loadout changes:
    - Added security field uniform

#### Changes to ` maps/nerva/Loadout/loadout_suit.dm`
- Loadout changes:
    - Added security winter coat (this is also applied to both Glloydstation & Wyrm)
    - Added security cloak
