### PR TITLE
Space Combat Expansion Part 1: The Fuckening Part 2 - Revengeance

### DIFF
--- a/code/modules/urist/modules/newtrading/trade/trade_items/organs.dm
+++ b/code/modules/urist/modules/newtrading/trade/trade_items/organs.dm
@@ -86,4 +86,4 @@
 	item_type = /obj/item/organ/internal/stack
 	category = "organs"
 	quantity = 1
-	value = 600
+	value = 800

--- a/code/modules/urist/modules/shipbattles/overmapships/components/component_weapons.dm
+++ b/code/modules/urist/modules/shipbattles/overmapships/components/component_weapons.dm
@@ -16,29 +16,30 @@
 	if(ready && !broken)
 		Fire()
 
-/datum/shipcomponents/weapons/proc/Fire() //now infinitely less hacky and broken
+/datum/shipcomponents/weapons/proc/Fire(var/obj/effect/urist/projectile_landmark/ship/map_landmark) //now infinitely less hacky and broken
 	if(broken) //check one more time, just in case. doing it this way can stop burst fire mid burst
 		return
 
 	else
-		var/obj/effect/urist/projectile_landmark/ship/P = pick(GLOB.ship_projectile_landmarks)
+		if(!map_landmark)
+			map_landmark = pick(GLOB.ship_projectile_landmarks)
 
 		if(burst)
-			if(P)
+			if(map_landmark)
 				ready = FALSE
 				if(shot_number < burst)
 					shot_number ++
-					P.Fire(projectile_type)
+					map_landmark.Fire(projectile_type)
 					spawn(burst_delay)
-						Fire()
+						Fire(map_landmark) //doing this so we fire from the same landmark. this gets us sustained fire on parts of the ship instead of the random scatter we have now.
 
 				else if(shot_number >= burst)
 					spawn(firedelay)
 						shot_number = 0
 						ready = TRUE
 		else
-			if(P)
-				P.Fire(projectile_type)
+			if(map_landmark)
+				map_landmark.Fire(projectile_type)
 				ready = FALSE
 				spawn(firedelay)
 					ready = TRUE
@@ -55,60 +56,55 @@
 
 /datum/shipcomponents/weapons/ioncannon
 	name = "ion cannon"
-	firedelay = 12 SECONDS
+	firedelay = 14 SECONDS
 	projectile_type = /obj/item/projectile/ion/ship
 	weapon_type = /obj/machinery/shipweapons/beam/ion
-
-/datum/shipcomponents/weapons/ioncannon/dual
-	name = "dual ion cannon"
-	firedelay = 20 SECONDS
 	burst = 2
 
 /datum/shipcomponents/weapons/ioncannon/heavy
 	name = "heavy ion cannon"
 	firedelay = 22 SECONDS
 	projectile_type = /obj/item/projectile/ion/ship/heavy
+	burst = 2
 
 /datum/shipcomponents/weapons/autocannon
 	name = "autocannon"
 	firedelay = 16 SECONDS
 	projectile_type = /obj/item/projectile/bullet/ship/cannon
-	burst = 5
+	burst = 7
 
 /datum/shipcomponents/weapons/smallmissile
 	name = "small missile launcher"
 	projectile_type = /obj/item/projectile/bullet/ship/missile/smallmissile
 	firedelay = 20 SECONDS
+	burst = 2
 
 /datum/shipcomponents/weapons/smallmissile/battery
 	name = "small missile battery"
-	burst = 3
+	burst = 4
 	firedelay = 40 SECONDS
 
 /datum/shipcomponents/weapons/smallalienmissile
 	name = "small alien missile launcher"
 	projectile_type = /obj/item/projectile/bullet/ship/missile/smallalienmissile
 	firedelay = 26 SECONDS
-
-/datum/shipcomponents/weapons/smallalienmissile/dual
-	name = "small alien dual missile launcher"
-	firedelay = 32 SECONDS
 	burst = 2
 
 /datum/shipcomponents/weapons/smallalienmissile/battery
 	name = "small alien missile battery"
 	firedelay = 38 SECONDS
-	burst = 3
+	burst = 4
 
 /datum/shipcomponents/weapons/bigmissile
 	name = "large missile launcher"
 	projectile_type = /obj/item/projectile/bullet/ship/missile/bigmissile
 	firedelay = 30 SECONDS
+	burst = 2
 
 /datum/shipcomponents/weapons/bigmissile/battery
 	name = "large missile battery"
 	firedelay = 50 SECONDS
-	burst = 3
+	burst = 4
 
 /datum/shipcomponents/weapons/bigalienmissile
 	name = "large alien missile launcher"
@@ -148,7 +144,7 @@
 /datum/shipcomponents/weapons/lightlaser/auto
 	name = "light laser autocannon"
 	firedelay = 18 SECONDS
-	burst = 4
+	burst = 5
 	weapon_type = /obj/machinery/shipweapons/beam/rapidlightlaser
 
 /datum/shipcomponents/weapons/heavylaser
@@ -165,7 +161,7 @@
 /datum/shipcomponents/weapons/heavylaser/auto
 	name = "heavy laser autocannon"
 	firedelay = 30 SECONDS
-	burst = 3
+	burst = 4
 
 /datum/shipcomponents/weapons/pulse
 	name = "pulse cannon"
@@ -174,18 +170,26 @@
 	weapon_type = /obj/machinery/shipweapons/beam/lightpulse
 	burst = 3
 
+/datum/shipcomponents/weapons/pulse/rapid
+	name = "multi-phasic pulse cannon"
+	firedelay = 26 SECONDS
+	projectile_type = /obj/item/projectile/beam/ship/pulse/light
+	weapon_type = /obj/machinery/shipweapons/beam/lightpulse
+	burst = 5
+
 /datum/shipcomponents/weapons/pulse/heavy
 	name = "heavy pulse cannon"
-	firedelay = 30 SECONDS
+	firedelay = 32 SECONDS
 	projectile_type = /obj/item/projectile/beam/ship/pulse/heavy
 	weapon_type = /obj/machinery/shipweapons/beam/heavypulse
+	burst = 3
 
 //alien
 
 /datum/shipcomponents/weapons/alien/light
 	name = "alien rapid-fire beam cannon"
 	firedelay = 22 SECONDS
-	burst = 5
+	burst = 6
 	projectile_type = /obj/item/projectile/beam/ship/alien/light
 
 /datum/shipcomponents/weapons/alien/heavy
@@ -197,5 +201,5 @@
 /datum/shipcomponents/weapons/alien/heavy/burst
 	name = "alien rapid-fire heavy beam cannon"
 	firedelay = 36 SECONDS
-	burst = 3
+	burst = 5
 	projectile_type = /obj/item/projectile/beam/ship/alien/heavy

--- a/code/modules/urist/modules/shipbattles/overmapships/components/components.dm
+++ b/code/modules/urist/modules/shipbattles/overmapships/components/components.dm
@@ -55,14 +55,14 @@
 
 /datum/shipcomponents/shield/light
 	name = "light shield"
-	strength = 800
+	strength = 850
 	health = 200
 	recharge_rate = 80
 	recharge_delay = 10 SECONDS
 
 /datum/shipcomponents/shield/medium
 	name = "medium shield"
-	strength = 1200
+	strength = 1300
 	health = 400
 	recharge_rate = 70
 	recharge_delay = 10 SECONDS
@@ -83,14 +83,14 @@
 
 /datum/shipcomponents/shield/alien_light
 	name = "light alien shield"
-	strength = 200
+	strength = 300
 	health = 200
 	recharge_rate = 60
 	recharge_delay = 5 SECONDS
 
 /datum/shipcomponents/shield/alien_heavy
 	name = "heavy alien shield"
-	strength = 500
+	strength = 600
 	health = 200
 	recharge_rate = 60
 	recharge_delay = 8 SECONDS

--- a/code/modules/urist/modules/shipbattles/overmapships/hostile_ships.dm
+++ b/code/modules/urist/modules/shipbattles/overmapships/hostile_ships.dm
@@ -13,23 +13,21 @@
 	ship_category = "small pirate ship"
 	boardingmap = "maps/shipmaps/ship_pirate_small1.dmm"
 	can_board = TRUE
+	potential_weapons = list(/datum/shipcomponents/weapons/autocannon, /datum/shipcomponents/weapons/lightlaser/auto, /datum/shipcomponents/weapons/heavylaser, /datum/shipcomponents/weapons/pulse)
 
-/mob/living/simple_animal/hostile/overmapship/pirate/small/New()
+/mob/living/simple_animal/hostile/overmapship/pirate/small/Initialize()
 	components = list(
 		new /datum/shipcomponents/shield/light,
 		new /datum/shipcomponents/engines/standard,
 		new /datum/shipcomponents/weapons/smallmissile,
-		new /datum/shipcomponents/weapons/lightlaser,
+		new /datum/shipcomponents/weapons/lightlaser/auto,
 		new /datum/shipcomponents/teleporter/pirate/small
 	)
 
-	if(prob(50))
-		components += new /datum/shipcomponents/weapons/autocannon
+	add_weapons()
+	add_weapons()
 
-	else
-		components += new /datum/shipcomponents/weapons/lightlaser/auto
-
-	..()
+	.=..()
 
 /mob/living/simple_animal/hostile/overmapship/pirate/med
 //	shipdatum = /datum/ships/piratesmall
@@ -40,20 +38,25 @@
 	ship_category = "medium pirate vessel"
 	boardingmap = "maps/shipmaps/ship_pirate_small1.dmm"
 	can_board = TRUE
+	potential_weapons = list(/datum/shipcomponents/weapons/pulse/rapid, /datum/shipcomponents/weapons/smalltorpedo, /datum/shipcomponents/weapons/heavylaser/auto, /datum/shipcomponents/weapons/bigmissile, /datum/shipcomponents/weapons/heavylaser/dual)
 
-/mob/living/simple_animal/hostile/overmapship/pirate/med/New()
+/mob/living/simple_animal/hostile/overmapship/pirate/med/Initialize()
 	components = list(
 		new /datum/shipcomponents/shield/medium,
 		new /datum/shipcomponents/engines/standard,
 		new /datum/shipcomponents/weapons/smallmissile/battery,
 		new /datum/shipcomponents/weapons/heavylaser,
-		new /datum/shipcomponents/weapons/heavylaser,
+		new /datum/shipcomponents/weapons/ioncannon,
 		new /datum/shipcomponents/weapons/autocannon,
 		new /datum/shipcomponents/point_defence/basic,
+		new /datum/shipcomponents/shield_disruptor,
 		new /datum/shipcomponents/teleporter/pirate
 	)
 
-	..()
+	add_weapons()
+	add_weapons()
+
+	.=..()
 
 /mob/living/simple_animal/hostile/overmapship/alien
 	wander = 1
@@ -64,7 +67,7 @@
 	designation = ""
 
 /mob/living/simple_animal/hostile/overmapship/alien/small
-	shields = 200 //really weak, but fast charging shields
+	shields = 250 //really weak, but fast charging shields
 	health = 1200 //and beefy hulls
 	maxHealth = 1200
 	ship_category = "Lactera fast attack craft"
@@ -81,6 +84,7 @@
 		new /datum/shipcomponents/weapons/smallalienmissile,
 		new /datum/shipcomponents/weapons/smallalienmissile,
 		new /datum/shipcomponents/point_defence/alienlight,
+		new /datum/shipcomponents/shield_disruptor,
 		new /datum/shipcomponents/teleporter/alien/small
 	)
 
@@ -104,8 +108,10 @@
 		new /datum/shipcomponents/weapons/bigalienmissile,
 		new /datum/shipcomponents/weapons/bigalienmissile,
 		new /datum/shipcomponents/weapons/smallalienmissile/battery,
+		new /datum/shipcomponents/weapons/smallalienmissile/battery,
 		new /datum/shipcomponents/weapons/alientorpedo,
 		new /datum/shipcomponents/point_defence/alienstandard,
+		new /datum/shipcomponents/shield_disruptor/overcharge,
 		new /datum/shipcomponents/teleporter/alien
 	)
 

--- a/code/modules/urist/modules/shipbattles/overmapships/overmapships.dm
+++ b/code/modules/urist/modules/shipbattles/overmapships/overmapships.dm
@@ -30,6 +30,7 @@
 	var/map_spawned = FALSE //have we spawned our boardingmap
 	turns_per_move = 10 //make this influenced by the engine on a ship
 	autonomous = TRUE
+	var/potential_weapons = list()
 
 /mob/living/simple_animal/hostile/overmapship/Initialize()
 	.=..()
@@ -169,3 +170,7 @@
 
 	for(var/obj/effect/urist/triggers/ai_defender_landmark/A in GLOB.trigger_landmarks)
 		A.spawn_mobs()
+
+/mob/living/simple_animal/hostile/overmapship/proc/add_weapons()
+	var/datum/shipcomponents/weapons/W = pick(potential_weapons)
+	components += new W

--- a/code/modules/urist/modules/shipbattles/shipweapons/ship_projectiles.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/ship_projectiles.dm
@@ -17,7 +17,7 @@
 
 /obj/item/projectile/ion/ship/heavy
 	heavy_effect_range = 8
-	light_effect_range = 12
+	light_effect_range = 16
 	ship = 1
 	kill_count = 300
 
@@ -30,7 +30,7 @@
 	name ="autocannon shell"
 	icon = 'icons/urist/items/ship_projectiles.dmi'
 	icon_state= "cannon"
-	damage = 200
+	damage = 600
 	check_armour = "bullet"
 	sharp = 1
 	edge = 1
@@ -43,7 +43,7 @@
 
 /obj/item/projectile/bullet/ship/cannon/on_impact(var/atom/A)
 	if(isturf(A))
-		A.ex_act(2)
+		explosion(A, -1, 0, 2, 0, 0)
 
 	..()
 
@@ -77,7 +77,7 @@
 
 		W.dismantle_wall(1)
 
-	explosion(location, ex_devestation, ex_heavy, ex_light)
+	explosion(location, ex_devestation, ex_heavy, ex_light, 0, 0)
 
 /obj/item/projectile/bullet/ship/missile/smallmissile
 	name = "small missile"
@@ -87,17 +87,18 @@
 	shake_range = 15
 	ex_devestation = 0
 	ex_heavy = 2
-	ex_light = 5
+	ex_light = 6
 
 /obj/item/projectile/bullet/ship/missile/smallalienmissile
 	name = "small alien missile"
 	icon = 'icons/urist/items/ship_projectiles.dmi'
 	icon_state= "smallalienmissile"
+	wall_decon = TRUE
 	damage = 150
 	shake_range = 20
 	ex_devestation = 0
 	ex_heavy = 3
-	ex_light = 6
+	ex_light = 7
 
 /obj/item/projectile/bullet/ship/missile/bigmissile
 	name = "big missile"
@@ -107,8 +108,8 @@
 	shake_range = 25
 	wall_decon = TRUE
 	ex_devestation = 1
-	ex_heavy = 3
-	ex_light = 8
+	ex_heavy = 4
+	ex_light = 9
 
 /obj/item/projectile/bullet/ship/missile/bigalienmissile
 	name = "big alien missile"
@@ -118,8 +119,8 @@
 	shake_range = 30
 	wall_decon = TRUE
 	ex_devestation = 1
-	ex_heavy = 4
-	ex_light = 9
+	ex_heavy = 5
+	ex_light = 10
 
 /obj/item/projectile/bullet/ship/missile/smalltorpedo
 	name = "small torpedo"
@@ -128,20 +129,9 @@
 	damage = 100
 	shake_range = 20
 	wall_decon = TRUE
-	ex_devestation = 4
-	ex_heavy = 5
-	ex_light = 6
-
-/obj/item/projectile/bullet/ship/missile/alientorpedo
-	name = "alien torpedo"
-	icon = 'icons/urist/items/ship_projectiles48x48.dmi'
-	icon_state= "alientorpedo"
-	damage = 150
-	shake_range = 25
-	wall_decon = TRUE
-	ex_devestation = 5
-	ex_heavy = 6
-	ex_light = 7
+	ex_devestation = 6
+	ex_heavy = 7
+	ex_light = 8
 
 /obj/item/projectile/bullet/ship/missile/bigtorpedo
 	name = "big torpedo"
@@ -150,9 +140,31 @@
 	damage = 200
 	shake_range = 30
 	wall_decon = TRUE
-	ex_devestation = 6
-	ex_heavy = 7
-	ex_light = 8
+	ex_devestation = 7
+	ex_heavy = 8
+	ex_light = 9
+
+/obj/item/projectile/bullet/ship/missile/alientorpedo
+	name = "alien torpedo"
+	icon = 'icons/urist/items/ship_projectiles48x48.dmi'
+	icon_state= "alientorpedo"
+	damage = 150
+	shake_range = 25
+	wall_decon = TRUE
+	ex_devestation = 7
+	ex_heavy = 8
+	ex_light = 9
+
+/obj/item/projectile/bullet/ship/missile/bigalientorpedo
+	name = "alien torpedo"
+	icon = 'icons/urist/items/ship_projectiles48x48.dmi'
+	icon_state= "alientorpedo"
+	damage = 200
+	shake_range = 30
+	wall_decon = TRUE
+	ex_devestation = 8
+	ex_heavy = 9
+	ex_light = 10
 
 //beam weapons
 
@@ -177,9 +189,13 @@
 	ship = 1
 	kill_count = 300
 	var/wall_decon = FALSE
+	var/shake_range = 10
+	var/ex_devestation = 0
+	var/ex_heavy = 0
+	var/ex_light = 2
 
 /obj/item/projectile/beam/ship/on_hit(var/atom/target, var/blocked = 0)
-	for(var/mob/M in range(10, target))
+	for(var/mob/M in range(shake_range, target))
 		if(!M.stat && !istype(M, /mob/living/silicon/ai))\
 			shake_camera(M, 3, 1)
 
@@ -190,10 +206,10 @@
 
 		W.dismantle_wall(1)
 
-	for(var/obj/machinery/light/L in range(15, target))
+	for(var/obj/machinery/light/L in range(shake_range, target))
 		L.flicker(rand(5,15))
 
-	explosion(location, -1, 0, 1, 1, 0)
+	explosion(location, ex_devestation, ex_heavy, ex_light, 1, 0)
 
 	..()
 
@@ -201,7 +217,7 @@
 	name = "light laser"
 	icon_state = "heavylaser"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-	damage = 300
+	damage = 400
 	armor_penetration = 100
 
 	muzzle_type = /obj/effect/projectile/laser/heavy/muzzle
@@ -212,7 +228,7 @@
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-	damage = 600
+	damage = 800
 	armor_penetration = 200
 //	life = 30
 	wall_decon = TRUE
@@ -232,21 +248,17 @@
 	name = "light laser"
 	icon_state = "alienprojectile"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-	damage = 1000
+	damage = 1200
 	armor_penetration = 200
 
 /obj/item/projectile/beam/ship/alien/heavy
 	name = "heavy laser"
 	icon_state = "alienprojectile"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-	damage = 1800
+	damage = 2000
 	armor_penetration = 200
 
 /obj/item/projectile/beam/ship/pulse
-	icon = 'icons/urist/items/ship_projectiles.dmi'
-	ship = 1
-	kill_count = 300
-	var/ex_size = 0
 	icon_state = "pulse"
 	fire_sound='sound/weapons/pulse.ogg'
 
@@ -254,30 +266,16 @@
 	tracer_type = /obj/effect/projectile/laser/pulse/tracer
 	impact_type = /obj/effect/projectile/laser/pulse/impact
 
-/obj/item/projectile/beam/ship/pulse/on_hit(var/atom/target, var/blocked = 0)
-	for(var/mob/M in range(12, target))
-		if(!M.stat && !istype(M, /mob/living/silicon/ai))\
-			shake_camera(M, 3, 1)
-
-	var/location = (get_turf(target))
-
-	if (istype(target, /turf/simulated/wall))
-		var/turf/simulated/wall/W = target
-
-		W.dismantle_wall(1)
-
-	for(var/obj/machinery/light/L in range(15, target))
-		L.flicker(rand(5,15))
-
-	explosion(location, ex_size, ex_size, ex_size, ex_size, 0)
-
-
-	..()
-
 /obj/item/projectile/beam/ship/pulse/light
 	damage = 100
-	ex_size = 2
+	ex_devestation = 3
+	ex_heavy = 3
+	ex_light = 3
+	shake_range = 12
 
 /obj/item/projectile/beam/ship/pulse/heavy
 	damage = 100
-	ex_size = 4
+	ex_devestation = 5
+	ex_heavy = 5
+	ex_light = 5
+	shake_range = 15

--- a/code/modules/urist/random.dm
+++ b/code/modules/urist/random.dm
@@ -23,16 +23,27 @@
 	icon = 'icons/mob/screen1.dmi'
 	icon_state = "grabbed1"
 	invisibility = 101
+	var/empulse = FALSE
 	var/dmg_dev = 1
 	var/dmg_hvy = 2
 	var/dmg_lgt = 5
 
 /obj/effect/urist/spawn_bomb/Initialize()
 	.=..()
-	explosion(src.loc, dmg_dev, dmg_hvy, dmg_lgt, 1)
+	if(empulse)
+		empulse(src.loc, dmg_hvy, dmg_lgt, 0)
+
+	else
+		explosion(src.loc, dmg_dev, dmg_hvy, dmg_lgt, 1)
+
 	qdel(src)
 
-/obj/effect/urist/spawn_bomb/abandoned //we're only doing light damage here, most just to break windows and make things look weathered.
+/obj/effect/urist/spawn_bomb/abandoned //we're only doing light damage here, mostly just to break windows and make things look weathered.
 	dmg_dev = 0
 	dmg_hvy = 0
 	dmg_lgt = 8
+
+/obj/effect/urist/spawn_bomb/bluespace_artillery
+	dmg_dev = 3
+	dmg_hvy = 7
+	dmg_lgt = 14

--- a/code/modules/urist/structures/boardingstructures.dm
+++ b/code/modules/urist/structures/boardingstructures.dm
@@ -77,6 +77,10 @@
 						if(B.shipid == src.shipid)
 							B.incomprehensibleprocname() //i fucking hate myself. what was i trying to prove with this shit.
 
+						if(GLOB.using_map.overmap_ship)
+							for(var/datum/shipcomponents/C in GLOB.using_map.overmap_ship)
+								C.broken = TRUE
+
 					spawn(1 MINUTE)
 						if(GLOB.using_map.overmap_ship)
 							if(!GLOB.using_map.overmap_ship.target.dying)

--- a/maps/away/stations/nanotrasentrading.dmm
+++ b/maps/away/stations/nanotrasentrading.dmm
@@ -1611,6 +1611,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/spacestations/nanotrasenspace)
+"kA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/spacestations/nanotrasenspace)
 "kE" = (
 /obj/machinery/light{
 	dir = 4
@@ -4379,7 +4385,7 @@ ad
 ad
 qy
 nX
-aL
+kA
 aL
 aL
 ad


### PR DESCRIPTION
The inevitable sequel to #940 

Beefs up damage of hostile weaponry across the board. 
adds more variance in weaponry, 
adds some new features to teleporters that make the lactera teleporters more dangerous. 
actually adds shield disruptors to hostile ships, and buffs/reworks shield disruptors in general. 
Changes how burst weapons work so they all fire from the same landmark, which means there will actually be a spread from the salvo along a stretch of the ship
some boarding fixes and tweaks.

Hopefully this will improve space combat balancing, although there is likely more to be tweaked in the future.

