### PR TITLE
Fixed hand teleporter

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -566,7 +566,7 @@
 /obj/item/integrated_circuit/manipulation/bluespace_rift/do_work()
 	var/obj/machinery/computer/teleporter/tporter = get_pin_data_as_type(IC_INPUT, 1, /obj/machinery/computer/teleporter)
 	var/step_dir = get_pin_data(IC_INPUT, 2)
-	if(!(get(z) in GetConnectedZlevels(get_z(tporter))))
+	if(!(get_z(src) in GetConnectedZlevels(get_z(tporter))))
 		tporter = null
 
 	var/turf/rift_location = get_turf(src)


### PR DESCRIPTION
Fixes an issue with the hand teleporter and z-level checking, causing the hand teleporter to not lock onto the target but teleport you randomly nearby instead.