### PR TITLE
Forensic Kit tweak

### DIFF
--- a/code/modules/detectivework/tools/crimekit.dm
+++ b/code/modules/detectivework/tools/crimekit.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "case"
 	item_state = "case"
+	slot_flags = SLOT_BELT
 	startswith = list(
 		/obj/item/weapon/storage/box/swabs,
 		/obj/item/weapon/storage/box/fingerprints,


### PR DESCRIPTION
- Forensic Box kits can fit in the belt slot, still can't fit in bags which is a fair trade off.