### PR TITLE
Fixed ship weapons dupe glitch

### DIFF
--- a/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
@@ -304,7 +304,8 @@
 		S.name = "[src.name] assembly"
 		S.shipid = src.shipid
 		S.anchored = 1
-		linkedcomputer.linkedweapons -= src
+		if(linkedcomputer)
+			linkedcomputer.linkedweapons -= src
 		qdel(src)
 
 	else


### PR DESCRIPTION
Fixes a glitch where sometimes ship weapons would be duplicated on deconstruction; caused by the linkedcomputer reference sometimes being null (if the linked computer was destroyed or never existed), causing the proc to error out and qdel to never get called.