### PR TITLE
Bringing social media back to the station

### DIFF
--- a/nano/templates/email_client.tmpl
+++ b/nano/templates/email_client.tmpl
@@ -5,29 +5,35 @@
 		<p>Downloading attachment...</p>
 		<div class="item">
 		<div class="itemLabel">
-			File name: 
+			File name:
 		</div>
 		<div class="itemContent">
 			{{:data.down_filename}}&nbsp
 		</div>
 		<div class="itemLabel">
-			Progress: 
+			Progress:
 		</div>
 		<div class="itemContent">
 			{{:helper.displayBar(data.down_progress, 0, data.down_size)}} {{:data.down_progress}} / {{:data.down_size}} GQ
 		</div>
 		<div class="itemLabel">
-			Download rate: 
+			Download rate:
 		</div>
 		<div class="itemContent">
 			{{:data.down_speed}} GQ/s&nbsp
-		</div>		
+		</div>
 	</div>
 	{{:helper.link('Cancel Download', null, {'canceldownload' : 1})}}
 {{else data.current_account}}
 	<b>Welcome to your account, {{:data.current_account}}</b><br>
-	{{:helper.link('New Message', 'mail-closed', {'new_message' : 1})}}
+	{{:helper.link('New Message', 'mail-closed', {'addressbook' : 1})}}
 	{{:helper.link('Change Password', 'locked', {'changepassword' : 1})}}
+	{{:helper.link('Set notification', 'alert', {'set_notification' : 1})}}
+	{{if data.notification_mute}}
+		{{:helper.link('Unmute', 'volume-on', {'mute' : 1})}}
+	{{else}}
+		{{:helper.link('Mute', 'volume-off', {'mute' : 1})}}
+	{{/if}}
 	{{:helper.link('Log Out', 'key', {'logout' : 1})}}<br><br>
 	{{if data.addressbook}}
 		{{:helper.link('Back', null, {'close_addressbook' : 1})}}
@@ -36,67 +42,11 @@
 		<table>
 		<tr><td>Address book:
 		{{for data.accounts}}
-			<tr class="candystripe"><td>{{:helper.link(value.login, null, {'set_recipient' : value.login})}}
+			<tr class="candystripe"><td>{{:value.name}}<td>{{:value.job}}<td>{{:helper.link(value.login, null, {'send' : value.login})}}
 		{{/for}}
 		</table>
-	{{else data.new_message}}
-		<div class="item">
-			<div class="itemLabel">
-				{{:helper.link('', 'pencil', {'edit_title' : 1})}} Title: 
-			</div>
-			<div class="itemContent">
-				<div class="statusDisplayComm" style="width:100%;min-height:1.7em;padding-bottom: 0;">
-					{{:data.msg_title}}
-				</div>
-			</div>
-		</div>
-		<div class="item">
-			<div class="itemLabel">
-				{{:helper.link('', 'plusthick', {'addressbook' : 1})}} Recipient:
-			</div>
-			<div class="itemContent">
-				<div class="statusDisplayComm" style="width:100%;min-height:1.7em;padding-bottom: 0;">
-					{{:data.msg_recipient}}
-				</div>
-			</div>
-		</div>
-		<div class="item">
-			<div class="itemLabel">
-				{{:helper.link('','pencil', {'edit_body' : 1})}} Message:
-			</div>
-			<div class="itemContent">
-				<div class="statusDisplayComm" style="width:100%;min-height:1.7em;padding-bottom: 0;">
-					{{:data.msg_body}}
-				</div>
-			</div>
-		</div>
-			{{if data.msg_hasattachment}}
-				<div class="item">
-					<div class="itemLabel">
-						Attachment:
-					</div>
-					<div class="itemContent">
-						{{:data.msg_attachment_filename}} ({{:data.msg_attachment_size}}GQ)
-					</div>
-				</div>
-			{{/if}}
-			<div class="itemContent">
-				{{:helper.link('Add attachment', null, {'addattachment' : 1})}}
-				{{if data.msg_hasattachment}}
-					{{:helper.link('Remove attachment', null, {'remove_attachment' : 1})}}
-				{{/if}}
-				{{:helper.link('Send', null, {'send' : 1})}}
-				{{:helper.link('Cancel', null, {'cancel' : 1})}}
-			</div>
-		</div>
 	{{else data.cur_title}}
 		<div class="item">
-			<div class="itemLabel">
-				Title: 
-			</div>
-			<div class="itemContent">
-				{{:data.cur_title}}&nbsp
-			</div>
 			<div class="itemLabel">
 				Origin:
 			</div>
@@ -115,14 +65,6 @@
 			<div class="itemContent">
 				{{:data.cur_body}}&nbsp
 			</div>
-			{{if data.cur_hasattachment}}
-				<div class="itemLabel">
-					Attachment:
-				</div>
-				<div class="itemContent">
-					{{:data.cur_attachment_filename}} ({{:data.cur_attachment_size}}GQ)
-				</div>
-			{{/if}}
 			<div class="itemLabel">
 				Options:
 			</div>
@@ -130,12 +72,9 @@
 				{{:helper.link('Reply', null, {'reply' : data.cur_uid})}}
 				{{:helper.link('Delete', null, {'delete' : data.cur_uid})}}
 				{{:helper.link('Close', null, {'cancel' : data.cur_uid})}}
-				{{:helper.link('Save to Disk', null, {'cancel' : data.cur_uid})}}
-				{{if data.cur_hasattachment}}
-					{{:helper.link('Save Attachment', null, {'downloadattachment' : 1})}}
-				{{/if}}
+				{{:helper.link('Save to Disk', null, {'save' : data.cur_uid})}}
 			</div>
-		</div>		
+		</div>
 	{{else}}
 		{{:helper.link('Inbox', 'mail-closed', {'set_folder' : 'Inbox'}, data.folder == 'Inbox' ? 'selected' : null)}}
 		{{:helper.link('Sent', 'arrowreturnthick-1-w', {'set_folder' : 'Sent'}, data.folder == 'Sent' ? 'selected' : null)}}
@@ -146,14 +85,12 @@
 			<table>
 				<tr>
 					<th>Source</th>
-					<th>Title</th>
-					<th>{{:data.at_prefix}}</th>
+					<th>Received at</th>
 					<th></th>
 				</tr>
 				{{for data.messages}}
 					<tr class="candystripe">
 						<td>{{:value.source}}&nbsp</td>
-						<td>{{:value.title}}&nbsp</td>
 						<td>{{:value.timestamp}}&nbsp</td>
 						<td>
 							{{:helper.link('', 'trash', {'delete' : value.uid})}}
@@ -168,7 +105,7 @@
 		{{/if}}
 	{{/if}}
 {{else}}
-	<b>Welcome to NTNet Email System. Please log in.</b>
+	<b>Welcome to Messenger System. Please log in.</b>
 	<div class="item">
 		<div class="itemLabel">
 			Email address:


### PR DESCRIPTION
Makes several changes to the email client to make it more similar to the old PDA messenger system. Overall streamlines the client, making sending messages faster with less hassle and button presses and will hopefully once again encourage people to use their PDAs to speed text when being held at gunpoint.

Main changes:

- Completely changes the "New Message" functionality, previously to send an email you had to fill out three fields separately, the Title/Subject, the Recipient, and the message body itself
- Now when selecting "New Message" you are immediately brought to the address book with all of the crewmembers listed. Selecting any of their names will open up the message prompt box, and after you hit ok after typing in your message the message immediately sends. Exactly like the old PDA system, fast and only needs 2 button clicks right to the point.
- Reply functionality is also greatly improved as well. Previously, replying would bring you right back to the new message screen and you would have to click again to fill out the message. Now, you just hit Reply when seeing the notification, and the new message prompt box pops up immediately. You type in your message, press ok and it's sent. For speedy texting on the go.
- Notification message has been changed slightly. Removes the noise of titles (since they are gone anyways) and bolds who is sending you the message so it stands out more.
- Still keeps the same new system with the modular computers and programs. All this changes do is change the overall look and functionality of the Email Client program to encourage it's use among the crew. Now it's basically old PDAs with the new nano UI.
