### PR TITLE
Clowns cannot honk if you remove his Alt-Title.

### DIFF
--- a/maps/nerva/datums/nerva_jobs.dm
+++ b/maps/nerva/datums/nerva_jobs.dm
@@ -246,8 +246,6 @@
 	alt_titles = list(
 	"Technical Assistant","Medical Intern","Cargo Assistant", "Security Deputy",
 	"Botanist" = /decl/hierarchy/outfit/job/service/gardener,
-	"Clown" = /decl/hierarchy/outfit/job/clown,
-	"Mime" = /decl/hierarchy/outfit/job/mime
 	)
 
 /datum/job/chef


### PR DESCRIPTION
### Features:

- Removes Alt Titles for Assistant for Mime and Clown.
- Clown + Mime Role remain, with the typical genetic stuff, Clown getting clumsy and such.
- Removes fun.

![3e135cd02d697b9168e80c668c1bfdc9](https://user-images.githubusercontent.com/53942081/72212793-100d2300-34db-11ea-8d53-abcb1665d5eb.png)
