### PR TITLE
Resolve add_antag issues

### DIFF
--- a/code/datums/vote/add_antag.dm
+++ b/code/datums/vote/add_antag.dm
@@ -44,7 +44,7 @@
 /datum/vote/add_antagonist/proc/spawn_antags()
 	var/list/antag_choices = list()
 	for(var/antag_type in result)
-		antag_choices += GLOB.all_antag_types_[antag_type]
+		antag_choices += GLOB.all_antag_types_[GLOB.antag_names_to_ids_[antag_type]]
 	if(SSticker.attempt_late_antag_spawn(antag_choices)) // This takes a while.
 		antag_add_finished = 1
 		if(automatic)

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -12,10 +12,10 @@
 
 	if(isghostmind(player))
 		create_default(player.current)
-	else
-		create_antagonist(player, move_to_spawn, do_not_announce, preserve_appearance, do_not_greet)
-		if(!do_not_equip)
-			equip(player.current)
+
+	create_antagonist(player, move_to_spawn, do_not_announce, preserve_appearance, do_not_greet)
+	if(!do_not_equip)
+		equip(player.current)
 
 	if(player.current)
 		player.current.faction = faction


### PR DESCRIPTION
attempt_late_antag_spawn would previously never get antag datums. Ghosts would have a blank body created, but fail the second round of add_antag due to them already being made antags.