### PR TITLE
Fixes windows blocking air always

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -141,6 +141,8 @@
 /obj/structure/window/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(istype(mover) && mover.checkpass(PASS_FLAG_GLASS))
 		return 1
+	if(air_group && !anchored)
+		return 1
 	if(is_fulltile())
 		return 0	//full tile window, you can't move into it!
 	if(get_dir(loc, target) & dir)


### PR DESCRIPTION
Breaking full tile windows would cause them to be pushed out onto space, but continue to block air. This would then cause ZAS to never trigger an update for the newly exposed room.