### PR TITLE
Bug fix: Corrected Cryopod logging 

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -439,7 +439,7 @@
 		set_occupant(target)
 
 		// Book keeping!
-		log_and_message_admins("has entered a stasis pod")
+		log_and_message_admins("has [target != user ? "placed [key_name(target)] into" : "entered"] a stasis pod")
 
 		//Despawning occurs when process() is called with an occupant without a client.
 		src.add_fingerprint(target)


### PR DESCRIPTION
Noticed cryopod logging is broken when a user drags another player into a pod- The admin log would incorrectly state that the user entered cryo rather than the mob dragged. This has been updated to display both the user and target mobs logged correctly.