### PR TITLE
Make Mentors Useful Again

### DIFF
--- a/code/__defines/admin.dm
+++ b/code/__defines/admin.dm
@@ -33,6 +33,7 @@
 #define R_SOUNDS        0x800
 #define R_SPAWN         0x1000
 #define R_MOD           0x2000
+#define R_MENTOR        0x4000
 #define R_HOST          0x8000 //higher than this will overflow
 #define R_INVESTIGATE   (R_ADMIN|R_MOD)
 

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -159,6 +159,7 @@
 	if (rights & R_SOUNDS)      . += "[seperator]+SOUND"
 	if (rights & R_SPAWN)       . += "[seperator]+SPAWN"
 	if (rights & R_MOD)         . += "[seperator]+MODERATOR"
+	if (rights & R_MENTOR)		. += "[seperator]+MENTOR"
 	return .
 
 // heat2color functions. Adapted from: http://www.tannerhelland.com/4435/convert-temperature-rgb-algorithm-code/

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -14,7 +14,7 @@ var/global/floorIsLava = 0
 	msg = "<span class=\"log_message\"><span class=\"prefix\">STAFF LOG:</span> <span class=\"message\">[msg]</span></span>"
 	log_adminwarn(msg)
 	for(var/client/C in GLOB.admins)
-		if(C && C.holder && (R_INVESTIGATE & C.holder.rights))
+		if(check_rights(R_INVESTIGATE|R_MENTOR, 0, C))
 			to_chat(C, msg)
 /proc/msg_admin_attack(var/text) //Toggleable Attack Messages
 	log_attack(text)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -41,6 +41,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 				if("sound","sounds")			rights |= R_SOUNDS
 				if("spawn","create")			rights |= R_SPAWN
 				if("mod")						rights |= R_MOD
+				if("mentor")					rights |= R_MENTOR
 
 		admin_ranks[rank] = rights
 		previous_rights = rights

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -332,6 +332,24 @@ var/list/admin_verbs_mod = list(
 	/datum/admins/proc/view_persistent_data
 )
 
+var/list/admin_verbs_mentor = list(
+	/client/proc/cmd_admin_pm_context,
+	/client/proc/cmd_admin_pm_panel,
+	/client/proc/admin_ghost,
+	/client/proc/cmd_admin_subtle_message,
+	/client/proc/cmd_admin_check_contents,
+	/client/proc/cmd_mod_say,
+	/client/proc/dsay,
+	/client/proc/debug_variables,
+	/datum/admins/proc/show_player_info,
+	/datum/admins/proc/show_player_panel,
+	/client/proc/player_panel_new,
+	/client/proc/check_antagonists,
+	/client/verb/aooc,
+	/client/proc/jumptomob,
+	/client/proc/jumptokey
+)
+
 /client/proc/add_admin_verbs()
 	if(holder)
 		verbs += admin_verbs_default
@@ -352,6 +370,7 @@ var/list/admin_verbs_mod = list(
 		if(holder.rights & R_SPAWN)			verbs += admin_verbs_spawn
 		if(holder.rights & R_MOD)			verbs += admin_verbs_mod
 		if(holder.rights & R_ADMIN)			verbs += admin_verbs_poll
+		if(holder.rights & R_MENTOR)		verbs += admin_verbs_mentor
 
 /client/proc/remove_admin_verbs()
 	verbs.Remove(

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1244,7 +1244,7 @@
 		show_player_panel(M)
 
 	else if(href_list["adminplayerobservejump"])
-		if(!check_rights(R_MOD|R_ADMIN))	return
+		if(!check_rights(R_MOD|R_ADMIN|R_MENTOR))	return
 
 		var/mob/M = locate(href_list["adminplayerobservejump"])
 		var/client/C = usr.client
@@ -1257,7 +1257,7 @@
 		C.jumptomob(M)
 
 	else if(href_list["adminplayerobservefollow"])
-		if(!check_rights(R_MOD|R_ADMIN))
+		if(!check_rights(R_MOD|R_ADMIN|R_MENTOR))
 			return
 
 		var/mob/M = locate(href_list["adminplayerobservefollow"])
@@ -1282,7 +1282,7 @@
 		if(ismob(M))
 			var/take_msg = "<span class='notice'><b>[key_name(usr.client)]</b> is attending to <b>[key_name(M)]'s</b> message.</span>"
 			for(var/client/X in GLOB.admins)
-				if((R_ADMIN|R_MOD) & X.holder.rights)
+				if((R_ADMIN|R_MOD|R_MENTOR) & X.holder.rights)
 					to_chat(X, take_msg)
 			to_chat(M, "<span class='notice'><b>Your message is being attended to by [usr.client]. Thanks for your patience!</b></span>")
 		else
@@ -1543,7 +1543,7 @@
 		usr.client.cmd_admin_direct_narrate(M)
 
 	else if(href_list["subtlemessage"])
-		if(!check_rights(R_MOD,0) && !check_rights(R_ADMIN))  return
+		if(!check_rights(R_MOD|R_MENTOR,0) && !check_rights(R_ADMIN))  return
 
 		var/mob/M = locate(href_list["subtlemessage"])
 		usr.client.cmd_admin_subtle_message(M)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -119,7 +119,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	var/admin_number_afk = 0
 
 	for(var/client/X in GLOB.admins)
-		if((R_ADMIN|R_MOD) & X.holder.rights)
+		if((R_ADMIN|R_MOD|R_MENTOR) & X.holder.rights)
 			if(X.is_afk())
 				admin_number_afk++
 			if(X.get_preference_value(/datum/client_preference/staff/play_adminhelp_ping) == GLOB.PREF_HEAR)

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -36,7 +36,7 @@
 	set category = "Admin"
 	set name = "Jump to Mob"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_MENTOR))
 		return
 
 	if(config.allow_admin_jump)
@@ -79,7 +79,7 @@
 	set category = "Admin"
 	set name = "Jump to Key"
 
-	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
+	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_MENTOR))
 		return
 
 	if(config.allow_admin_jump)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -156,7 +156,7 @@
 		//check client/X is an admin and isn't the sender or recipient
 		if(X == C || X == src)
 			continue
-		if(X.key != key && X.key != C.key && (X.holder.rights & R_ADMIN|R_MOD))
+		if(X.key != key && X.key != C.key && (X.holder.rights & R_ADMIN|R_MOD|R_MENTOR))
 			to_chat(X, "<span class='pm'><span class='other'>" + create_text_tag("pm_other", "PM:", X) + " <span class='name'>[key_name(src, X, 0, ticket)]</span> to <span class='name'>[key_name(C, X, 0, ticket)]</span> (<a href='?_src_=holder;take_ticket=\ref[ticket]'>[(ticket.status == TICKET_OPEN) ? "TAKE" : "JOIN"]</a>) (<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>): <span class='message'>[msg]</span></span></span>")
 
 /client/proc/cmd_admin_irc_pm(sender)
@@ -183,5 +183,5 @@
 	for(var/client/X in GLOB.admins)
 		if(X == src)
 			continue
-		if(X.holder.rights & R_ADMIN|R_MOD)
+		if(X.holder.rights & R_ADMIN|R_MOD|R_MENTOR)
 			to_chat(X, "<span class='pm'><span class='other'>" + create_text_tag("pm_other", "PM:", X) + " <span class='name'>[key_name(src, X, 0)]</span> to <span class='name'>[sender]</span>: <span class='message'>[msg]</span></span></span>")

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -21,7 +21,7 @@
 	set name = "Msay"
 	set hidden = 1
 
-	if(!check_rights(R_ADMIN|R_MOD))
+	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))
 		return
 
 	msg = sanitize(msg)


### PR DESCRIPTION
Re-added Mentors, finally.
If any permissions are missing or wonky, please do let me know as permission/rank handling in baycode is inconsistent at best and hard to test with just 1 alt. Though as far as I could test it all works.

Current perms:

- AdminPMs
- aghost
- Subtlemessage
- Check contents
- VV (No edit)
- PP
- msay
- dsay
- aooc
- Check antagonists
- jmp to mob/key