### PR TITLE
Updates open space icon updates

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -71,9 +71,9 @@ What is the naming convention for planes or layers?
 
 //Reserve planes for openspace
 #define OPENSPACE_PLANE_START -462
-#define OPENSPACE_PLANE_END -22
+#define OPENSPACE_PLANE_END -24
 #define OPENSPACE_PLANE -463
-#define OVER_OPENSPACE_PLANE -18
+#define OVER_OPENSPACE_PLANE -23
 
 #define OPENSPACE_LAYER_OBJS 2
 #define OPENSPACE_LAYER_MOBS 3

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -97,24 +97,26 @@
 		var/below_is_open = isopenspace(below)
 		if(below_is_open)
 			underlays = below.underlays
-			overlays = below.overlays
+			overlays += below.overlays
 
 		else
 			var/image/bottom_turf = image(icon = below.icon, icon_state = below.icon_state, dir=below.dir, layer=below.layer)
 			bottom_turf.plane = below.plane + src.plane
 			bottom_turf.color = below.color
 			underlays += bottom_turf
-			underlays += below.overlays
-
+			for(var/I in below.overlays)
+				var/image/orig = I // http://www.byond.com/forum/post/982465#comment3242258
+				var/image/copy = image(orig, dir = orig.dir, layer = orig.layer)
+				copy.plane = bottom_turf.plane
+				underlays += copy
 
 		// get objects (not mobs, they are handled by /obj/zshadow)
 		var/list/o_img = list()
 		for(var/obj/O in below)
 			if(O.invisibility) continue // Ignore objects that have any form of invisibility
 			if(O.loc != below) continue // Ignore multi-turf objects not directly below
-			if(abs(O.pixel_y) >= 8 || abs(O.pixel_x) >= 8 && !istype(O, /obj/structure/stairs)) continue // Ignore objects that would be in the wall
-			var/image/temp2 = image(O, dir = O.dir, layer = (OPENSPACE_LAYER_OBJS + (O.plane/100) + below_is_open)) //Need to layer things properly, and stay low enough for the things on top of us
-			temp2.plane = OVER_OPENSPACE_PLANE
+			var/image/temp2 = image(O, dir = O.dir, layer = O.layer)
+			temp2.plane = O.plane + src.plane
 			temp2.color = O.color
 			temp2.overlays += O.overlays
 			// TODO Is pixelx/y needed?


### PR DESCRIPTION
Updates open space's `on_update_icon` code to the last version before the introduction of Z-Mimic.
There's still issues with multi-tile objects, camera rotation (when isn't there), and atmos manifolds which may get their own tickets soon.
Closes #898 Closes #899 Closes #900 Closes #901 Closes #902