### PR TITLE
Makes the exosuit tracking beacons actually buildable

### DIFF
--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -385,6 +385,7 @@
 
 /datum/design/item/mecha_tracking
 	name = "Exosuit tracking beacon"
+	id = "mecha_tracking"
 	build_type = MECHFAB
 	time = 5
 	materials = list(DEFAULT_WALL_MATERIAL = 500)


### PR DESCRIPTION
The exosuit tracking beacons now properly show as something that can be built. No longer will people be able to hide their crazy mech shenanigans. Not like many people would bother trying to, anyways.