### PR TITLE
Multi Z-level repair additions

### DIFF
--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -10,7 +10,8 @@
 	matter = list(MATERIAL_ALUMINIUM = 150)
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 	action_button_name = "Toggle T-Ray scanner"
-
+	
+	var/standard_mode = TRUE
 	var/scan_range = 3
 
 	var/on = 0
@@ -64,15 +65,15 @@
 	var/list/update_remove = active_scanned - scanned
 
 	//Add new overlays
-	for(var/obj/O in update_add)
-		var/image/overlay = get_overlay(O)
-		active_scanned[O] = overlay
+	for(var/atom/A in update_add)
+		var/image/overlay = get_overlay(A)
+		active_scanned[A] = overlay
 		user_client.images += overlay
 
 	//Remove stale overlays
-	for(var/obj/O in update_remove)
-		user_client.images -= active_scanned[O]
-		active_scanned -= O
+	for(var/atom/A in update_remove)
+		user_client.images -= active_scanned[A]
+		active_scanned -= A
 
 //creates a new overlay for a scanned object
 /obj/item/device/t_scanner/proc/get_overlay(var/atom/movable/scanned)
@@ -81,10 +82,16 @@
 	if(scanned in overlay_cache)
 		. = overlay_cache[scanned]
 	else
-		var/image/I = image(loc = scanned, icon = scanned.icon, icon_state = scanned.icon_state)
+		var/image/I
+		if(isturf(scanned))
+			I = image(loc = locate(scanned.x, scanned.y, scanned.z-1), icon = 'icons/turf/areas.dmi', icon_state = "unknown")	//Placeholder icon for now
+		else
+			I = image(loc = scanned, icon = scanned.icon, icon_state = scanned.icon_state)
 		I.plane = HUD_PLANE
 		I.layer = UNDER_HUD_LAYER
 		I.appearance_flags = RESET_ALPHA
+		if(!standard_mode)
+			I.appearance_flags |= RESET_COLOR	//Because the placeholder icon can be hard to see at times.
 
 		//Pipes are special
 		if(istype(scanned, /obj/machinery/atmospherics/pipe))
@@ -116,31 +123,37 @@
 
 /obj/item/device/t_scanner/proc/get_scanned_objects(var/scan_dist)
 	. = list()
-
-	var/turf/center = get_turf(src.loc)
+	
+	var/turf/center
+	if(standard_mode)
+		center = get_turf(src.loc)
+	else
+		center = get_turf(locate(src.loc.x,src.loc.y,src.loc.z+1))
+		if(!AreConnectedZLevels(center.z, src.loc.z)) return
 	if(!center) return
 
 	for(var/turf/T in range(scan_range, center))
-		for(var/mob/M in T.contents)
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if(H.is_cloaked())
+		if(standard_mode)
+			for(var/mob/M in T.contents)
+				if(ishuman(M))
+					var/mob/living/carbon/human/H = M
+					if(H.is_cloaked())
+						. += M
+				else if(round_is_spooky() && isobserver(M))
 					. += M
-			else if(M.alpha < 255)
-				. += M
-			else if(round_is_spooky() && isobserver(M))
-				. += M
 
-		if(!!T.is_plating())
-			continue
-
-		for(var/obj/O in T.contents)
-			if(O.level != 1)
+			if(!!T.is_plating())
 				continue
-			if(!O.invisibility)
-				continue //if it's already visible don't need an overlay for it
-			. += O
 
+			for(var/obj/O in T.contents)
+				if(O.level != 1)
+					continue
+				if(!O.invisibility)
+					continue //if it's already visible don't need an overlay for it
+				. += O
+		else
+			if(isopenspace(T))
+				. += T
 
 
 /obj/item/device/t_scanner/proc/set_user_client(var/client/new_client)
@@ -160,5 +173,18 @@
 /obj/item/device/t_scanner/dropped(mob/user)
 	set_user_client(null)
 	..()
+
+/obj/item/device/t_scanner/verb/switch_mode()
+	set name = "Toggle Scanning Mode"
+	set category = "Object"
+
+	if (usr.stat || usr.restrained() || usr.incapacitated()) return
+
+	if(on)
+		for(var/scanned in active_scanned)
+			user_client.images -= active_scanned[scanned]
+	active_scanned = list()
+	standard_mode = !standard_mode
+	to_chat(usr, "<span class='notice'>You set the t-scanner to scan [standard_mode ? "through tiles below you" : "for missing tiles above you"]</span>")
 
 #undef OVERLAY_CACHE_LEN

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -187,4 +187,9 @@
 	standard_mode = !standard_mode
 	to_chat(usr, "<span class='notice'>You set the t-scanner to scan [standard_mode ? "through tiles below you" : "for missing tiles above you"]</span>")
 
+/obj/item/device/t_scanner/AltClick(var/mob/user)
+	if(!CanPhysicallyInteract(user))
+		return
+	switch_mode()
+
 #undef OVERLAY_CACHE_LEN

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -85,3 +85,26 @@
 /obj/item/stack/material/rods/add()
 	. = ..()
 	update_icon()
+
+/obj/item/stack/material/rods/verb/place_above()
+	set name = "Construct Lattice Above"
+	set category = "Object"
+
+	if (usr.stat || usr.restrained() || usr.incapacitated()) return
+
+	var/turf/target = get_turf(locate(src.loc.x,src.loc.y,src.loc.z+1))
+	
+	if(!target || !AreConnectedZLevels(src.loc.z,target.z))
+		to_chat(usr, "<span class='warning'>There's nothing above you.</span>")
+		return
+	
+	if(isopenspace(target))
+		if(locate(/obj/structure/lattice, target))
+			to_chat(usr, "<span class='warning'>There's already a lattice in that location.</span>")
+			return
+		target.attackby(src, src.loc)
+		playsound(usr, 'sound/weapons/Genhit.ogg', 50, 1)
+	else
+		to_chat(usr, "<span class='warning'>There's no empty space above you.</span>")
+		return
+	

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -32,6 +32,25 @@
 			return
 	..()
 
+/obj/item/stack/tile/verb/place_above()
+	set name = "Place Tile Above"
+	set category = "Object"
+
+	if (usr.stat || usr.restrained() || usr.incapacitated()) return
+
+	var/turf/target = get_turf(locate(src.loc.x,src.loc.y,src.loc.z+1))
+	
+	if(!target || !AreConnectedZLevels(src.loc.z,target.z))
+		to_chat(usr, "<span class='warning'>There's nothing above you.</span>")
+		return
+	
+	if(locate(/obj/structure/lattice, target))
+		target.attackby(src, src.loc)
+		to_chat(usr, "<span class='notice'>You slide \the [src] into the lattice above.</span>")
+		playsound(usr, 'sound/weapons/Genhit.ogg', 50, 1)
+	else
+		to_chat(usr, "<span class='warning'>There's no exposed lattice above you.</span>")
+
 /*
  * Grass
  */


### PR DESCRIPTION
Currently, repairing hull breaches than span over multiple z-levels is a real pain. There's always one tile you've missed _somewhere_ that's almost impossible to find, running up the stairs and back down while the bridge which has inevitably been hit by a missile is venting atmosphere. And good luck if the breach is from Deck 1 into 2 with that maze of maintenance tunnels. So, I thought I'd try to make that a little easier. This is my first PR that isn't some kind of bugfix and is an actual addition, so feel free to yell at my incompetence or general issues with it.

This adds the following:

- **Rod stacks have a new verb** "Construct Lattice Above", available in the context menu and Object tab. This allows the player to construct a lattice on an open space tile above their current location. Negating the need to run upstairs and attempt to find the hole. Does not allow further construction other than lattice, ie catwalks.
- **Floor tiles also have a similar verb** "Place Tile Above", again available in the context menu and Object tab. This again allows the player to place a floor tile down onto a lattice above them. Does not allow full floor construction, ie placing a floor tile onto plating.
- **T-Scanners now gain a secondary scan mode**, toggled by either the context menu or in the Object tab. This mode, instead of revealing pipes and wires under tiles, will instead scan above you and overlay any tiles missing plating, currently denoted by a red X. This icon is a placeholder because I am incompetent at anything artistic so I just used something that fit. Has the same range as the standard mode. Side-effect of this is a fix of an oversight in the original code: The t-scanners do scan invisible mobs (line 124), but would be filtered out regardless in line 67. This tweak passes all atoms and instead relies on get_scanned_objects to filter type.

Example from above:
![Screenshot from 2021-06-14 00-39-00](https://user-images.githubusercontent.com/54823378/121825906-e1394480-ccac-11eb-823c-3a0b342e381b.png)

And the damage below with the mode active (again, placeholder icons):
![Screenshot from 2021-06-14 00-39-24](https://user-images.githubusercontent.com/54823378/121825932-0332c700-ccad-11eb-8e25-1f74940fc5ab.png)


Again, if anything is wrong or it's simply a bad idea, feel free to yell in my general direction.