### PR TITLE
Discord Bug Fixes

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -506,8 +506,14 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				var/image = photo_data ? photo_data.photo : null
 				SSstatistics.add_field("newscaster_stories",1)
 				news_network.SubmitArticle(src.msg, src.scanned_user, src.channel_name, image, 0)
-				if(photo_data)
-					photo_data.photo.dropInto(loc)
+				if(photo_data)	//Let's actually remove the photo data and place the photo back into the user's hands if possible
+					if(!photo_data.is_synth)
+						if(!issilicon(usr))
+							usr.put_in_hands(photo_data.photo)
+						else
+							photo_data.photo.dropInto(loc)
+					qdel(photo_data)
+					photo_data = null					
 				src.screen=4
 
 			src.updateUsrDialog()
@@ -737,17 +743,18 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 /obj/machinery/newscaster/proc/AttachPhoto(mob/user as mob)
 	if(photo_data)
 		if(!photo_data.is_synth)
-			photo_data.photo.dropInto(loc)
 			if(!issilicon(user))
 				user.put_in_hands(photo_data.photo)
+			else
+				photo_data.photo.dropInto(loc)
 		qdel(photo_data)
 		photo_data = null
 		return
 
 	if(istype(user.get_active_hand(), /obj/item/weapon/photo))
+		var/obj/item/photo = user.get_active_hand()
 		if(!user.unequip_item(src))
 			return
-		var/obj/item/photo = user.get_active_hand()
 		photo_data = new(photo, 0)
 	else if(istype(user,/mob/living/silicon))
 		var/mob/living/silicon/tempAI = user

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -68,6 +68,7 @@
 	desc = "An easy to fit mahogany wood floor tile."
 	icon_state = "tile-mahogany"
 	matter = list(MATERIAL_WOOD = 450)
+	build_type = /decl/flooring/wood/mahogany
 
 /obj/item/stack/tile/maple
 	name = "maple floor tile"
@@ -75,6 +76,7 @@
 	desc = "An easy to fit maple wood floor tile."
 	icon_state = "tile-maple"
 	matter = list(MATERIAL_WOOD = 450)
+	build_type = /decl/flooring/wood/maple
 
 /obj/item/stack/tile/ebony
 	name = "ebony floor tile"
@@ -82,6 +84,7 @@
 	desc = "An easy to fit ebony floor tile."
 	icon_state = "tile-ebony"
 	matter = list(MATERIAL_WOOD = 450)
+	build_type = /decl/flooring/wood/ebony
 
 /obj/item/stack/tile/walnut
 	name = "walnut floor tile"
@@ -89,6 +92,7 @@
 	desc = "An easy to fit walnut wood floor tile."
 	icon_state = "tile-walnut"
 	matter = list(MATERIAL_WOOD = 450)
+	build_type = /decl/flooring/wood/walnut
 
 /obj/item/stack/tile/floor
 	name = "steel floor tile"
@@ -107,6 +111,7 @@
 	icon_state = "tile"
 	matter = list(MATERIAL_STEEL = 450)
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	build_type = /decl/flooring/tiling/mono
 
 /obj/item/stack/tile/mono/dark
 	name = "dark mono tile"
@@ -114,6 +119,7 @@
 	icon_state = "tile"
 	matter = list(MATERIAL_STEEL = 450)
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	build_type = /decl/flooring/tiling/dark/mono
 
 /obj/item/stack/tile/mono/white
 	name = "white mono tile"
@@ -121,7 +127,7 @@
 	icon_state = "tile"
 	matter = list(MATERIAL_STEEL = 450)
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	build_type = /decl/flooring/tiling/mono
+	build_type = /decl/flooring/tiling/mono/white
 
 /obj/item/stack/tile/grid
 	name = "grey grid tile"
@@ -218,6 +224,7 @@
 	singular name = "stone slab"
 	desc = "A smooth, flat slab of some kind of stone."
 	icon_state = "tile_stone"
+	build_type = /decl/flooring/tiling/stone
 
 /*
  * Carpets

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -204,3 +204,13 @@
 	else
 		icon_state = "[bis.base_icon_state]"
 		item_state = "[bis.base_icon_state]"
+
+/obj/item/weapon/flame/lighter/zippo/vanity/on_update_icon()
+	var/datum/extension/base_icon_state/bis = get_extension(src, /datum/extension/base_icon_state)
+
+	if(lit)
+		icon_state = "[bis.base_icon_state]on"
+		item_state = "[bis.base_icon_state]on"
+	else
+		icon_state = "[bis.base_icon_state]"
+		item_state = "[bis.base_icon_state]"


### PR DESCRIPTION
Fixes various bug reports from Discord

- **Newscasters eating photos**: Fixes a bug where photos would be essentially eaten by newscasters and yet they'd refuse to print them. Caused by an oversight in calling user.unequip_item _before_ getting the object from user.get_active_hand() [Line 748 - 750], causing user.get_active_hand() to be null as, well.. The photo has already been dropped.. Derp. Also tweaked and fixed some behaviour. Photo data is actually deleted after the photo is removed after posting the article, stopping weird item warping issues. Also tries to place the photo into the user's hand rather than onto the floor- Can't have the captain stealing that compromising photo of them away.
- **Various floor tiles not building**: Fixes a bug where various floor tiles simply would not build, caused by a lack of build_type being defined. Fixed floors are: Mahogany, Maple, Ebony, Walnut, Mono, Light Mono, Dark Mono, Tiled Stone.
- **Vanity zippos missing icons**: Fixes a bug where all zippos under the vanity path would have no 'open' icon, caused by those items having a different icon_state format.