### PR TITLE
Bug Fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
@@ -55,6 +55,11 @@
 	if(ishuman(me) && !skip_species_mention)
 		var/mob/living/carbon/human/H = me
 		var/use_name = "\improper [H.species.name]"
+		if(H.wear_suit && (H.wear_suit.type == /obj/item/clothing/suit/urist/fleshsuit))
+			for(var/obj/item/clothing/C in list(H.wear_mask, H.head))
+				if(C && (C.body_parts_covered & FACE))
+					use_name = "\improper Human"
+					break
 		species_text = " for \a [use_name]"
 	. = "[get_third_person_message_start(my_gender)] [get_standalone_value_descriptor(my_value)][species_text]"
 

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -129,7 +129,11 @@
 	for(var/datum/computer_file/program/P in idle_threads)
 		P.event_idremoved(1)
 
-	user.put_in_hands(card_slot.stored_card)
+	if(ishuman(user))
+		user.put_in_hands(card_slot.stored_card)
+	else
+		card_slot.stored_card.dropInto(loc)
+
 	to_chat(user, "You remove [card_slot.stored_card] from [src].")
 	card_slot.stored_card = null
 	update_uis()


### PR DESCRIPTION
Fixes a couple of bugs:

- Human Suit (Fleshsuit) - When examined this would still display the species information in the descriptors. Changed to display human if the suit is worn while the face is covered.
- ID readers - If an ID card was inserted into a console and then ejected by an AI (or robot), it would fail putting it into their hands and instead place it on the mob's tile. This lead to interesting issues where IDs would be warped into the AI core. Now it'll drop it on the console's loc if the mob doesn't have hands.