### PR TITLE
Traitor Equipment - Price Balance Pass

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -18,7 +18,7 @@
 /datum/uplink_item/item/tools/clerical
 	name = "Morphic Clerical Kit"
 	desc = "Comes with all you need to fake paperwork. Assumes you have passed basic writing lessons."
-	item_cost = 16
+	item_cost = 6
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/clerical
 
 /datum/uplink_item/item/tools/plastique
@@ -44,7 +44,7 @@
 /datum/uplink_item/item/tools/suit_sensor_mobile
 	name = "Suit Sensor Jamming Device"
 	desc = "This device will affect suit sensor data using method and radius defined by the user."
-	item_cost = 20
+	item_cost = 18
 	path = /obj/item/device/suit_sensor_jammer
 
 /datum/uplink_item/item/tools/encryptionkey_binary
@@ -54,7 +54,7 @@
 
 /datum/uplink_item/item/tools/emag
 	name = "Cryptographic Sequencer"
-	item_cost = 24
+	item_cost = 30
 	path = /obj/item/weapon/card/emag
 
 /datum/uplink_item/item/tools/hacking_tool
@@ -72,7 +72,7 @@
 
 /datum/uplink_item/item/tools/thermal
 	name = "Thermal Imaging Glasses"
-	item_cost = 24
+	item_cost = 32
 	path = /obj/item/clothing/glasses/thermal/syndi
 
 /datum/uplink_item/item/tools/flashdark
@@ -112,10 +112,10 @@
 
 /datum/uplink_item/item/tools/interceptor
 	name = "Radio Interceptor"
-	item_cost = 30
+	item_cost = 20
 	path = /obj/item/device/radio/intercept
 	desc = "A radio that can intercept secure radio channels. Doesn't fit in pockets."
-	
+
 /datum/uplink_item/item/tools/ttv
 	name = "Binary Gas Bomb"
 	item_cost = 40

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -6,7 +6,7 @@
 
 /datum/uplink_item/item/visible_weapons/dartgun
 	name = "Dart Gun"
-	item_cost = 20
+	item_cost = 12
 	path = /obj/item/weapon/gun/projectile/dartgun
 
 /datum/uplink_item/item/visible_weapons/crossbow
@@ -23,7 +23,7 @@
 /datum/uplink_item/item/visible_weapons/g9mm
 	name = "Silenced Holdout Pistol"
 	desc = "9mm with silencer kit and ammunition."
-	item_cost = 32
+	item_cost = 20
 	path = /obj/item/weapon/storage/box/syndie_kit/g9mm
 
 /datum/uplink_item/item/badassery/money_cannon
@@ -40,7 +40,7 @@
 
 /datum/uplink_item/item/visible_weapons/energy_gun
 	name = "Energy Gun"
-	item_cost = 32
+	item_cost = 24
 	path = /obj/item/weapon/gun/energy/gun
 
 /datum/uplink_item/item/visible_weapons/revolver
@@ -102,7 +102,7 @@
 
 /datum/uplink_item/item/visible_weapons/sawnoff
 	name = "Sawnoff Shotgun"
-	item_cost = 45
+	item_cost = 40
 	path = /obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn
 
 /datum/uplink_item/item/visible_weapons/deagle
@@ -112,7 +112,7 @@
 
 /datum/uplink_item/item/visible_weapons/beretta
 	name = "9mm Pistol"
-	item_cost = 40
+	item_cost = 32
 	path = /obj/item/weapon/gun/projectile/beretta
 
 /datum/uplink_item/item/visible_weapons/sigsauer

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -7,7 +7,7 @@
 /datum/uplink_item/item/services/fake_ion_storm
 	name = "Ion Storm Announcement"
 	desc = "Interferes with ion sensors."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/device/uplink_service/fake_ion_storm
 
 /datum/uplink_item/item/services/suit_sensor_garble
@@ -31,7 +31,7 @@
 /datum/uplink_item/item/services/suit_sensor_shutdown
 	name = "Complete Suit Sensor Shutdown"
 	desc = "Completely disables all suit sensors for 10 minutes."
-	item_cost = 40
+	item_cost = 32
 	path = /obj/item/device/uplink_service/jamming
 
 /datum/uplink_item/item/services/fake_update_annoncement

--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -12,7 +12,7 @@
 /datum/uplink_item/item/stealth_items/spy
 	name = "Bug Kit"
 	desc = "For when you want to conduct voyeurism from afar."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/weapon/storage/box/syndie_kit/spy
 
 /datum/uplink_item/item/stealth_items/id
@@ -23,28 +23,24 @@
 /datum/uplink_item/item/stealth_items/chameleon_kit
 	name = "Chameleon Kit"
 	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
-	item_cost = 20
+	item_cost = 18
 	path = /obj/item/weapon/storage/backpack/chameleon/sydie_kit
 
 /datum/uplink_item/item/stealth_items/voice
 	name = "Chameleon Mask/Voice Changer"
-	item_cost = 20
+	item_cost = 16
 	path = /obj/item/clothing/mask/chameleon/voice
 
 /datum/uplink_item/item/stealth_items/chameleon_projector
 	name = "Chameleon-Projector"
-	item_cost = 32
+	desc = "Allows you to mimic a scanned object to hide. Make sure someone doesn't pick you up!"
+	item_cost = 30
 	path = /obj/item/device/chameleon
 
 /datum/uplink_item/item/stealth_items/fleshsuit
 	name = "Human-suit"
 	item_cost = 5
 	path = /obj/item/weapon/storage/box/syndie_kit/fleshsuit
-
-/datum/uplink_item/item/stealth_items/smugglers_satchel
-	name = "Smuggler's Satchel"
-	item_cost = 8
-	path = /obj/item/weapon/storage/backpack/satchel/flat
 
 /datum/uplink_item/item/stealth_items/sneakies
 	name = "Sneakies"
@@ -54,5 +50,5 @@
 /datum/uplink_item/item/stealth_items/smuggler_satchel
 	name = "Smuggler's Satchel"
 	desc = "This satchel is thin enough to be hidden in the gap between plating and tiling, great for stashing your stolen goods. Comes with a crowbar and a floor tile inside."
-	item_cost = 20
+	item_cost = 16
 	path = /obj/item/weapon/storage/backpack/satchel/flat

--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -33,5 +33,5 @@
 
 /datum/uplink_item/item/stealthy_weapons/syringegun
 	name = "Disguised Syringe Gun"
-	item_cost = 10
+	item_cost = 8
 	path = /obj/item/weapon/storage/box/syndie_kit/syringegun


### PR DESCRIPTION
### What does this do?
_This is going to go well, I've been testing and tweaking some of the values of specific traitor gear, before I plan to add additional gear based on job variants. My ideal goal would to make each traitor weapon actually viable to use and reduce the amount of meta loadouts so that most equipment is picked, however that is an additional element I'd like to tackle further down the road._

### Tools/Stealth Gear:

**Camera Bug Kit:** 8 -> 6TC - Camera Bug Kits are rarely used and would benefit from being able to be purchased at a lower cost, especially as a final purchase, when funds are low.

**Smuggler's Satchel:** 20 -> 16 TC - Smuggler's Satchel is a very useful item for stealth traitors and should be more available for traitors stashing away high-value gear. I often tend to use disposal bins as a method for storage due to the steeper price of satchels.

**Voice Changer Kit:** 20 -> 16TC - Voice Changers are seldom use other than to irratate or occasionaly decieve people, lowering the cost of this should make this more viable, ideally for covert, or as a gimmick. I believe they are already chameleon items, so this is an incredibly useful tool for diverting attention that should be used more often.

**Chameleon Scanner:** 32 -> 30TC - Chameleon Scanners seemed be be seldom used despite their amazing potential to both dodge shots and also hide incredibly effectively. Lowering the cost minorly should hopefully make them more used. 

**Chameleon Kit:** 20 -> 18 TC - These are a common traitor item found in maintenance spawns, I'd argue to lower the cost further so that people could attempt more covert gear combinations, but I think lowering the price to 18 justifies the common occurance of them in maintenance.

**Clerical Kit:**  16 -> 4TC - Clerical Kits aren't useful 9 times out of 10, and are more of a gimmick item than of any assistance, since we are Mid RP, we don't really hold paperwork in such high regard as say, Bay.

**Crytographic Sequencer/EMAG:** 24 TC -> 30 TC - Emags are arguably one of the best traitor items in the game, allowing instant access to highly valuble areas instantly. Other tools, such as hacking and door-hacker antag tools pale in comparison. I believe a higher cost will weigh into the usefulness of this item and make traitors take more interesting approaches to access, e.g hidden walls, door-hacker, etc. However, I can lower the door-hacker's price if this is deemed too controversial.

**Radio Interceptor:** 30 -> 20TC - Gaining insight into other radios is an incredibly powerful element of playing SS13, however the huge cost of a bulky item you cannot hide in your pockets makes it unlikely that you'd purchase this, lowering the cost would likely prove this to be far more of a common purchase. (Or making it pocketable.)

**Thermal Vision Goggles:**  24 -> 32TC - Thermals are one of the most used and incredibly useful tools, they offer a huge amount of information for people to gain and use against non-antag crew. I've adjusted the price to make them more expensive, this should lead to a difference in what equipment is ran with it making sure that antags are sure that they actually need this in whatever they want to do, however I've ensured that it is still cheap enough that you can 50. Cal Sniper the Captain's Head through a wall, if you wish.

### Weapons:

**Disguised Syringe Gun:** 10 -> 8TC - This "gun" is more of a gimmick for antagonists than a viable weapon to be used. Lowering the cost of this will make it atleast worth it for minor fun, or as a final choice pick.

**Energy Gun:** 32 -> 24TC - Energy Guns are incredibly abudant on Nerva, with our Boarding Armories and two other smaller ones. This allows traitors to have more weaponry to stun or kill at a cheaper price that still require accessing a recharger in risky areas to recharge.

**Silenced Pistol:** 32 -> 20TC - Silenced Pistols are not commonly used and lack a lot of damage potential. Lowering the price allows them to be more accessible to be used as a reliable secondary, or for the risky a reliable primary weapon. Additionally this would allow for more ammo to be purchased.

**9MM Pistol:** 40 -> 32TC - A non-silenced version of the 9mm that would be far more commonly used if it was cheaper as a backup pistol. This should still be cheap enough that traitors can buy additional ammo if they need to.

**Sawn-Off Shotgun:** 45 -> 40TC - Shotguns themselves are incredibly reliable and useful at close range, but taking a sawn-off still feels like a handicap, due to the two shot load limit. Lowering the price to make this a reliable secondary or primary should lead to more players picking it up as a secondary purchase.

### Services:

**Ion Storm Announcement:** 8 -> 6TC - As we are so used to Captains/FO's flying into Ion Storms, these really aren't that useful, nor reliable as a way to drag attention to the AI, lowering the price of this allows it to be used more in gimmicks, while we are totally desensitized to spirally into meteors and ionic storms.

**Suit Sensor Shutdown:** 40 -> 32TC - Murder is very difficult on Nerva during some rounds due to medical watching sensors like a hawk, lowering the price of this should allow traitors to quickly get the task done without being immediatley jumped upon. I considered lowering this further, however it would conflict with the other suit sensor traitor item.


**Bugs Fixed:**

- Removed Duplicate Smuggler's Satchel on the Uplink Tab.
- Removes Null Text from Chameleon Scanner.

### Feel free to let me know if you think prices should be raised, dropped/anything else. I'm interested in what people think about these changes as a whole. Next up will be adding a bunch of job related traitor gear that people can use for **!!!FUN!!!**

