### PR TITLE
More text fixes

### DIFF
--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -24,8 +24,8 @@
 	if(!src.try_consume_fuel()) //insufficient fuel
 		for(var/area/A in shuttle_area)
 			for(var/mob/living/M in A)
-				M.show_message("<spawn class='warning'>You hear the shuttle engines sputter... perhaps it doesn't have enough fuel?", AUDIBLE_MESSAGE,
-				"<spawn class='warning'>The shuttle shakes but fails to take off.", VISIBLE_MESSAGE)
+				M.show_message("<span class='warning'>You hear the shuttle engines sputter... perhaps it doesn't have enough fuel?", AUDIBLE_MESSAGE,
+				"<span class='warning'>The shuttle shakes but fails to take off.", VISIBLE_MESSAGE)
 				return 0 //failure!
 	return 1 //sucess, continue with launch
 
@@ -113,7 +113,7 @@
 
 /obj/structure/fuel_port/attack_hand(mob/user as mob)
 	if(!opened)
-		to_chat(user, "<spawn class='notice'>The door is secured tightly. You'll need a crowbar to open it.")
+		to_chat(user, "<span class='notice'>The door is secured tightly. You'll need a crowbar to open it.")
 		return
 	else if(contents.len > 0)
 		user.put_in_hands(contents[1])
@@ -131,16 +131,16 @@
 /obj/structure/fuel_port/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(isCrowbar(W))
 		if(opened)
-			to_chat(user, "<spawn class='notice'>You tightly shut \the [src] door.")
+			to_chat(user, "<span class='notice'>You tightly shut \the [src] door.")
 			playsound(src.loc, 'sound/effects/locker_close.ogg', 25, 0, -3)
 			opened = 0
 		else
-			to_chat(user, "<spawn class='notice'>You open up \the [src] door.")
+			to_chat(user, "<span class='notice'>You open up \the [src] door.")
 			playsound(src.loc, 'sound/effects/locker_open.ogg', 15, 1, -3)
 			opened = 1
 	else if(istype(W,/obj/item/weapon/tank))
 		if(!opened)
-			to_chat(user, "<spawn class='warning'>\The [src] door is still closed!")
+			to_chat(user, "<span class='warning'>\The [src] door is still closed!")
 			return
 		if(contents.len == 0)
 			user.unEquip(W, src)

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -24,8 +24,8 @@
 	if(!src.try_consume_fuel()) //insufficient fuel
 		for(var/area/A in shuttle_area)
 			for(var/mob/living/M in A)
-				M.show_message("<span class='warning'>You hear the shuttle engines sputter... perhaps it doesn't have enough fuel?", AUDIBLE_MESSAGE,
-				"<span class='warning'>The shuttle shakes but fails to take off.", VISIBLE_MESSAGE)
+				M.show_message("<span class='warning'>You hear the shuttle engines sputter... perhaps it doesn't have enough fuel?</span>", AUDIBLE_MESSAGE,
+				"<span class='warning'>The shuttle shakes but fails to take off.</span>", VISIBLE_MESSAGE)
 				return 0 //failure!
 	return 1 //sucess, continue with launch
 
@@ -113,7 +113,7 @@
 
 /obj/structure/fuel_port/attack_hand(mob/user as mob)
 	if(!opened)
-		to_chat(user, "<span class='notice'>The door is secured tightly. You'll need a crowbar to open it.")
+		to_chat(user, "<span class='notice'>The door is secured tightly. You'll need a crowbar to open it.</span>")
 		return
 	else if(contents.len > 0)
 		user.put_in_hands(contents[1])
@@ -131,16 +131,16 @@
 /obj/structure/fuel_port/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(isCrowbar(W))
 		if(opened)
-			to_chat(user, "<span class='notice'>You tightly shut \the [src] door.")
+			to_chat(user, "<span class='notice'>You tightly shut \the [src] door.</span>")
 			playsound(src.loc, 'sound/effects/locker_close.ogg', 25, 0, -3)
 			opened = 0
 		else
-			to_chat(user, "<span class='notice'>You open up \the [src] door.")
+			to_chat(user, "<span class='notice'>You open up \the [src] door.</span>")
 			playsound(src.loc, 'sound/effects/locker_open.ogg', 15, 1, -3)
 			opened = 1
 	else if(istype(W,/obj/item/weapon/tank))
 		if(!opened)
-			to_chat(user, "<span class='warning'>\The [src] door is still closed!")
+			to_chat(user, "<span class='warning'>\The [src] door is still closed!</span>")
 			return
 		if(contents.len == 0)
 			user.unEquip(W, src)

--- a/code/modules/urist/gamemodes/vampire/vampire_powers.dm
+++ b/code/modules/urist/gamemodes/vampire/vampire_powers.dm
@@ -79,7 +79,7 @@
 
 	if(!M.vampire.torpor)
 		M.vampire.torpor = 1
-		H << "<span class='notice'>You are now entering torpor. For all intents and purposes, you will appear dead. You can wake up at any time, but you will be slightly drowsy briefly afterwards.</span>"
+		H << "<span class='notice'>You are now entering torpor. You are able to heal damage while in coffins and morgue trays. For all intents and purposes, you will appear dead. You can wake up at any time, but you will be slightly drowsy briefly afterwards.</span>"
 		H.status_flags |= FAKEDEATH		//play dead
 	else
 		M.vampire.torpor = 0


### PR DESCRIPTION
Replaces spawn with span for the warnings in overmap_shuttles. Also adds the coffin/morgue tray regeneration requirement to the toggle message for Vampiric Torpor.