### PR TITLE
The retirement home has called v2.0

### DIFF
--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -30,6 +30,7 @@
 Admin Observer
 Retired Admin		+MOD +ADMIN +VAREDIT
 Moderator		+MOD +ADMIN
+Retired Moderator	+MENTOR
 Admin Candidate		+ADMIN
 Trial Admin		+@ +SPAWN +REJUV +VAREDIT +BAN
 Badmin			+@ +POSSESS +BUILDMODE +SERVER +FUN

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -17,6 +17,7 @@ Scrdest - Coder
 
 AseaHeru - Mentor
 Mapleguy555 - Mentor
+Lance77am - Mentor
 Mentor_Knight - Mentor
 
 laniakeaa - Admin Observer

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -6,32 +6,32 @@
 ######################################################################
 
 glloyd - Head Admin
-Stefender - Game Master
+
 Lady_Blanc - Game Master
 MisterPaper - Game Master
 Gale212 - Game Master
 
-Scrdest - Coder
+hanspanda - Trial Admin
 
-Vakothu - Dev Mod
-Licton15 - Moderator
-laniakeaa - Moderator
+Scrdest - Coder
 
 AseaHeru - Mentor
 Mapleguy555 - Mentor
-Lance77am - Mentor
 Mentor_Knight - Mentor
 
-Irrationalist - Retired Admin
+laniakeaa - Admin Observer
+Licton15 - Admin Observer
 CoraiUnki - Inactive Admin
 Acemuto10 - Inactive Admin
 Wommy - Inactive Admin
-hanspanda - Inactive Admin
 Kydrasz - Inactive Admin
 MisterTeeth - Inactive Admin
 Zty8212000 - Inactive Admin
 Capesh - Inactive Admin
+Vakothu - Retired Admin
 Nienhaus2 - Retired Admin
 MrBarman - Retired Admin
 Lyeos - Retired Admin
+Stefender - Retired Admin
+Irrationalist - Retired Admin
 #Electronics

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -20,8 +20,8 @@ Mapleguy555 - Mentor
 Lance77am - Mentor
 Mentor_Knight - Mentor
 
-laniakeaa - Admin Observer
-Licton15 - Admin Observer
+laniakeaa - Retired Moderator
+Licton15 - Retired Moderator
 CoraiUnki - Inactive Admin
 Acemuto10 - Inactive Admin
 Wommy - Inactive Admin


### PR DESCRIPTION
As the staff list is currently horribly out-of-date, this should hopefully cover the changes and bring everything to match roles in Discord.

Wasn't sure what to do with moderators who have retired, as Retired Admin would actually grant them _more_ rights. Stuck them in observers for now.