### PR TITLE
Disables Extended in Secret/Random Votes.

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -92,7 +92,7 @@ MOD_JOB_TEMPBAN_MAX 1440
 ##
 ## default probablity is 1, increase to make that mode more likely to be picked
 ## set to 0 to disable that mode
-PROBABILITY EXTENDED 1
+PROBABILITY EXTENDED 0
 PROBABILITY TRAITOR 1
 PROBABILITY SPYVSSPY 1
 PROBABILITY WIZARD 1


### PR DESCRIPTION
**Disables the ability to get Extended from a Secret/Random vote.**

As per discussions.
Looks like a simple config change, which was a nice change.
