### PR TITLE
Ports pixelshifting!

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -479,6 +479,11 @@ default behaviour is:
 	if (buckled)
 		return
 
+	if(is_shifted)
+		is_shifted = FALSE
+		pixel_x = default_pixel_x
+		pixel_y = default_pixel_y
+
 	if (restrained())
 		stop_pulling()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -481,8 +481,7 @@ default behaviour is:
 
 	if(is_shifted)
 		is_shifted = FALSE
-		pixel_x = default_pixel_x
-		pixel_y = default_pixel_y
+		animate(src, pixel_x = default_pixel_x, pixel_y = default_pixel_y, 5, 1, LINEAR_EASING)
 
 	if (restrained())
 		stop_pulling()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1058,6 +1058,42 @@
 	set hidden = 1
 	set_face_dir(client.client_dir(WEST))
 
+/mob/proc/can_shift()
+	return !(incapacitated() || buckled || grabbed_by.len)
+
+/mob/verb/shiftnorth()
+	set hidden = TRUE
+	if(!canface() || !can_shift())
+		return FALSE
+	if(pixel_y <= 16)
+		pixel_y++
+		is_shifted = TRUE
+
+/mob/verb/shiftsouth()
+	set hidden = TRUE
+	if(!canface() || !can_shift())
+		return FALSE
+	if(pixel_y >= -16)
+		pixel_y--
+		is_shifted = TRUE
+
+/mob/verb/shiftwest()
+	set hidden = TRUE
+	if(!canface() || !can_shift())
+		return FALSE
+	if(pixel_x >= -16)
+		pixel_x--
+		is_shifted = TRUE
+
+/mob/verb/shifteast()
+	set hidden = TRUE
+	if(!canface() || !can_shift())
+		return FALSE
+	if(pixel_x <= 16)
+		pixel_x++
+		is_shifted = TRUE
+
+
 /mob/proc/adjustEarDamage()
 	return
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -83,6 +83,7 @@
 	var/confused = 0		//Carbon
 	var/sleeping = 0		//Carbon
 	var/resting = 0			//Carbon
+	var/is_shifted = FALSE
 	var/lying = 0
 	var/lying_prev = 0
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -24,6 +24,9 @@ macro "borghotkeymode"
 		name = "CTRL+West"
 		command = "westface"
 	elem 
+		name = "CTRL+SHIFT+West"
+		command = "shiftwest"
+	elem 
 		name = "West+REP"
 		command = ".moveleft"
 	elem 
@@ -32,6 +35,9 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+North"
 		command = "northface"
+	elem 
+		name = "CTRL+SHIFT+North"
+		command = "shiftnorth"
 	elem 
 		name = "North+REP"
 		command = ".moveup"
@@ -42,6 +48,9 @@ macro "borghotkeymode"
 		name = "CTRL+East"
 		command = "eastface"
 	elem 
+		name = "CTRL+SHIFT+East"
+		command = "shifteast"
+	elem 
 		name = "East+REP"
 		command = ".moveright"
 	elem 
@@ -50,6 +59,9 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem 
+		name = "CTRL+SHIFT+South"
+		command = "shiftsouth"
 	elem 
 		name = "South+REP"
 		command = ".movedown"
@@ -252,6 +264,9 @@ macro "macro"
 		name = "CTRL+West"
 		command = "westface"
 	elem 
+		name = "CTRL+SHIFT+West"
+		command = "shiftwest"
+	elem 
 		name = "West+REP"
 		command = ".moveleft"
 	elem 
@@ -260,6 +275,9 @@ macro "macro"
 	elem 
 		name = "CTRL+North"
 		command = "northface"
+	elem 
+		name = "CTRL+SHIFT+North"
+		command = "shiftnorth"
 	elem 
 		name = "North+REP"
 		command = ".moveup"
@@ -270,6 +288,9 @@ macro "macro"
 		name = "CTRL+East"
 		command = "eastface"
 	elem 
+		name = "CTRL+SHIFT+East"
+		command = "shifteast"
+	elem 
 		name = "East+REP"
 		command = ".moveright"
 	elem 
@@ -278,6 +299,9 @@ macro "macro"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem 
+		name = "CTRL+SHIFT+South"
+		command = "shiftsouth"
 	elem 
 		name = "South+REP"
 		command = ".movedown"
@@ -425,6 +449,9 @@ macro "hotkeymode"
 		name = "CTRL+West"
 		command = "westface"
 	elem 
+		name = "CTRL+SHIFT+West"
+		command = "shiftwest"
+	elem 
 		name = "West+REP"
 		command = ".moveleft"
 	elem 
@@ -433,6 +460,9 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+North"
 		command = "northface"
+	elem 
+		name = "CTRL+SHIFT+North"
+		command = "shiftnorth"
 	elem 
 		name = "North+REP"
 		command = ".moveup"
@@ -443,6 +473,9 @@ macro "hotkeymode"
 		name = "CTRL+East"
 		command = "eastface"
 	elem 
+		name = "CTRL+SHIFT+East"
+		command = "shifteast"
+	elem 
 		name = "East+REP"
 		command = ".moveright"
 	elem 
@@ -451,6 +484,9 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem 
+		name = "CTRL+SHIFT+South"
+		command = "shiftsouth"
 	elem 
 		name = "South+REP"
 		command = ".movedown"
@@ -673,6 +709,9 @@ macro "borgmacro"
 		name = "CTRL+West"
 		command = "westface"
 	elem 
+		name = "CTRL+SHIFT+West"
+		command = "shiftwest"
+	elem 
 		name = "West+REP"
 		command = ".moveleft"
 	elem 
@@ -681,6 +720,9 @@ macro "borgmacro"
 	elem 
 		name = "CTRL+North"
 		command = "northface"
+	elem 
+		name = "CTRL+SHIFT+North"
+		command = "shiftnorth"
 	elem 
 		name = "North+REP"
 		command = ".moveup"
@@ -691,6 +733,9 @@ macro "borgmacro"
 		name = "CTRL+East"
 		command = "eastface"
 	elem 
+		name = "CTRL+SHIFT+East"
+		command = "shifteast"
+	elem 
 		name = "East+REP"
 		command = ".moveright"
 	elem 
@@ -699,6 +744,9 @@ macro "borgmacro"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+	elem 
+		name = "CTRL+SHIFT+South"
+		command = "shiftsouth"
 	elem 
 		name = "South+REP"
 		command = ".movedown"


### PR DESCRIPTION
"What's pixelshifting?" I hear you ask. Well, pixelshifting is this magic feature. When you press CTRL + SHIFT + ARROWKEYS, your pixel spessmen will bump a pixel in that direction. By holding CTRL + SHIFT and rapidly mashing an arrow key, you can move up to 16 pixels in any direction, resetting to normal the moment you move. This'll probably be used never, but hey, the option exists for if you people want to move around a bit during the rare moments of RP.

## Changelog
```changelog
code: adds pixelshifting, done by holding CTRL + SHIFT and pressing the arrow keys.
```
