### PR TITLE
Requested Feature: Examine shows wet floors

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -38,6 +38,11 @@
 		overlays -= wet_overlay
 		wet_overlay = null
 
+/turf/simulated/examine()
+	. = ..()
+	if(wet && (get_lumcount() >= 0.25))
+		to_chat(usr, "<span class='warning'>It has a slight shimmer to it.</span>")
+
 /turf/simulated/clean_blood()
 	for(var/obj/effect/decal/cleanable/blood/B in contents)
 		B.clean_blood()


### PR DESCRIPTION
A simple feature requested by `Doctor Derp#3046` on the Discord to help janitors.

Floors now have additional flavour text on the examine verb if they're wet. This also takes into account ambient lighting; If there's not enough light to reflect off of the water's surface, you won't see it.