### PR TITLE
fixes ID issues and botany windoor

### DIFF
--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -13665,10 +13665,10 @@
 	icon_state = "corner_white";
 	dir = 9
 	},
-/obj/machinery/door/window/westleft,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/window/westright,
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
 "awZ" = (

--- a/maps/nerva/obj/nerva_ids.dm
+++ b/maps/nerva/obj/nerva_ids.dm
@@ -22,13 +22,13 @@
 	name = "identification card"
 	desc = "A card issued to the ship's clown."
 	icon_state = "clown"
-	job_access_type = /datum/job/assistant
+	job_access_type = /datum/job/clown
 
 /obj/item/weapon/card/id/civilian/mime
 	name = "identification card"
 	desc = "A card issued to the ship's mime."
 	icon_state = "mime"
-	job_access_type = /datum/job/assistant
+	job_access_type = /datum/job/mime
 
 /obj/item/weapon/card/id/nerva_scientist
 	name = "identification card"


### PR DESCRIPTION
Gives mimes and clowns proper access. Also makes the botany windoors symmetrical.
