### PR TITLE
Adds additional toolbelt acceptable items.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -129,7 +129,6 @@
 		/obj/item/weapon/hand_labeler,
 		/obj/item/clothing/gloves,
 		/obj/item/device/geiger,
-		/obj/item/device/multitool/hacktool, // Tator Multitool.
 		/obj/item/device/floor_painter,
 		/obj/item/weapon/circuitboard
 		)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -127,7 +127,11 @@
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/weapon/marshalling_wand,
 		/obj/item/weapon/hand_labeler,
-		/obj/item/clothing/gloves
+		/obj/item/clothing/gloves,
+		/obj/item/device/geiger,
+		/obj/item/device/multitool/hacktool, // Tator Multitool.
+		/obj/item/device/floor_painter,
+		/obj/item/weapon/circuitboard
 		)
 
 
@@ -313,7 +317,9 @@
 		/obj/item/clothing/gloves,
 		/obj/item/device/assembly/mousetrap,
 		/obj/item/weapon/crowbar/prybar,
-		/obj/item/clothing/mask/plunger
+		/obj/item/weapon/crowbar,
+		/obj/item/clothing/mask/plunger,
+		/obj/item/taperoll
 		)
 
 /obj/item/weapon/storage/belt/holster/general
@@ -406,7 +412,9 @@
 		/obj/item/weapon/pinpointer/radio,
 		/obj/item/device/taperecorder,
 		/obj/item/device/tape,
-		/obj/item/device/analyzer
+		/obj/item/device/analyzer,
+		/obj/item/taperoll,
+		/obj/item/clothing/gloves
 		)
 	can_holster = list(/obj/item/weapon/material/hatchet/machete)
 	sound_in = 'sound/effects/holster/sheathin.ogg'

--- a/code/modules/urist/items/clothes/belt.dm
+++ b/code/modules/urist/items/clothes/belt.dm
@@ -20,7 +20,11 @@
  	/obj/item/stack/cable_coil,
  	/obj/item/device/analyzer,
  	/obj/item/device/mmi,
-	/obj/item/device/integrated_electronics
+	/obj/item/device/integrated_electronics,
+	/obj/item/device/multitool/hacktool, // Tator Multitool.
+	/obj/item/clothing/gloves,
+	/obj/item/weapon/hand_labeler,
+	/obj/item/taperoll
  	)
 
 /obj/item/weapon/storage/belt/robotics/full/New()

--- a/code/modules/urist/items/clothes/belt.dm
+++ b/code/modules/urist/items/clothes/belt.dm
@@ -21,7 +21,6 @@
  	/obj/item/device/analyzer,
  	/obj/item/device/mmi,
 	/obj/item/device/integrated_electronics,
-	/obj/item/device/multitool/hacktool, // Tator Multitool.
 	/obj/item/clothing/gloves,
 	/obj/item/weapon/hand_labeler,
 	/obj/item/taperoll


### PR DESCRIPTION
# Adjusts certain items to fit normally in toolbelts.

## Normal/Engineering Toolbelt - 

-  Geiger Counter
- Multitool (Hacktool Version)
- Floor Painter
- Circuit Boards (I.E - Door Controls, Etc.)

## Janitor Toolbelt - 

- Tape Roll/Duct Tape
- Crowbars

## Roboticist Belt

- Multitool (Hack Tool)
- Gloves
- Hand Labeller
- Tape Roll/Duct Tape
