### PR TITLE
Fixed dufflebag item icons

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -182,7 +182,10 @@
 	name = "dufflebag"
 	desc = "A large dufflebag for holding extra things."
 	icon_state = "duffle"
-	item_state_slots = null
+	item_state_slots = list(
+		slot_l_hand_str = "duffle",
+		slot_r_hand_str = "duffle",
+		)
 
 /obj/item/weapon/storage/backpack/dufflebag/New()
 	..()
@@ -194,36 +197,64 @@
 	name = "black dufflebag"
 	desc = "A large dufflebag for holding extra tactical supplies."
 	icon_state = "duffle_syndie"
+	item_state_slots = list(
+		slot_l_hand_str = "duffle_syndie",
+		slot_r_hand_str = "duffle_syndie",
+		)
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/med
 	name = "medical dufflebag"
 	desc = "A large dufflebag for holding extra tactical medical supplies."
 	icon_state = "duffle_syndiemed"
+	item_state_slots = list(
+		slot_l_hand_str = "duffle_syndiemed",
+		slot_r_hand_str = "duffle_syndiemed",
+		)
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/ammo
 	name = "ammunition dufflebag"
 	desc = "A large dufflebag for holding extra weapons ammunition and supplies."
 	icon_state = "duffle_syndieammo"
+	item_state_slots = list(
+		slot_l_hand_str = "duffle_syndieammo",
+		slot_r_hand_str = "duffle_syndieammo",
+		)
 
 /obj/item/weapon/storage/backpack/dufflebag/captain
 	name = "captain's dufflebag"
 	desc = "A large dufflebag for holding extra captainly goods."
 	icon_state = "duffle_captain"
+	item_state_slots = list(
+		slot_l_hand_str = "duffle_captain",
+		slot_r_hand_str = "duffle_captain",
+		)
 
 /obj/item/weapon/storage/backpack/dufflebag/med
 	name = "medical dufflebag"
 	desc = "A large dufflebag for holding extra medical supplies."
 	icon_state = "duffle_med"
+	item_state_slots = list(
+		slot_l_hand_str = "duffle_med",
+		slot_r_hand_str = "duffle_med",
+		)
 
 /obj/item/weapon/storage/backpack/dufflebag/sec
 	name = "security dufflebag"
 	desc = "A large dufflebag for holding extra security supplies and ammunition."
 	icon_state = "duffle_sec"
+	item_state_slots = list(
+		slot_l_hand_str = "duffle_sec",
+		slot_r_hand_str = "duffle_sec",
+		)
 
 /obj/item/weapon/storage/backpack/dufflebag/eng
 	name = "industrial dufflebag"
 	desc = "A large dufflebag for holding extra tools and supplies."
 	icon_state = "duffle_eng"
+	item_state_slots = list(
+		slot_l_hand_str = "duffle_eng",
+		slot_r_hand_str = "duffle_eng",
+		)
 
 /*
  * Satchel Types


### PR DESCRIPTION
Dufflebag item icons were missing for some reason, causing them to look like backpacks in your hand.