### PR TITLE
Surgery & Cloning bugfixes

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -138,7 +138,7 @@
 	if(occupant.getCloneLoss() == 0) // Rare case, but theoretically possible
 		return 100
 
-	return between(0, 100 * (occupant.getCloneLoss() - occupant.maxHealth / 100) / (occupant.maxHealth * heal_level / 100), 100)
+	return between(0, 100 * ((occupant.maxHealth/2 - occupant.getCloneLoss()) / (heal_level / (occupant.maxHealth/2 / 100))), 100)
 
 //Grow clones to maturity then kick them out.  FREELOADERS
 /obj/machinery/clonepod/Process()

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -337,13 +337,6 @@
 					temp = "Error: Clonepod malfunction."
 				else if(!config.revival_cloning)
 					temp = "Error: Unable to initiate cloning cycle."
-
-				else if(pod.growclone(C))
-					temp = "Initiating cloning cycle..."
-					if(!config.use_cortical_stacks)
-						records.Remove(C)
-					qdel(C)
-					menu = 1
 				else
 					var/cloning
 					if(config.use_cortical_stacks)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -63,6 +63,7 @@
 	shock_level = 40
 	delicate = 1
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
+	strict_access_requirement = FALSE
 
 /decl/surgery_step/fix_vein/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -311,7 +311,7 @@
 	)
 	min_duration = 70
 	max_duration = 90
-	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP
+	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP
 
 /decl/surgery_step/robotics/fix_organ_robotic/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()


### PR DESCRIPTION
Arterial bleeding in encased organs (upper body, head) can now be fixed in situations where the organ is also broken.
Robotic organs in non-robotic external organs (read: laces) can now be repaired.
Cloning will properly calculate the amount of damage left to heal before a clone is released.