### PR TITLE
Fixes a small mapping error with the engine chamber.

### DIFF
--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -16299,7 +16299,7 @@
 	p_open = 0
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/nitrogen,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/engine)
 "aBG" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,


### PR DESCRIPTION
Instead of being an airless tile, the tile under the ejection door was a N2 tank tile.