### PR TITLE
Fixes Deck 1 Medbay Storage APC.

### DIFF
--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -1663,6 +1663,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
+/obj/structure/cable,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/extstorage)
 "dq" = (


### PR DESCRIPTION
### Purpose:
Adds a cable to connect Deck One's Medbay Storage APC to the powergrid, so that the room doesn't power down after 10 minutes. 