### PR TITLE
Fixes Colony and Crashed Pods, Adds Previous PR Content in Map.

### DIFF
--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -306,6 +306,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/sign/osha/biohazardous{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plating,
 /area/medical/extstorage)
 "aK" = (
@@ -2194,6 +2197,7 @@
 /obj/item/device/radio,
 /obj/item/weapon/storage/box/glowsticks,
 /obj/structure/table/standard,
+/obj/item/weapon/storage/box/survivalkit,
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/cockpit)
 "ek" = (
@@ -3839,6 +3843,7 @@
 /obj/item/device/radio,
 /obj/item/device/spaceflare,
 /obj/random/toolbox,
+/obj/item/weapon/storage/box/survivalkit,
 /turf/simulated/floor/tiled,
 /area/antonine_hangar/start)
 "hd" = (
@@ -19189,9 +19194,6 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/hadrian/main)
 "Hz" = (
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = -32
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -23462,6 +23464,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers"
+	},
+/obj/item/weapon/storage/fancy/vials,
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -8837,7 +8837,6 @@
 /area/security/checkpoint)
 "apT" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/folder/red,
 /obj/item/weapon/handcuffs,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -8851,6 +8850,7 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 10
 	},
+/obj/item/weapon/book/manual/security_space_law/nervaspacelaw,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
 "apU" = (
@@ -8904,7 +8904,6 @@
 "apZ" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/blue,
-/obj/item/weapon/folder/red,
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/camera/network/security{
@@ -8912,6 +8911,8 @@
 	dir = 1;
 	icon_state = "camera"
 	},
+/obj/item/weapon/book/manual/security_space_law/nervaspacelaw,
+/obj/item/weapon/book/manual/security_space_law/nervaspacelaw,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "aqa" = (
@@ -8923,6 +8924,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
+/obj/item/weapon/folder/red,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "aqb" = (
@@ -12065,6 +12067,7 @@
 	icon_state = "corner_white";
 	tag = "icon-corner_white (NORTHEAST)"
 	},
+/obj/item/weapon/book/manual/security_space_law/nervaspacelaw,
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "auc" = (
@@ -13046,6 +13049,7 @@
 	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/vending/whitedragon,
 /turf/simulated/floor/tiled,
 /area/civilian/messhall)
 "avQ" = (
@@ -20725,6 +20729,7 @@
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/folder/red,
 /obj/item/weapon/pen,
+/obj/item/weapon/book/manual/security_space_law/nervaspacelaw,
 /turf/simulated/floor/carpet,
 /area/security/cosoffice)
 "aJh" = (
@@ -26172,7 +26177,7 @@
 /area/maintenance/third_deck/afs)
 "aRR" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "First Deck Substation";
+	name = "Third Deck Substation";
 	req_access = list("ACCESS_ENGINEERING")
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -29433,6 +29438,7 @@
 /obj/item/weapon/material/clipboard,
 /obj/item/clothing/accessory/armband/bluegoldcom,
 /obj/item/clothing/accessory/armband/cargo,
+/obj/item/weapon/storage/box/survivalkit,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/qm)
 "kBU" = (

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -14843,6 +14843,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/book/manual/security_space_law/nervaspacelaw,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
 "KL" = (

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -71,6 +71,7 @@
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/crowbar,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "ak" = (
@@ -338,6 +339,7 @@
 	pixel_x = -6;
 	pixel_y = 0
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "aK" = (
@@ -356,6 +358,12 @@
 /obj/item/trash/liquidfood,
 /obj/item/weapon/storage/box/detergent,
 /obj/item/clothing/mask/plunger,
+/obj/structure/closet/crate,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aL" = (
@@ -408,6 +416,7 @@
 "aQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/crowbar,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "aR" = (
@@ -516,14 +525,14 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 "be" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/alarm{
+	dir = 4;
+	locked = 0;
+	pixel_x = -25;
+	pixel_y = 0
 	},
-/obj/structure/bed/chair,
-/obj/structure/closet/hydrant{
-	pixel_x = -27
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/microwave,
+/obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bf" = (
@@ -563,6 +572,7 @@
 /obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/reagent_containers/food/drinks/coffeecup/metal,
+/obj/item/device/geiger,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/crashed_pod)
 "bk" = (
@@ -604,17 +614,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bq" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/weapon/crowbar,
-/obj/item/weapon/crowbar,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
-"br" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/microwave,
+/obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bt" = (
@@ -638,11 +641,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
@@ -650,19 +657,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
-"bx" = (
-/obj/machinery/alarm{
-	dir = 4;
-	locked = 0;
-	pixel_x = -25;
-	pixel_y = 0
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "by" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -742,91 +736,42 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
-"bH" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/map_template/crashed_pod)
-"bI" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
 "bJ" = (
 /obj/machinery/door/airlock/external{
 	name = "escape pod airlock"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
-"bK" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/ash,
-/obj/item/trash/cigbutt/cigarbutt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
 "bL" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/loading{
+	dir = 1;
+	icon_state = "loadingarea"
 	},
-/obj/structure/closet,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/clothing,
-/obj/random/gloves,
-/obj/random/gloves,
-/obj/random/hat,
-/obj/random/hat,
-/obj/random/hat,
-/obj/random/hat,
-/obj/random/hat,
-/obj/item/clothing/under/color/orange,
-/obj/item/clothing/under/color/orange,
-/obj/item/clothing/under/color/blackjumpshorts,
-/obj/item/clothing/under/color/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
-"bN" = (
-/obj/machinery/seed_extractor,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bO" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/structure/table/steel_reinforced,
 /obj/item/device/binoculars,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/candy/proteinbar,
 /obj/item/weapon/reagent_containers/food/drinks/cans/speer,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/device/geiger,
+/obj/item/device/geiger,
 /turf/simulated/floor/tiled/dark,
-/area/map_template/crashed_pod)
-"bP" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -859,13 +804,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
 "bR" = (
-/obj/structure/table/steel_reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/tastybread,
-/obj/item/device/geiger,
-/obj/item/device/geiger,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/loading,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
 /area/map_template/crashed_pod)
 "bS" = (
 /obj/effect/floor_decal/industrial/hatch/orange,
@@ -1015,33 +957,15 @@
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/crashed_pod)
-"cb" = (
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/item/device/oxycandle,
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/crashed_pod)
 "cc" = (
+/obj/machinery/conveyor{
+	dir = 5;
+	icon_state = "conveyor0";
+	id = "crashedpodid"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"cd" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/multitool,
 /obj/item/weapon/screwdriver,
@@ -1060,9 +984,44 @@
 /obj/item/weapon/pen/blue,
 /obj/item/weapon/pen/green,
 /obj/item/weapon/pen/red,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
+/obj/item/device/oxycandle,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
-"cd" = (
+"pj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"rE" = (
+/obj/machinery/conveyor{
+	dir = 6;
+	icon_state = "conveyor0";
+	id = "crashedpodid"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"vI" = (
+/obj/machinery/computer/mining{
+	pixel_x = 32;
+	req_access = list()
+	},
+/obj/machinery/conveyor{
+	id = "crashedpodid"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"yw" = (
 /obj/structure/closet/crate/large/hydroponics,
 /obj/item/seeds/potatoseed,
 /obj/item/seeds/potatoseed,
@@ -1084,6 +1043,52 @@
 /obj/item/seeds/whitebeetseed,
 /obj/item/weapon/storage/plants,
 /obj/item/seeds/bananaseed,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"zh" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/dark,
+/area/map_template/crashed_pod)
+"AH" = (
+/obj/machinery/mineral/unloading_machine{
+	input_turf = 1;
+	output_turf = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"Kk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor_switch{
+	id = "crashedpodid"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"NX" = (
+/obj/machinery/mineral/processing_unit{
+	input_turf = 8;
+	output_turf = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/crashed_pod)
+"Pp" = (
+/obj/machinery/mineral/stacking_machine{
+	input_turf = 2;
+	output_turf = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/crashed_pod)
+"UK" = (
+/obj/machinery/computer/mining{
+	pixel_x = -32;
+	req_access = list()
+	},
+/obj/machinery/conveyor{
+	id = "crashedpodid"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 
@@ -1115,9 +1120,9 @@ aE
 aB
 ay
 be
+yw
 ca
-bx
-bK
+bT
 ax
 bV
 bS
@@ -1172,9 +1177,9 @@ bc
 bi
 bt
 bR
-ay
-bY
-bX
+AH
+UK
+rE
 ab
 "}
 (6,1,1) = {"
@@ -1190,9 +1195,9 @@ bd
 bk
 bG
 bv
-bB
-bF
-bZ
+Kk
+pj
+NX
 ax
 "}
 (7,1,1) = {"
@@ -1208,8 +1213,8 @@ bj
 bl
 bw
 bM
-ay
-bW
+Pp
+vI
 cc
 ab
 "}
@@ -1245,8 +1250,8 @@ bn
 by
 bU
 ay
-bH
-bN
+bY
+bX
 ab
 "}
 (10,1,1) = {"
@@ -1263,8 +1268,8 @@ bo
 bA
 bz
 bB
-bI
-cb
+bF
+bZ
 ax
 "}
 (11,1,1) = {"
@@ -1277,11 +1282,11 @@ aM
 aR
 ay
 bq
+zh
+zh
 bu
-br
-bT
 ay
-bP
+bW
 cd
 ab
 "}

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -183,10 +183,7 @@
 /turf/simulated/floor/carpet,
 /area/map_template/colony/command)
 "aD" = (
-/obj/structure/flora/pottedplant/unusual{
-	desc = "Steve's distant cousin.";
-	name = "Randy"
-	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/command)
 "aE" = (
@@ -395,6 +392,10 @@
 /obj/effect/floor_decal/techfloor/hole/right{
 	icon_state = "techfloor_hole_right";
 	dir = 1
+	},
+/obj/structure/flora/pottedplant/unusual{
+	desc = "Steve's distant cousin.";
+	name = "Randy"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/command)
@@ -655,6 +656,7 @@
 	dir = 4;
 	pixel_x = -21
 	},
+/obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "by" = (
@@ -2945,6 +2947,7 @@
 	icon_state = "techfloor_edges";
 	dir = 5
 	},
+/obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony)
 "fD" = (
@@ -3565,6 +3568,7 @@
 /obj/item/weapon/storage/box/snack/noraisin,
 /obj/item/weapon/storage/box/snack/jerky,
 /obj/item/weapon/storage/box/snack/candy,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/colony/messhall)
 "gs" = (
@@ -4211,10 +4215,6 @@
 /obj/item/ammo_magazine/mc9mm/flash,
 /obj/item/ammo_magazine/c45m/rubber,
 /obj/item/ammo_magazine/c45m/flash,
-/obj/item/weapon/storage/box/shotgunshells,
-/obj/item/weapon/storage/box/shotgunshells,
-/obj/item/weapon/storage/box/shotgunammo,
-/obj/item/weapon/storage/box/shotgunammo,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -4225,6 +4225,8 @@
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/item/device/radio,
+/obj/item/weapon/storage/box/ammo/beanbags,
+/obj/item/weapon/storage/box/ammo/shotgunshells,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/map_template/colony/armory)
 "hC" = (
@@ -4745,6 +4747,7 @@
 	pixel_y = -32;
 	req_access = list()
 	},
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/lino,
 /area/map_template/colony/messhall)
 "ix" = (
@@ -6082,8 +6085,7 @@
 	icon_state = "techfloor_edges";
 	dir = 5
 	},
-/obj/structure/closet/secure_closet/hydroponics_torch,
-/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/machinery/biogenerator,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/hydroponics)
 "ky" = (
@@ -8765,6 +8767,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/hydroponics)
 "yE" = (
@@ -8800,7 +8803,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/hydroponics)
 "Dj" = (
@@ -8967,6 +8970,7 @@
 	icon_state = "techfloor_edges";
 	dir = 5
 	},
+/obj/item/weapon/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/colony/hydroponics)
 "Vk" = (


### PR DESCRIPTION
### Changes:

- Adds Survial Boxes to Hadrian and Trajan
- Adds Vials to Virology
- Moves Virology Feeder to the south.
- Adds Universal Enzyme, Trash Crates, Shredder, Biogenerator to the Colony Away.
- Adds Space Law books to Security, HoS Office, One in the Command Bridge.
- Adds White Dragon Vendor to Canteen.
- Fixes Naming in Airlocks for Engine Room.
- Adds Ore Refinery area to the Crashed Pod Area and an additional botany tray.