### PR TITLE
Tweaked Verbage

### DIFF
--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -113,7 +113,7 @@
 		if(connected_port)
 			disconnect()
 			to_chat(user, "<span class='notice'>You disconnect \the [src] from the port.</span>")
-			log_and_message_admins("[key_name(user)] has disconnected [src.name] at [get_area(src)] | X[src.x] Y[src.y] Z[src.z].")
+			log_and_message_admins("has disconnected [src.name] at [get_area(src)] | X[src.x] Y[src.y] Z[src.z].")
 			update_icon()
 			return
 		else
@@ -121,7 +121,7 @@
 			if(possible_port)
 				if(connect(possible_port))
 					to_chat(user, "<span class='notice'>You connect \the [src] to the port.</span>")
-					log_and_message_admins("[key_name(user)] has connected [src.name] at [get_area(src)] | X[src.x] Y[src.y] Z[src.z].")
+					log_and_message_admins("has connected [src.name] at [get_area(src)] | X[src.x] Y[src.y] Z[src.z].")
 					update_icon()
 					return
 				else


### PR DESCRIPTION
_Very_ minor gripe. **log_and_message_admins** proc already contains **key_name(user)**, currently this produces duplicated key logging in chat and the server logs.