### PR TITLE
[DON'T MERGE YET] Mapchange 2021

### DIFF
--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -50,8 +50,8 @@
 /area/medical/virology)
 "aj" = (
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -140,21 +140,21 @@
 /area/medical/virology)
 "as" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	tag = "icon-map_scrubber_on (EAST)";
+	dir = 4;
 	icon_state = "map_scrubber_on";
-	dir = 4
+	tag = "icon-map_scrubber_on (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "at" = (
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -168,12 +168,12 @@
 /area/medical/virology)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -210,12 +210,12 @@
 "aw" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -226,12 +226,12 @@
 /area/medical/extstorage)
 "ax" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -265,8 +265,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -306,9 +306,9 @@
 /area/maintenance/fourth_deck/fp)
 "aE" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -346,8 +346,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Virology";
@@ -420,8 +420,8 @@
 "aQ" = (
 /obj/structure/catwalk,
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/fourth_deck/afp)
@@ -447,8 +447,8 @@
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/food/snacks/mimeburger,
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb1";
-	icon_state = "cobweb1"
+	icon_state = "cobweb1";
+	tag = "icon-cobweb1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -481,9 +481,9 @@
 /obj/item/device/antibody_scanner,
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/effect/floor_decal/corner/paleblue{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/beakers,
@@ -525,9 +525,9 @@
 /area/medical/cloning)
 "bd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -538,9 +538,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/lime{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -551,12 +551,12 @@
 /area/medical/cloning)
 "be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -570,12 +570,12 @@
 /area/medical/cloning)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -593,8 +593,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -717,31 +717,31 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "bp" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "bq" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Hanger Port - Fore"
@@ -754,24 +754,24 @@
 "br" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "bs" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -781,8 +781,8 @@
 "bt" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -905,23 +905,23 @@
 "bJ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "bK" = (
 /obj/machinery/atmospherics/unary/engine{
-	tag = "icon-nozzle (EAST)";
+	dir = 4;
 	icon_state = "nozzle";
-	dir = 4
+	tag = "icon-nozzle (EAST)"
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/bdportengine)
 "bL" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -1085,8 +1085,8 @@
 /area/maintenance/fourth_deck/afp)
 "bZ" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -1150,9 +1150,9 @@
 /area/logistics/hangar)
 "ci" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8;
@@ -1184,8 +1184,8 @@
 /area/engineering/bdportengine)
 "cn" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/reinforced,
@@ -1259,9 +1259,9 @@
 /area/maintenance/fourth_deck/afp)
 "cx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	tag = "icon-map_scrubber_on (EAST)";
+	dir = 4;
 	icon_state = "map_scrubber_on";
-	dir = 4
+	tag = "icon-map_scrubber_on (EAST)"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/medical1,
@@ -1333,9 +1333,9 @@
 	dir = 4
 	},
 /obj/structure/handrai{
-	tag = "icon-handrail (EAST)";
+	dir = 4;
 	icon_state = "handrail";
-	dir = 4
+	tag = "icon-handrail (EAST)"
 	},
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/alarm{
@@ -1355,8 +1355,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
@@ -1442,19 +1442,19 @@
 /area/logistics/hangar)
 "cN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "cO" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	icon_state = "heater"
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -1474,8 +1474,8 @@
 /area/maintenance/fourth_deck/fp)
 "cR" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -1484,8 +1484,8 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -1494,8 +1494,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -1504,8 +1504,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1519,8 +1519,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1534,8 +1534,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -1554,8 +1554,8 @@
 	id = "fuelmode"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1569,8 +1569,8 @@
 /area/engineering/bdportengine)
 "cY" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/meter,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1586,8 +1586,8 @@
 /area/engineering/bdportengine)
 "cZ" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -1605,8 +1605,8 @@
 /area/engineering/bdportengine)
 "da" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/tvalve/digital{
 	dir = 4;
@@ -1800,9 +1800,9 @@
 	},
 /obj/item/weapon/storage/toolbox/emergency,
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb2 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb2";
-	dir = 1
+	tag = "icon-cobweb2 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -1821,8 +1821,8 @@
 /area/logistics/hangar)
 "dt" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8;
@@ -1872,12 +1872,12 @@
 /area/exploration_shuttle/power)
 "dx" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
+	dir = 8;
+	icon_state = "handrail"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -2056,19 +2056,19 @@
 	icon_state = "intact"
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_techfloor_grid"
 	},
 /obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_corners"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "dM" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
+	dir = 10;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2089,8 +2089,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2101,8 +2101,8 @@
 	tag = "icon-intact (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2118,8 +2118,8 @@
 	tag = "icon-intact (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2128,13 +2128,13 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2147,16 +2147,16 @@
 /area/engineering/bdportengine)
 "dT" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHWEST)";
+	dir = 9;
 	icon_state = "warning";
-	dir = 9
+	tag = "icon-warning (NORTHWEST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "dU" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2253,12 +2253,12 @@
 /area/logistics/hangar)
 "ee" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -2281,9 +2281,9 @@
 	dir = 4
 	},
 /obj/structure/handrai{
-	tag = "icon-handrail (EAST)";
+	dir = 4;
 	icon_state = "handrail";
-	dir = 4
+	tag = "icon-handrail (EAST)"
 	},
 /obj/item/weapon/storage/toolbox/mechanical{
 	pixel_x = -2;
@@ -2299,8 +2299,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -2338,9 +2338,9 @@
 /area/exploration_shuttle/cockpit)
 "ek" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (NORTH)";
+	dir = 1;
 	icon_state = "shuttle_chair_preview";
-	dir = 1
+	tag = "icon-shuttle_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -2356,8 +2356,8 @@
 /area/exploration_shuttle/cockpit)
 "em" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 5
+	dir = 5;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -2443,8 +2443,8 @@
 /area/maintenance/fourth_deck/fp)
 "eu" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-stickyweb2";
-	icon_state = "stickyweb2"
+	icon_state = "stickyweb2";
+	tag = "icon-stickyweb2"
 	},
 /obj/structure/bed/nice,
 /obj/random/plushie,
@@ -2470,9 +2470,9 @@
 /area/engineering/bdportengine)
 "ex" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2507,9 +2507,9 @@
 	id = "fuelmode"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2522,9 +2522,9 @@
 "eD" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -2553,8 +2553,8 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
@@ -2569,8 +2569,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -2623,8 +2623,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -2644,13 +2644,13 @@
 /area/maintenance/fourth_deck/afp)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -2669,8 +2669,8 @@
 "eR" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -2686,8 +2686,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -2713,9 +2713,9 @@
 	dir = 6
 	},
 /obj/structure/handrai{
-	tag = "icon-handrail (EAST)";
+	dir = 4;
 	icon_state = "handrail";
-	dir = 4
+	tag = "icon-handrail (EAST)"
 	},
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -26;
@@ -2725,14 +2725,14 @@
 /area/exploration_shuttle/cockpit)
 "eU" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (EAST)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/cockpit)
@@ -2748,9 +2748,9 @@
 /area/exploration_shuttle/cockpit)
 "eW" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -2777,9 +2777,9 @@
 	level = 2
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHWEST)";
+	dir = 9;
 	icon_state = "warning";
-	dir = 9
+	tag = "icon-warning (NORTHWEST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2790,13 +2790,13 @@
 	level = 2
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2832,9 +2832,9 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
 /obj/structure/disposalpipe/up,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -2909,9 +2909,9 @@
 /area/exploration_shuttle/main)
 "fl" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (EAST)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -2926,8 +2926,8 @@
 /area/exploration_shuttle/main)
 "fm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -3000,9 +3000,9 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -3053,8 +3053,8 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 4
+	dir = 4;
+	icon_state = "map_connector"
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
@@ -3099,8 +3099,8 @@
 	pixel_y = 23
 	},
 /obj/structure/bed/chair/shuttle/blue{
-	icon_state = "shuttle_chair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
 /turf/simulated/floor/tiled,
 /area/antonine_hangar/start)
@@ -3111,9 +3111,9 @@
 /area/maintenance/fourth_deck/fp)
 "fx" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /obj/item/weapon/flame/lighter/zippo/vanity/butterfly,
 /obj/random/junk,
@@ -3150,8 +3150,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -3209,9 +3209,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -3226,13 +3226,13 @@
 /area/maintenance/fourth_deck/afp)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3261,13 +3261,13 @@
 /area/maintenance/fourth_deck/afp)
 "fP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3283,9 +3283,9 @@
 /area/maintenance/fourth_deck/afp)
 "fQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3306,13 +3306,13 @@
 /area/maintenance/fourth_deck/afp)
 "fR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3322,13 +3322,13 @@
 /area/maintenance/fourth_deck/afp)
 "fS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3339,13 +3339,13 @@
 /area/maintenance/fourth_deck/afp)
 "fT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3387,9 +3387,9 @@
 /area/logistics/hangar)
 "fW" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (EAST)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3401,8 +3401,8 @@
 /area/exploration_shuttle/main)
 "fX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -3431,8 +3431,8 @@
 /obj/random/medical,
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/item/bodybag/cryobag,
 /turf/simulated/floor/tiled,
@@ -3462,8 +3462,8 @@
 /area/antonine_hangar/start)
 "gc" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -3499,34 +3499,34 @@
 "gf" = (
 /obj/structure/closet/crate/freezer/rations,
 /obj/structure/handrai{
-	tag = "icon-handrail (EAST)";
+	dir = 4;
 	icon_state = "handrail";
-	dir = 4
+	tag = "icon-handrail (EAST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod2/station)
 "gg" = (
 /obj/structure/handrai{
-	tag = "icon-handrail (WEST)";
+	dir = 8;
 	icon_state = "handrail";
-	dir = 8
+	tag = "icon-handrail (WEST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod2/station)
 "gh" = (
 /obj/structure/handrai{
-	tag = "icon-handrail (EAST)";
+	dir = 4;
 	icon_state = "handrail";
-	dir = 4
+	tag = "icon-handrail (EAST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
 "gi" = (
 /obj/structure/closet/crate/freezer/rations,
 /obj/structure/handrai{
-	tag = "icon-handrail (WEST)";
+	dir = 8;
 	icon_state = "handrail";
-	dir = 8
+	tag = "icon-handrail (WEST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
@@ -3567,9 +3567,9 @@
 /area/logistics/hangar)
 "gm" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (EAST)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3608,8 +3608,8 @@
 /area/exploration_shuttle/atmos)
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/meter,
 /obj/structure/cable/cyan{
@@ -3634,9 +3634,9 @@
 /area/exploration_shuttle/atmos)
 "gt" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -3646,8 +3646,8 @@
 	pixel_x = -24
 	},
 /obj/structure/bed/chair/shuttle/blue{
-	icon_state = "shuttle_chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
 	},
 /turf/simulated/floor/tiled,
 /area/antonine_hangar/start)
@@ -3667,8 +3667,8 @@
 	},
 /obj/structure/cable/cyan,
 /obj/structure/bed/chair/shuttle/blue{
-	icon_state = "shuttle_chair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "shuttle_chair_preview"
 	},
 /turf/simulated/floor/tiled,
 /area/antonine_hangar/start)
@@ -3728,8 +3728,8 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 5
+	dir = 5;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -3752,9 +3752,9 @@
 	pixel_y = 0
 	},
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod2/station)
@@ -3766,9 +3766,9 @@
 	pixel_y = 0
 	},
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (WEST)";
+	dir = 8;
 	icon_state = "shuttlechair";
-	dir = 8
+	tag = "icon-shuttlechair (WEST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
@@ -3826,9 +3826,9 @@
 /area/exploration_shuttle/main)
 "gS" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (EAST)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3847,12 +3847,12 @@
 /area/exploration_shuttle/main)
 "gT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/item/device/radio/beacon/anchored{
 	level = 1
@@ -3936,8 +3936,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -3952,8 +3952,8 @@
 /area/exploration_shuttle/atmos)
 "gY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -4073,8 +4073,8 @@
 	use_power = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -4091,9 +4091,9 @@
 /area/engineering/bdportengine)
 "hl" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -4102,27 +4102,27 @@
 /area/shuttle/escape_pod2/station)
 "hm" = (
 /obj/structure/handrai{
-	tag = "icon-handrail (WEST)";
+	dir = 8;
 	icon_state = "handrail";
-	dir = 8
+	tag = "icon-handrail (WEST)"
 	},
 /obj/effect/shuttle_landmark/escape_pod/start/pod2,
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod2/station)
 "hn" = (
 /obj/structure/handrai{
-	tag = "icon-handrail (EAST)";
+	dir = 4;
 	icon_state = "handrail";
-	dir = 4
+	tag = "icon-handrail (EAST)"
 	},
 /obj/effect/shuttle_landmark/escape_pod/start/pod3,
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
 "ho" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (WEST)";
+	dir = 8;
 	icon_state = "shuttlechair";
-	dir = 8
+	tag = "icon-shuttlechair (WEST)"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -4166,9 +4166,9 @@
 /area/logistics/hangar)
 "ht" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (EAST)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -4265,29 +4265,29 @@
 	pixel_y = -22
 	},
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "hB" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	tag = "icon-air_map (WEST)";
+	dir = 8;
 	icon_state = "air_map";
-	dir = 8
+	tag = "icon-air_map (WEST)"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "hC" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -4303,9 +4303,9 @@
 /area/antonine_hangar/start)
 "hE" = (
 /obj/machinery/computer/shuttle_control/explore/antonine{
-	tag = "icon-computer (NORTH)";
+	dir = 1;
 	icon_state = "computer";
-	dir = 1
+	tag = "icon-computer (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/antonine_hangar/start)
@@ -4331,13 +4331,13 @@
 "hI" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -4349,13 +4349,13 @@
 "hJ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4363,8 +4363,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4381,13 +4381,13 @@
 	req_access = list(19)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4399,12 +4399,12 @@
 "hL" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -4423,8 +4423,8 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -4433,9 +4433,9 @@
 /area/engineering/bdportengine)
 "hO" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
 	frequency = 1380;
@@ -4448,9 +4448,9 @@
 /area/shuttle/escape_pod2/station)
 "hP" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (WEST)";
+	dir = 8;
 	icon_state = "shuttlechair";
-	dir = 8
+	tag = "icon-shuttlechair (WEST)"
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
 	frequency = 1380;
@@ -4487,8 +4487,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
+	dir = 8;
+	icon_state = "handrail"
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -4545,13 +4545,13 @@
 "ia" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4564,13 +4564,13 @@
 "ib" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4582,13 +4582,13 @@
 "ic" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4601,9 +4601,9 @@
 "id" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
@@ -4616,9 +4616,9 @@
 "ie" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -4676,9 +4676,9 @@
 	pixel_x = -22
 	},
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod2/station)
@@ -4688,9 +4688,9 @@
 	pixel_x = 25
 	},
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (WEST)";
+	dir = 8;
 	icon_state = "shuttlechair";
-	dir = 8
+	tag = "icon-shuttlechair (WEST)"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
@@ -4823,9 +4823,9 @@
 "iB" = (
 /obj/machinery/dnaforensics,
 /obj/effect/floor_decal/corner/red/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
@@ -4856,8 +4856,8 @@
 	pixel_y = 24
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -4884,9 +4884,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/breakroom)
@@ -4900,8 +4900,8 @@
 /obj/structure/bed/nice,
 /obj/item/weapon/bedsheet/red,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/effect/floor_decal/corner/red/three_quarters{
 	dir = 1
@@ -4963,9 +4963,9 @@
 	programs_list_id = "NervaMainPrograms"
 	},
 /obj/effect/floor_decal/corner/white/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/civilian/holodeck)
@@ -4983,9 +4983,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/civilian/holodeck)
@@ -5004,9 +5004,9 @@
 	req_access = newlist()
 	},
 /obj/effect/floor_decal/corner/white/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/civilian/holodeck)
@@ -5025,8 +5025,8 @@
 /area/logistics/hangar)
 "iV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -5047,9 +5047,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5064,9 +5064,9 @@
 	},
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5080,9 +5080,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5092,22 +5092,22 @@
 "iZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cargo)
 "ja" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cargo)
@@ -5127,16 +5127,16 @@
 "jd" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j1";
-	dir = 1
+	tag = "icon-pipe-j1 (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5148,13 +5148,13 @@
 "je" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5164,13 +5164,13 @@
 "jf" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -5182,9 +5182,9 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5195,8 +5195,8 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5214,13 +5214,13 @@
 /area/logistics/hangar)
 "jj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -5230,12 +5230,12 @@
 /area/maintenance/fourth_deck/fp)
 "jk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -5250,8 +5250,8 @@
 	},
 /obj/item/clothing/gloves/forensic,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -5298,8 +5298,8 @@
 /area/security/breakroom)
 "jr" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/network/security{
@@ -5320,8 +5320,8 @@
 	},
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/breakroom)
@@ -5330,9 +5330,9 @@
 /area/security/breakroom)
 "ju" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
@@ -5370,21 +5370,21 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "jy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/item/device/radio/intercom{
 	frequency = 1343;
@@ -5395,12 +5395,12 @@
 	c_tag = "AI Upload Entrance"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -5410,28 +5410,28 @@
 	req_access = list(19)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bottom_hallway)
 "jA" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -5441,8 +5441,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5489,24 +5489,24 @@
 /area/civilian/holodeck)
 "jH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/civilian/holodeck)
 "jI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5519,13 +5519,13 @@
 /area/civilian/holodeck)
 "jJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/white/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Holodeck Control";
@@ -5541,17 +5541,17 @@
 /area/civilian/holodeck)
 "jL" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "jM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/access_button/airlock_interior{
 	frequency = 1331;
@@ -5708,13 +5708,13 @@
 /area/maintenance/fourth_deck/fp)
 "kc" = (
 /obj/item/modular_computer/console/preset/security{
-	tag = "icon-console (EAST)";
+	dir = 4;
 	icon_state = "console";
-	dir = 4
+	tag = "icon-console (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
@@ -5725,12 +5725,12 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -5744,8 +5744,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -5758,9 +5758,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood,
@@ -5772,13 +5772,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5795,13 +5795,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/airlock/security{
 	name = "Forensics Lab";
@@ -5816,13 +5816,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/sign/deck/fourth{
 	pixel_y = -24
@@ -5837,13 +5837,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated/dark,
@@ -5857,13 +5857,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/airlock/security{
 	name = "Security Dorms";
@@ -5878,41 +5878,41 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/breakroom)
 "km" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/breakroom)
 "kn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/breakroom)
@@ -5923,8 +5923,8 @@
 	pixel_x = 22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/structure/bed/nice,
 /obj/item/weapon/bedsheet/red,
@@ -5938,8 +5938,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -5954,35 +5954,35 @@
 /area/command/aiupload)
 "kq" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	tag = "icon-borderfloor_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "borderfloor_white";
-	dir = 9
+	tag = "icon-borderfloor_white (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/command/aiupload)
 "kr" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	tag = "icon-borderfloor_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "borderfloor_white";
-	dir = 5
+	tag = "icon-borderfloor_white (NORTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/command/aiupload)
 "ks" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/command/aiupload)
@@ -5992,14 +5992,14 @@
 	req_access = list(16)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,
@@ -6014,11 +6014,11 @@
 "kv" = (
 /obj/structure/ladder/up,
 /obj/machinery/door/blast/regular/open{
-	tag = "icon-pdoor0 (WEST)";
-	name = "Bridge Lockdown";
-	icon_state = "pdoor0";
 	dir = 8;
-	id = "bridgelock"
+	icon_state = "pdoor0";
+	id = "bridgelock";
+	name = "Bridge Lockdown";
+	tag = "icon-pdoor0 (WEST)"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6027,8 +6027,8 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -6042,14 +6042,14 @@
 "kx" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6082,18 +6082,18 @@
 	icon_state = "camera"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfourth)
 "kB" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -6101,9 +6101,9 @@
 "kC" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -6118,9 +6118,9 @@
 	icon_state = "camera"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -6143,9 +6143,9 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/corner/white/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/civilian/holodeck)
@@ -6184,12 +6184,12 @@
 	id_tag = "trajan_shuttle_pump_out_external"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
+	dir = 8;
+	icon_state = "handrail"
 	},
 /obj/machinery/access_button/airlock_exterior{
 	frequency = 1331;
@@ -6256,8 +6256,8 @@
 /area/exploration_shuttle/cargo)
 "kO" = (
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
+	dir = 8;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cargo)
@@ -6279,8 +6279,8 @@
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -6396,9 +6396,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	tag = "icon-borderfloor_white (WEST)";
+	dir = 8;
 	icon_state = "borderfloor_white";
-	dir = 8
+	tag = "icon-borderfloor_white (WEST)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/command/aiupload)
@@ -6411,18 +6411,18 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	tag = "icon-borderfloor_white (EAST)";
+	dir = 4;
 	icon_state = "borderfloor_white";
-	dir = 4
+	tag = "icon-borderfloor_white (EAST)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/command/aiupload)
 "lf" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/porta_turret,
 /obj/item/device/radio/intercom{
@@ -6563,8 +6563,8 @@
 /area/logistics/hangar)
 "lu" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -6581,8 +6581,8 @@
 	id_tag = "trajan_out"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -6605,8 +6605,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exploration_shuttle/main)
@@ -6620,8 +6620,8 @@
 	tag_exterior_sensor = "trajan_shuttle_sensor_external"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -6637,8 +6637,8 @@
 /area/exploration_shuttle/main)
 "ly" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -6665,8 +6665,8 @@
 	icon_state = "camera"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exploration_shuttle/main)
@@ -6791,35 +6791,35 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	tag = "icon-borderfloor_white (WEST)";
+	dir = 8;
 	icon_state = "borderfloor_white";
-	dir = 8
+	tag = "icon-borderfloor_white (WEST)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/command/aiupload)
 "lM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	tag = "icon-borderfloor_white (EAST)";
+	dir = 4;
 	icon_state = "borderfloor_white";
-	dir = 4
+	tag = "icon-borderfloor_white (EAST)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/command/aiupload)
 "lN" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/computer/robotics{
-	tag = "icon-computer (WEST)";
+	dir = 8;
 	icon_state = "computer";
-	dir = 8
+	tag = "icon-computer (WEST)"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -6845,9 +6845,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -6860,9 +6860,9 @@
 	tag_door = "escape_pod_2_berth_hatch"
 	},
 /obj/effect/floor_decal/corner/orange{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -6880,9 +6880,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/effect/floor_decal/corner/white{
 	dir = 4
@@ -6891,9 +6891,9 @@
 /area/hallway/centralfourth)
 "lV" = (
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
@@ -6909,9 +6909,9 @@
 	tag_door = "escape_pod_3_berth_hatch"
 	},
 /obj/effect/floor_decal/corner/orange{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -6936,17 +6936,17 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "lZ" = (
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -6979,24 +6979,24 @@
 "mc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "md" = (
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "me" = (
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
@@ -7005,9 +7005,9 @@
 /area/hallway/centralfourth)
 "mf" = (
 /obj/effect/floor_decal/corner/white{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -7030,8 +7030,8 @@
 /area/hallway/centralfourth)
 "mi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -7078,9 +7078,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7089,8 +7089,8 @@
 /area/hallway/centralfourth)
 "ml" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -7108,13 +7108,13 @@
 /area/hallway/centralfourth)
 "mm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7131,13 +7131,13 @@
 /area/hallway/centralfourth)
 "mn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7149,13 +7149,13 @@
 /area/hallway/centralfourth)
 "mo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -7175,8 +7175,8 @@
 "mp" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -7206,12 +7206,12 @@
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exploration_shuttle/main)
@@ -7223,8 +7223,8 @@
 	name = "Trajan External Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exploration_shuttle/main)
@@ -7238,8 +7238,8 @@
 	id_tag = "trajan_shuttle_pump_out_internal"
 	},
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /obj/machinery/oxygen_pump{
 	pixel_y = -32
@@ -7250,8 +7250,8 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light/small,
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -7280,8 +7280,8 @@
 	pixel_y = -28
 	},
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exploration_shuttle/main)
@@ -7338,39 +7338,39 @@
 "mF" = (
 /obj/machinery/suit_storage_unit/explorer,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "mG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j1";
-	dir = 1
+	tag = "icon-pipe-j1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "mH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -7397,13 +7397,13 @@
 "mJ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7413,13 +7413,13 @@
 "mK" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7430,13 +7430,13 @@
 "mL" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -7447,21 +7447,21 @@
 "mM" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "mN" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -7476,13 +7476,13 @@
 "mO" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7538,9 +7538,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	tag = "icon-borderfloor_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "borderfloor_white";
-	dir = 10
+	tag = "icon-borderfloor_white (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/old_tile,
@@ -7552,16 +7552,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	tag = "icon-borderfloor_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "borderfloor_white";
-	dir = 6
+	tag = "icon-borderfloor_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/old_tile,
@@ -7571,13 +7571,13 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7597,8 +7597,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7609,8 +7609,8 @@
 /area/command/aiupload)
 "mV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -7637,8 +7637,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7732,9 +7732,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -7750,13 +7750,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -7771,13 +7771,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7796,13 +7796,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -7820,9 +7820,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7837,8 +7837,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -7846,8 +7846,8 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -7881,13 +7881,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7908,9 +7908,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -7948,9 +7948,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7967,13 +7967,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -7990,8 +7990,8 @@
 	},
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfourth)
@@ -8005,9 +8005,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8039,12 +8039,12 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfourth)
@@ -8099,8 +8099,8 @@
 "nA" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -8113,8 +8113,8 @@
 /area/logistics/hangar)
 "nB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -8221,8 +8221,8 @@
 "nP" = (
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/plating,
 /area/command/fourth_emergency_storage)
@@ -8302,17 +8302,17 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "oa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -8327,16 +8327,16 @@
 "od" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/brown{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "oe" = (
 /obj/effect/floor_decal/corner/brown/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -8344,16 +8344,16 @@
 "of" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/centralfourth)
 "og" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -8436,8 +8436,8 @@
 "oq" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -8457,12 +8457,12 @@
 /area/logistics/hangar)
 "or" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8473,12 +8473,12 @@
 /area/logistics/hangar)
 "os" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -8494,25 +8494,25 @@
 	name = "Expedition Prep Access"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "ot" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8524,8 +8524,8 @@
 "ou" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8536,9 +8536,9 @@
 /area/logistics/genprep)
 "ov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -8553,12 +8553,12 @@
 /area/logistics/genprep)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8616,8 +8616,8 @@
 "oC" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -8702,12 +8702,12 @@
 	pixel_x = -21
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
@@ -8764,8 +8764,8 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bottomgun)
@@ -8815,9 +8815,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -8874,9 +8874,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8901,8 +8901,8 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/hangercheckpoint)
@@ -8914,9 +8914,9 @@
 "pb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -8949,9 +8949,9 @@
 /area/hallway/centralfourth)
 "pg" = (
 /obj/effect/floor_decal/corner/brown{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -9025,8 +9025,8 @@
 /area/logistics/genprep)
 "pr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
@@ -9110,8 +9110,8 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9124,8 +9124,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9182,8 +9182,8 @@
 	id_tag = null
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bottomgun)
@@ -9201,8 +9201,8 @@
 /area/security/bottomgun)
 "pM" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -9223,8 +9223,8 @@
 /area/engineering/drone_fabrication)
 "pP" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plating,
@@ -9312,8 +9312,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9330,9 +9330,9 @@
 /area/security/hangercheckpoint)
 "pZ" = (
 /obj/effect/floor_decal/corner/brown{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -9342,24 +9342,24 @@
 /area/hallway/centralfourth)
 "qa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "qb" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva3";
+	dir = 2;
 	icon_state = "nerva3";
-	dir = 2
+	tag = "icon-nerva3"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "qc" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4";
+	dir = 2;
 	icon_state = "nerva4";
-	dir = 2
+	tag = "icon-nerva4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -9424,12 +9424,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -9448,9 +9448,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -9467,12 +9467,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9486,12 +9486,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -9510,12 +9510,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9530,12 +9530,12 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9550,12 +9550,12 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9572,8 +9572,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9593,12 +9593,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9609,12 +9609,12 @@
 /area/logistics/hangar)
 "qs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9687,8 +9687,8 @@
 	req_access = list(75)
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
@@ -9771,9 +9771,9 @@
 /area/command/bottom_hallway)
 "qI" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -9781,8 +9781,8 @@
 	pixel_x = -25
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/nuke_storage)
@@ -9806,13 +9806,13 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHWEST)";
+	dir = 9;
 	icon_state = "warning";
-	dir = 9
+	tag = "icon-warning (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/nuke_storage)
@@ -9828,8 +9828,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -9890,12 +9890,12 @@
 	id = "torpedo"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
@@ -9912,16 +9912,16 @@
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bottomgun)
 "qR" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -9969,8 +9969,8 @@
 "qV" = (
 /obj/item/remains/robot,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -10085,17 +10085,17 @@
 /area/hallway/centralfourth)
 "rf" = (
 /obj/effect/floor_decal/corner/brown{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "rg" = (
 /obj/effect/floor_decal/corner/brown{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/urist/nervalogo,
 /obj/machinery/camera/network/fourth_deck{
@@ -10107,23 +10107,23 @@
 /area/hallway/centralfourth)
 "rh" = (
 /obj/effect/floor_decal/corner/brown{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2";
+	dir = 2;
 	icon_state = "nerva2";
-	dir = 2
+	tag = "icon-nerva2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "ri" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/brown{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/structure/sign/deck/fourth{
 	pixel_y = -24
@@ -10132,9 +10132,9 @@
 /area/hallway/centralfourth)
 "rj" = (
 /obj/effect/floor_decal/corner/brown/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -10142,8 +10142,8 @@
 	pixel_y = -22
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -10155,14 +10155,14 @@
 /area/turbolift/main_fourth_deck)
 "rl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -10182,21 +10182,21 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/centralfourth)
 "rn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/alarm{
@@ -10211,13 +10211,13 @@
 	name = "Central Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/catwalk_plated,
@@ -10231,13 +10231,13 @@
 /area/logistics/hangar)
 "rq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -10245,8 +10245,8 @@
 "rr" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -10267,8 +10267,8 @@
 /area/logistics/hangar)
 "rt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -10303,8 +10303,8 @@
 /area/logistics/hangar)
 "rw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -10335,8 +10335,8 @@
 /area/logistics/hangar)
 "rz" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -10450,9 +10450,9 @@
 /area/maintenance/fourth_deck/fs)
 "rL" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -10471,9 +10471,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/nuke_storage)
@@ -10482,9 +10482,9 @@
 /area/command/safe_room)
 "rP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -10498,17 +10498,17 @@
 /area/security/bottomgun)
 "rQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "torpedo"
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -10520,12 +10520,12 @@
 /area/security/bottomgun)
 "rR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bottomgun)
@@ -10536,9 +10536,9 @@
 /area/security/bottomgun)
 "rT" = (
 /obj/machinery/atmospherics/unary/engine{
-	tag = "icon-nozzle (EAST)";
+	dir = 4;
 	icon_state = "nozzle";
-	dir = 4
+	tag = "icon-nozzle (EAST)"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/bdstarengine)
@@ -10553,16 +10553,16 @@
 /area/engineering/bdstarengine)
 "rV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -10658,9 +10658,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/hangar)
@@ -10685,13 +10685,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -10703,13 +10703,13 @@
 "sl" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -10722,13 +10722,13 @@
 "sm" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -10794,8 +10794,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -10813,8 +10813,8 @@
 /obj/structure/table/steel,
 /obj/item/weapon/folder/blue,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
+	dir = 9;
+	icon_state = "techfloor_edges"
 	},
 /obj/item/weapon/deck/cards,
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
@@ -10825,9 +10825,9 @@
 /area/security/bottomgun)
 "su" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/conveyor{
 	dir = 1;
@@ -10848,8 +10848,8 @@
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bottomgun)
@@ -10861,8 +10861,8 @@
 /area/engineering/bdstarengine)
 "sx" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -10972,9 +10972,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -10992,9 +10992,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -11009,9 +11009,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -11029,17 +11029,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/central)
 "sK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11047,9 +11047,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -11066,12 +11066,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -11082,8 +11082,8 @@
 /area/maintenance/fourth_deck/central)
 "sM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11091,9 +11091,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11103,8 +11103,8 @@
 /area/maintenance/fourth_deck/central)
 "sN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11112,9 +11112,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11130,8 +11130,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -11140,8 +11140,8 @@
 /area/maintenance/fourth_deck/central)
 "sP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11149,9 +11149,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11193,14 +11193,14 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/disposalpipe/up,
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	tag = "icon-up-supply (WEST)";
+	dir = 8;
 	icon_state = "up-supply";
-	dir = 8
+	tag = "icon-up-supply (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	tag = "icon-up-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "up-scrubbers";
-	dir = 8
+	tag = "icon-up-scrubbers (WEST)"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -11238,12 +11238,12 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
@@ -11256,12 +11256,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -11269,9 +11269,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/hangar)
@@ -11285,12 +11285,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -11302,12 +11302,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -11319,12 +11319,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -11340,12 +11340,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -11361,12 +11361,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red,
@@ -11379,9 +11379,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -11450,9 +11450,9 @@
 /area/security/bottomgun)
 "tm" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11478,14 +11478,14 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bottomgun)
@@ -11502,9 +11502,9 @@
 "tp" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -11627,13 +11627,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -11649,13 +11649,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/light/small/red,
 /obj/structure/catwalk,
@@ -11668,13 +11668,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
@@ -11690,13 +11690,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -11708,13 +11708,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/conveyor{
@@ -11734,12 +11734,12 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
@@ -11750,9 +11750,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/hangar)
@@ -11804,15 +11804,15 @@
 "tW" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "tX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -11829,9 +11829,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -11911,8 +11911,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -11983,9 +11983,9 @@
 /obj/item/device/electronic_assembly/drone,
 /obj/item/integrated_circuit/manipulation/locomotion,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/logistics/advwork)
@@ -12033,21 +12033,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "uy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/hangar)
@@ -12111,8 +12111,8 @@
 	dir = 10
 	},
 /obj/machinery/light/chromatic{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -12122,12 +12122,12 @@
 	name = "Isolation Tray Valve"
 	},
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -12144,12 +12144,12 @@
 /area/rnd/xenobiology/xenoflora)
 "uI" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -12164,8 +12164,8 @@
 /area/rnd/xenobiology/xenoflora)
 "uJ" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 4
@@ -12178,8 +12178,8 @@
 	level = 2
 	},
 /obj/machinery/light/chromatic{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
@@ -12188,19 +12188,19 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "uM" = (
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
@@ -12247,15 +12247,15 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/safe_room)
 "uV" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Safe Room Atmospherics";
@@ -12294,8 +12294,8 @@
 "vb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -12333,9 +12333,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -12352,13 +12352,13 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -12385,9 +12385,9 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -12399,8 +12399,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -12512,9 +12512,9 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/table/standard,
 /obj/item/device/integrated_circuit_printer,
@@ -12569,8 +12569,8 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -12589,17 +12589,17 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12619,16 +12619,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12647,13 +12647,13 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12668,8 +12668,8 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12688,13 +12688,13 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12708,8 +12708,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -12730,12 +12730,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12744,12 +12744,12 @@
 /area/rnd/storage)
 "vK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -12763,12 +12763,12 @@
 /area/rnd/xenobiology/xenoflora)
 "vL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -12786,12 +12786,12 @@
 /area/rnd/xenobiology/xenoflora)
 "vM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
@@ -12802,23 +12802,23 @@
 	name = "Isolation Tray Valve"
 	},
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "vO" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -12829,8 +12829,8 @@
 /area/rnd/xenobiology/xenoflora)
 "vP" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
+	dir = 10;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4
@@ -12844,14 +12844,14 @@
 /area/rnd/xenobiology/xenoflora)
 "vR" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
@@ -12869,8 +12869,8 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_corners"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 26;
@@ -12893,8 +12893,8 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -12908,8 +12908,8 @@
 "vY" = (
 /obj/structure/closet/secure_closet/guncabinet/sidearm/small,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 6
+	dir = 6;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -12930,16 +12930,16 @@
 /area/maintenance/fourth_deck/fs)
 "wa" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "wb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -12978,8 +12978,8 @@
 /area/engineering/bdstarengine)
 "wf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -13039,9 +13039,9 @@
 /obj/item/device/electronic_assembly/medium,
 /obj/item/device/integrated_electronics/analyzer,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/logistics/advwork)
@@ -13072,13 +13072,13 @@
 /area/logistics/hangar)
 "wr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck Cargo Hallway";
@@ -13112,9 +13112,9 @@
 /obj/item/weapon/wrench,
 /obj/machinery/light,
 /obj/machinery/atmospherics/valve/shutoff{
-	tag = "icon-map_vclamp0 (WEST)";
+	dir = 8;
 	icon_state = "map_vclamp0";
-	dir = 8
+	tag = "icon-map_vclamp0 (WEST)"
 	},
 /obj/effect/floor_decal/industrial/shutoff{
 	dir = 4
@@ -13129,8 +13129,8 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -13144,16 +13144,16 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
 "ww" = (
 /obj/machinery/biogenerator,
 /obj/machinery/light/chromatic{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -13180,19 +13180,19 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "wz" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -13207,12 +13207,12 @@
 /area/rnd/xenobiology/xenoflora)
 "wA" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -13224,12 +13224,12 @@
 "wB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -13257,31 +13257,31 @@
 /area/rnd/xenobiology/xenoflora)
 "wE" = (
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "wF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13291,13 +13291,13 @@
 /area/rnd/xenobiology/xenoflora)
 "wG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13307,21 +13307,21 @@
 /area/rnd/xenobiology/xenoflora)
 "wH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -13332,25 +13332,25 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "wJ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
@@ -13573,8 +13573,8 @@
 	},
 /obj/item/weapon/crowbar,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -13621,17 +13621,17 @@
 /obj/item/integrated_circuit/output/sound/beeper,
 /obj/item/integrated_circuit/output/sound/beepsky,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/logistics/advwork)
 "xi" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
@@ -13645,9 +13645,9 @@
 /obj/item/stack/cable_coil,
 /obj/item/weapon/cell/high,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/machinery/camera/network/cargo{
 	c_tag = "Advanced Workshop";
@@ -13724,9 +13724,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/shutoff,
 /obj/structure/disposalpipe/segment,
@@ -13761,8 +13761,8 @@
 /area/rnd/xenobiology/xenoflora)
 "xu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -13780,31 +13780,31 @@
 	name = "Lower Xenoflora Tray Valve"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -13813,12 +13813,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/corner/green{
@@ -13831,8 +13831,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -13851,55 +13851,55 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xC" = (
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
@@ -13912,15 +13912,15 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/structure/table/glass,
 /obj/item/weapon/wrench,
 /obj/item/weapon/weldingtool,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/item/weapon/melee/baton/loaded,
 /obj/item/device/healthanalyzer,
@@ -13940,12 +13940,12 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -13968,9 +13968,9 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
@@ -13978,9 +13978,9 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
@@ -13990,8 +13990,8 @@
 /area/maintenance/fourth_deck/fs)
 "xL" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/reinforced,
@@ -14023,29 +14023,29 @@
 "xQ" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	tag = "icon-up-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "up-scrubbers";
-	dir = 4
+	tag = "icon-up-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	tag = "icon-up-supply (EAST)";
+	dir = 4;
 	icon_state = "up-supply";
-	dir = 4
+	tag = "icon-up-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/fuel{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "16-0";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "16-0"
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -14060,13 +14060,13 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -14075,9 +14075,9 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -14172,8 +14172,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -14191,13 +14191,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14223,13 +14223,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -14244,13 +14244,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14270,8 +14270,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -14318,16 +14318,16 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/fabwork)
 "yg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
@@ -14339,21 +14339,21 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	tag = "icon-warningcorner (WEST)";
+	dir = 8;
 	icon_state = "warningcorner";
-	dir = 8
+	tag = "icon-warningcorner (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
 "yh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -14368,13 +14368,13 @@
 /area/logistics/fabwork)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -14407,13 +14407,13 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/hangar)
@@ -14441,9 +14441,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
@@ -14469,8 +14469,8 @@
 "yp" = (
 /obj/machinery/vending/hydronutrients,
 /obj/machinery/light/chromatic{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -14489,24 +14489,24 @@
 /area/rnd/xenobiology/xenoflora)
 "yr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "ys" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/meter,
@@ -14514,28 +14514,28 @@
 /area/rnd/xenobiology/xenoflora)
 "yt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "yu" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -14556,8 +14556,8 @@
 /area/rnd/xenobiology/xenoflora)
 "yx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -14575,8 +14575,8 @@
 "yz" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -14622,9 +14622,9 @@
 /area/rnd/xenobiology/xenoflora)
 "yE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light/small,
@@ -14657,9 +14657,9 @@
 /area/engineering/substation/fourth_deck)
 "yI" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /obj/machinery/power/sensor{
 	name_tag = "Fourth Deck Power"
@@ -14706,9 +14706,9 @@
 /obj/item/weapon/disk/tech_disk,
 /obj/item/weapon/disk/tech_disk,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHWEST)";
+	dir = 9;
 	icon_state = "warning";
-	dir = 9
+	tag = "icon-warning (NORTHWEST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -14720,9 +14720,9 @@
 /area/logistics/advwork)
 "yM" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -14733,9 +14733,9 @@
 /area/logistics/advwork)
 "yN" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
@@ -14745,9 +14745,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -14770,9 +14770,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -14780,12 +14780,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -14799,8 +14799,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -14812,9 +14812,9 @@
 	id_tag = null
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/hangar)
@@ -14860,8 +14860,8 @@
 /obj/item/device/slime_scanner,
 /obj/item/device/analyzer/plant_analyzer,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/item/clothing/accessory/armband/whitered,
 /turf/simulated/floor/carpet/red,
@@ -14872,12 +14872,12 @@
 /area/rnd/xenobiology/xenoflora)
 "ze" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -14892,8 +14892,8 @@
 "zf" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 1
+	dir = 1;
+	icon_state = "map_connector"
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/holofloor/tiled/dark,
@@ -14901,8 +14901,8 @@
 "zg" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 1
+	dir = 1;
+	icon_state = "map_connector"
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/light/chromatic,
@@ -14910,12 +14910,12 @@
 /area/rnd/xenobiology/xenoflora)
 "zh" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/beakers,
@@ -14955,8 +14955,8 @@
 /area/rnd/xenobiology/xenoflora)
 "zj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /obj/machinery/meter,
 /obj/structure/cable{
@@ -14998,8 +14998,8 @@
 "zm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15010,9 +15010,9 @@
 /area/rnd/xenobiology/xenoflora)
 "zn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
@@ -15027,8 +15027,8 @@
 	tag = "icon-alarm0 (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
@@ -15067,8 +15067,8 @@
 "zs" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -15119,8 +15119,8 @@
 "zz" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -15139,9 +15139,9 @@
 "zC" = (
 /obj/machinery/light/small,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -15152,18 +15152,18 @@
 /area/engineering/substation/fourth_deck)
 "zD" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -15181,9 +15181,9 @@
 	pixel_y = -2
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	tag = "icon-warningcorner (NORTH)";
+	dir = 1;
 	icon_state = "warningcorner";
-	dir = 1
+	tag = "icon-warningcorner (NORTH)"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Fourth Deck Substation";
@@ -15213,9 +15213,9 @@
 "zH" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -15236,9 +15236,9 @@
 /obj/item/weapon/stock_parts/scanning_module,
 /obj/item/weapon/stock_parts/scanning_module,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -15269,9 +15269,9 @@
 "zM" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -15310,8 +15310,8 @@
 /area/logistics/fabwork)
 "zQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -15342,9 +15342,9 @@
 /area/logistics/hangar)
 "zV" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/hangar)
@@ -15357,12 +15357,12 @@
 /area/rnd/xenobiology/xenoflora)
 "zY" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15382,8 +15382,8 @@
 "zZ" = (
 /obj/machinery/light/chromatic,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/tiled/white,
@@ -15429,8 +15429,8 @@
 "Af" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -15449,9 +15449,9 @@
 "Ag" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -15459,8 +15459,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15470,9 +15470,9 @@
 "Ah" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -15480,8 +15480,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/random/junk,
 /obj/structure/disposalpipe/segment{
@@ -15492,9 +15492,9 @@
 "Ai" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15507,8 +15507,8 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -15593,9 +15593,9 @@
 "Ar" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb1 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb1";
-	dir = 1
+	tag = "icon-cobweb1 (NORTH)"
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -15620,8 +15620,8 @@
 	},
 /obj/item/device/radio,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -15639,18 +15639,18 @@
 /obj/item/weapon/stock_parts/matter_bin,
 /obj/item/weapon/stock_parts/micro_laser,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/logistics/advwork)
 "Aw" = (
 /obj/machinery/r_n_d/destructive_analyzer,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/logistics/advwork)
@@ -15681,9 +15681,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -15694,9 +15694,9 @@
 	},
 /obj/item/shipweapons/torpedo_warhead,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -15712,9 +15712,9 @@
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -15724,9 +15724,9 @@
 	amount = 50
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/camera/network/cargo{
 	c_tag = "Cargo Workshop";
@@ -15742,9 +15742,9 @@
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
@@ -15754,9 +15754,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -15773,18 +15773,18 @@
 	icon_state = "pipe-j2"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
 "AF" = (
 /obj/machinery/smartfridge/tanningrack,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -15807,8 +15807,8 @@
 "AI" = (
 /obj/machinery/chem_master,
 /obj/effect/floor_decal/corner/purple/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -15822,8 +15822,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemlab)
@@ -15835,8 +15835,8 @@
 /obj/machinery/reagentgrinder,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/purple/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/item/weapon/reagent_containers/dropper,
 /obj/structure/extinguisher_cabinet{
@@ -15846,9 +15846,9 @@
 /area/rnd/chemlab)
 "AL" = (
 /obj/structure/sign/chemistry{
-	tag = "icon-chemistry (EAST)";
+	dir = 4;
 	icon_state = "chemistry";
-	dir = 4
+	tag = "icon-chemistry (EAST)"
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/chemlab)
@@ -15888,9 +15888,9 @@
 	req_access = list(55)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -15905,8 +15905,8 @@
 "AR" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -15935,8 +15935,8 @@
 /area/rnd/xenobiology/xenoflora)
 "AU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/machinery/artifact_analyser,
 /turf/simulated/floor/tiled/dark,
@@ -15984,9 +15984,9 @@
 /area/maintenance/fourth_deck/afs)
 "Bb" = (
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb2 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb2";
-	dir = 1
+	tag = "icon-cobweb2 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -16000,9 +16000,9 @@
 /area/maintenance/fourth_deck/afs)
 "Bd" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -16012,9 +16012,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -16031,9 +16031,9 @@
 /obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/item/weapon/hand_labeler,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHWEST)";
+	dir = 10;
 	icon_state = "warning";
-	dir = 10
+	tag = "icon-warning (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/logistics/advwork)
@@ -16061,9 +16061,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/logistics/advwork)
@@ -16075,8 +16075,8 @@
 "Bn" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -16099,9 +16099,9 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemlab)
@@ -16124,8 +16124,8 @@
 /area/rnd/chemlab)
 "Bq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -16133,14 +16133,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemlab)
@@ -16151,8 +16151,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -16160,9 +16160,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemlab)
@@ -16182,16 +16182,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "Bt" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -16199,17 +16199,17 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "Bu" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -16234,9 +16234,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
@@ -16336,9 +16336,9 @@
 "BP" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/prep)
@@ -16390,8 +16390,8 @@
 /area/logistics/lowercargo)
 "BV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -16410,9 +16410,9 @@
 /area/logistics/lowercargo)
 "BX" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -16506,8 +16506,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16568,9 +16568,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16585,9 +16585,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16603,8 +16603,8 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -16636,9 +16636,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/prep)
@@ -16649,13 +16649,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/prep)
@@ -16666,13 +16666,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -16690,13 +16690,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
@@ -16708,13 +16708,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -16728,13 +16728,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -16757,13 +16757,13 @@
 /area/logistics/lowercargo)
 "Cx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
@@ -16771,9 +16771,9 @@
 "Cy" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -16830,9 +16830,9 @@
 	},
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -16850,8 +16850,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -16860,8 +16860,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -16872,14 +16872,14 @@
 	},
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -17022,8 +17022,8 @@
 /area/logistics/prep)
 "CY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/prep)
@@ -17067,16 +17067,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -17123,8 +17123,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 4
+	dir = 4;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
@@ -17164,9 +17164,9 @@
 	req_access = list(55)
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -17184,8 +17184,8 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -17214,14 +17214,14 @@
 	req_access = list(55)
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /obj/effect/floor_decal/corner/blue{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -17257,9 +17257,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
@@ -17268,8 +17268,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
@@ -17316,9 +17316,9 @@
 	id = "garbage"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/disposals)
@@ -17331,8 +17331,8 @@
 "Dz" = (
 /obj/item/weapon/stool/padded,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -17345,8 +17345,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -17381,9 +17381,9 @@
 	pixel_y = -28
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/item/weapon/carpentry/axe,
 /obj/item/weapon/carpentry/saw,
@@ -17403,9 +17403,9 @@
 	req_access = list(48)
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/prep)
@@ -17421,9 +17421,9 @@
 	req_access = list(48)
 	},
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/prep)
@@ -17465,16 +17465,16 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	tag = "icon-warningcorner (EAST)";
+	dir = 4;
 	icon_state = "warningcorner";
-	dir = 4
+	tag = "icon-warningcorner (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
 "DI" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -17492,8 +17492,8 @@
 /area/logistics/lowercargo)
 "DL" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "slimecell2";
@@ -17544,8 +17544,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -17608,9 +17608,9 @@
 /area/maintenance/fourth_deck/disposals)
 "DU" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /obj/structure/closet/crate,
 /obj/random/bomb_supply,
@@ -17637,12 +17637,12 @@
 /area/logistics/lowercargo)
 "DY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/dark,
@@ -17704,17 +17704,17 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	tag = "icon-warningcorner (WEST)";
+	dir = 8;
 	icon_state = "warningcorner";
-	dir = 8
+	tag = "icon-warningcorner (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -17757,9 +17757,9 @@
 	},
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -17794,14 +17794,14 @@
 	},
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /obj/effect/floor_decal/corner/orange{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -17942,9 +17942,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -17985,9 +17985,9 @@
 /area/logistics/lowercargo)
 "ED" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -18008,9 +18008,9 @@
 	req_access = list(55)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18023,17 +18023,17 @@
 	req_access = list(55)
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18059,8 +18059,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18073,19 +18073,19 @@
 	req_access = list(55)
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /obj/effect/floor_decal/corner/orange{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18106,9 +18106,9 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18117,14 +18117,14 @@
 /area/rnd/xenobiology)
 "EK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /mob/living/carbon/slime,
 /turf/simulated/floor/reinforced,
@@ -18146,19 +18146,19 @@
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "EM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -18174,13 +18174,13 @@
 /area/maintenance/fourth_deck/disposals)
 "EN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -18204,8 +18204,8 @@
 	pixel_y = -6
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/disposals)
@@ -18215,11 +18215,11 @@
 	id = "garbage"
 	},
 /obj/machinery/door/blast/regular{
-	icon_state = "pdoor0";
 	density = 0;
-	opacity = 0;
+	icon_state = "pdoor0";
 	id = "Disposal Exit";
-	name = "disposal exit vent"
+	name = "disposal exit vent";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/disposals)
@@ -18229,9 +18229,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -18253,8 +18253,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/storage)
@@ -18265,9 +18265,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/storage)
@@ -18278,21 +18278,21 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/storage)
 "EY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/storage)
@@ -18302,26 +18302,26 @@
 	req_access = list(31)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/logistics/storage)
 "Fa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -18335,14 +18335,14 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -18441,9 +18441,9 @@
 /area/maintenance/fourth_deck/afs)
 "Fn" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -18471,8 +18471,8 @@
 "Fr" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
@@ -18515,14 +18515,14 @@
 /area/logistics/lowercargo)
 "Fw" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -18538,9 +18538,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -18553,9 +18553,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
@@ -18599,10 +18599,10 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/tvalve/mirrored/digital/bypass{
-	tag = "icon-map_tvalvem1 (EAST)";
-	name = "Cell Air / Atmos Manipulation Switch";
+	dir = 4;
 	icon_state = "map_tvalvem1";
-	dir = 4
+	name = "Cell Air / Atmos Manipulation Switch";
+	tag = "icon-map_tvalvem1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -18632,8 +18632,8 @@
 /area/rnd/xenobiology)
 "FF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -18647,8 +18647,8 @@
 /area/rnd/xenobiology)
 "FG" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -18659,8 +18659,8 @@
 /area/rnd/xenobiology)
 "FH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -18687,9 +18687,9 @@
 /area/rnd/xenobiology)
 "FJ" = (
 /obj/machinery/atmospherics/unary/freezer{
-	tag = "icon-freezer_0 (WEST)";
+	dir = 8;
 	icon_state = "freezer_0";
-	dir = 8
+	tag = "icon-freezer_0 (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18702,8 +18702,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -18728,8 +18728,8 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/fourth_deck/disposals)
@@ -18766,8 +18766,8 @@
 /area/rnd/xenobiology)
 "FT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -18785,8 +18785,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18797,8 +18797,8 @@
 	pixel_y = 12
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18806,22 +18806,22 @@
 /obj/machinery/optable,
 /obj/item/device/slime_scanner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "FX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "FY" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18843,9 +18843,9 @@
 	id = "trash"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/fourth_deck/disposals)
@@ -18880,9 +18880,9 @@
 /area/maintenance/fourth_deck/afs)
 "Gn" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -18906,8 +18906,8 @@
 /area/rnd/xenobiology)
 "Gp" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/meter,
 /obj/structure/cable{
@@ -18942,9 +18942,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18953,32 +18953,32 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "Gt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "Gu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "Gv" = (
 /obj/machinery/atmospherics/unary/heater{
-	tag = "icon-heater_0 (WEST)";
+	dir = 8;
 	icon_state = "heater_0";
-	dir = 8
+	tag = "icon-heater_0 (WEST)"
 	},
 /obj/structure/sign/warning/nosmoking_1{
 	dir = 8;
@@ -19157,9 +19157,9 @@
 /area/maintenance/fourth_deck/afs)
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -19177,9 +19177,9 @@
 /area/rnd/xenobiology)
 "GS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -19308,8 +19308,8 @@
 "He" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -19328,16 +19328,16 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "Hi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -19348,8 +19348,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -19403,8 +19403,8 @@
 	name = "Hadrian External Access"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/white/monotile,
@@ -19430,12 +19430,12 @@
 /area/hadrian/main)
 "Hq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -19445,13 +19445,13 @@
 /area/space)
 "Hw" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/structure/handrai{
-	tag = "icon-handrail (EAST)";
+	dir = 4;
 	icon_state = "handrail";
-	dir = 4
+	tag = "icon-handrail (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -19534,9 +19534,9 @@
 /area/hadrian/main)
 "HG" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion_l (WEST)";
+	dir = 8;
 	icon_state = "propulsion_l";
-	dir = 8
+	tag = "icon-propulsion_l (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/hadrian/storage)
@@ -19552,8 +19552,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -19563,8 +19563,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
@@ -19581,16 +19581,16 @@
 	pixel_y = 10
 	},
 /obj/structure/handrai{
-	tag = "icon-handrail (EAST)";
+	dir = 4;
 	icon_state = "handrail";
-	dir = 4
+	tag = "icon-handrail (EAST)"
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/hadrian/main)
 "HK" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -19612,9 +19612,9 @@
 /area/hadrian/main)
 "HL" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (WEST)";
+	dir = 8;
 	icon_state = "propulsion";
-	dir = 8
+	tag = "icon-propulsion (WEST)"
 	},
 /turf/simulated/floor/plating/airless,
 /area/hadrian/storage)
@@ -19651,8 +19651,8 @@
 /area/hadrian/storage)
 "HO" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -19667,9 +19667,9 @@
 	dir = 5
 	},
 /obj/structure/handrai{
-	tag = "icon-handrail (WEST)";
+	dir = 8;
 	icon_state = "handrail";
-	dir = 8
+	tag = "icon-handrail (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/hadrian/storage)
@@ -19699,8 +19699,8 @@
 "HS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/purple/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/structure/bed/chair/shuttle,
 /obj/machinery/recharger/wallcharger{
@@ -19713,8 +19713,8 @@
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/purple/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/item/device/radio,
 /obj/item/device/radio,
@@ -19750,21 +19750,21 @@
 /area/hadrian/storage)
 "HX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
 	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -19775,16 +19775,16 @@
 /area/hadrian/storage)
 "HY" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19822,47 +19822,47 @@
 "Ic" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/hologram/holopad/longrange,
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
 "Id" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (EAST)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
 "Ie" = (
 /obj/effect/floor_decal/corner/purple/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /obj/machinery/computer/shuttle_control/explore/hadrian{
-	tag = "icon-computer (WEST)";
+	dir = 8;
 	icon_state = "computer";
-	dir = 8
+	tag = "icon-computer (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
@@ -19940,9 +19940,9 @@
 /area/hadrian/main)
 "In" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (EAST)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 4
+	tag = "icon-shuttle_chair_preview (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/purple,
@@ -19950,9 +19950,9 @@
 /area/hadrian/main)
 "Io" = (
 /obj/effect/floor_decal/corner/purple/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/machinery/computer/general_air_control{
 	dir = 8;
@@ -19987,13 +19987,13 @@
 "Ir" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /obj/structure/handrai{
-	tag = "icon-handrail (WEST)";
+	dir = 8;
 	icon_state = "handrail";
-	dir = 8
+	tag = "icon-handrail (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/hadrian/storage)
@@ -20055,9 +20055,9 @@
 	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/purple/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/random/firstaid,
 /obj/item/bodybag/cryobag,
@@ -20096,21 +20096,21 @@
 	dir = 8
 	},
 /obj/structure/handrai{
-	tag = "icon-handrail (EAST)";
+	dir = 4;
 	icon_state = "handrail";
-	dir = 4
+	tag = "icon-handrail (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/hadrian/main)
 "IB" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -20183,19 +20183,19 @@
 	pixel_y = -28
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/plating,
 /area/hadrian/main)
 "II" = (
 /obj/machinery/light/chromatic{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/table/glass,
 /obj/machinery/camera/network/research{
@@ -20243,8 +20243,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 9
+	dir = 9;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
@@ -20262,9 +20262,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -20291,9 +20291,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20317,8 +20317,8 @@
 /area/logistics/hangar)
 "Jm" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20344,9 +20344,9 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
@@ -20362,16 +20362,16 @@
 /area/logistics/lowercargo)
 "Js" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -20383,12 +20383,12 @@
 /area/command/safe_room)
 "Jz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/anomaly_container,
@@ -20410,9 +20410,9 @@
 /area/command/safe_room)
 "JH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -20426,8 +20426,8 @@
 	dir = 6
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -20477,20 +20477,20 @@
 /area/hadrian/main)
 "Kf" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/bed/chair/padded/blue{
-	icon_state = "chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "Kh" = (
 /obj/structure/curtain/open/bed,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
@@ -20519,8 +20519,8 @@
 /area/logistics/fabwork)
 "Kz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/fourth_deck/afs)
@@ -20539,8 +20539,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -20567,8 +20567,8 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
+	dir = 8;
+	icon_state = "handrail"
 	},
 /obj/machinery/airlock_sensor{
 	dir = 4;
@@ -20591,8 +20591,8 @@
 	icon_state = "map"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 10
+	dir = 10;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/safe_room)
@@ -20616,8 +20616,8 @@
 /area/maintenance/fourth_deck/afs)
 "KI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -20641,8 +20641,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -20664,9 +20664,9 @@
 /area/logistics/hangar)
 "Lp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -20681,14 +20681,14 @@
 /area/maintenance/fourth_deck/fs)
 "Lr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "hadrian_shutters";
@@ -20741,9 +20741,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20766,8 +20766,8 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/nuke_storage)
@@ -20778,12 +20778,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -20801,8 +20801,8 @@
 	pixel_y = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/command/fourth_emergency_storage)
@@ -20841,8 +20841,8 @@
 /area/command/safe_room)
 "MB" = (
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -20888,8 +20888,8 @@
 "Nh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Safe Room";
@@ -20935,9 +20935,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20959,9 +20959,9 @@
 /area/rnd/xenobiology)
 "NP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21001,17 +21001,17 @@
 /area/rnd/xenobiology/xenoflora)
 "Oq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/fourth_deck/fs)
 "Ox" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -21026,16 +21026,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_techfloor_grid"
 	},
 /obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_corners"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -32;
@@ -21062,8 +21062,8 @@
 /area/maintenance/fourth_deck/afp)
 "Pd" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-stickyweb2";
-	icon_state = "stickyweb2"
+	icon_state = "stickyweb2";
+	tag = "icon-stickyweb2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -21144,9 +21144,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
@@ -21161,9 +21161,9 @@
 /area/hallway/centralfourth)
 "PQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21177,8 +21177,8 @@
 	req_access = list(12)
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -21186,9 +21186,9 @@
 "Qq" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21206,9 +21206,9 @@
 /area/maintenance/fourth_deck/afs)
 "QD" = (
 /obj/structure/shuttle/engine/heater{
-	tag = "icon-heater (WEST)";
+	dir = 8;
 	icon_state = "heater";
-	dir = 8
+	tag = "icon-heater (WEST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21217,9 +21217,9 @@
 /area/hadrian/storage)
 "QH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21234,9 +21234,9 @@
 /area/maintenance/fourth_deck/afs)
 "QN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -21251,8 +21251,8 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -21269,9 +21269,9 @@
 /area/maintenance/fourth_deck/afp)
 "QR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21285,23 +21285,23 @@
 	req_access = list(12)
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "QX" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -21330,9 +21330,9 @@
 /area/maintenance/fourth_deck/fs)
 "Rc" = (
 /obj/effect/floor_decal/corner/purple/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -21376,8 +21376,8 @@
 /area/maintenance/fourth_deck/fs)
 "Ry" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21403,12 +21403,12 @@
 /area/civilian/freezer)
 "RQ" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/nuke_storage)
@@ -21454,9 +21454,9 @@
 "Sk" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21549,13 +21549,13 @@
 /area/civilian/holodeck)
 "SX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21566,8 +21566,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -21604,9 +21604,9 @@
 /area/hadrian/main)
 "Tm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21635,8 +21635,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -21703,8 +21703,8 @@
 "TV" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 1
+	dir = 1;
+	icon_state = "map_connector"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -21728,14 +21728,14 @@
 	name = "Expedition Prep Access"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
@@ -21743,8 +21743,8 @@
 "Uz" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 1
+	dir = 1;
+	icon_state = "map_connector"
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/firealarm{
@@ -21764,13 +21764,13 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -21790,8 +21790,8 @@
 "Vi" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -21800,9 +21800,9 @@
 /area/logistics/hangar)
 "Vj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21813,8 +21813,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -21892,8 +21892,8 @@
 "VH" = (
 /obj/effect/paint/silver,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/wall/titanium,
 /area/hadrian/main)
@@ -21902,13 +21902,13 @@
 	req_access = list(12)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21940,9 +21940,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -21966,9 +21966,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21979,12 +21979,12 @@
 /area/maintenance/fourth_deck/afs)
 "Wm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21995,8 +21995,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -22013,9 +22013,9 @@
 /area/logistics/fabwork)
 "Wu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22026,8 +22026,8 @@
 	dir = 4
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -22043,12 +22043,12 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/corner_techfloor_grid{
-	icon_state = "corner_techfloor_grid";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_techfloor_grid"
 	},
 /obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_corners"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22116,8 +22116,8 @@
 /area/command/safe_room)
 "Xx" = (
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/machinery/button/remote/airlock{
 	id = "bridgesafedoor";
@@ -22137,12 +22137,12 @@
 	},
 /obj/machinery/shield_diffuser,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/medical/virology)
@@ -22206,8 +22206,8 @@
 	pixel_x = 32
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
@@ -22223,13 +22223,13 @@
 /area/command/safe_room)
 "Yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22243,8 +22243,8 @@
 	id = "torpedo"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -22261,9 +22261,9 @@
 	id = "torpedo"
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -22300,8 +22300,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -22317,16 +22317,16 @@
 /area/rnd/xenobiology)
 "YU" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -22351,9 +22351,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -22365,9 +22365,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	tag = "icon-warningcorner (EAST)";
+	dir = 4;
 	icon_state = "warningcorner";
-	dir = 4
+	tag = "icon-warningcorner (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -22380,8 +22380,8 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -22424,9 +22424,9 @@
 /area/command/safe_room)
 "ZA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -22445,16 +22445,16 @@
 /area/maintenance/fourth_deck/fs)
 "ZD" = (
 /obj/structure/sign/warning/secure_area{
-	icon_state = "securearea";
-	dir = 1
+	dir = 1;
+	icon_state = "securearea"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/safe_room)
 "ZQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/table/rack,
 /obj/random/tank,
@@ -22467,8 +22467,8 @@
 	icon_state = "intact"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 4
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /obj/structure/cable{
 	d1 = 1;

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -27,8 +27,8 @@
 "aag" = (
 /obj/structure/catwalk,
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/third_deck/centp)
@@ -218,9 +218,9 @@
 /obj/item/device/flashlight/flare/glowstick/random,
 /obj/random/maintenance,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/centp)
@@ -235,8 +235,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/centp)
@@ -351,9 +351,9 @@
 /area/maintenance/third_deck/afp)
 "abc" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/medical/treatment)
@@ -437,8 +437,8 @@
 	pixel_x = -5
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 9
+	dir = 9;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/white,
@@ -450,8 +450,8 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 1
+	dir = 1;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -461,8 +461,8 @@
 "abm" = (
 /obj/machinery/optable,
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 1
+	dir = 1;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -479,8 +479,8 @@
 "abn" = (
 /obj/machinery/computer/operating,
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 5
+	dir = 5;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
@@ -536,8 +536,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/centp)
@@ -562,8 +562,8 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/centp)
@@ -628,9 +628,9 @@
 	pixel_z = 0
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/medical/treatment)
@@ -642,8 +642,8 @@
 	},
 /obj/structure/closet/crate/freezer,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/item/weapon/reagent_containers/ivbag/nanoblood,
 /obj/item/weapon/reagent_containers/ivbag/nanoblood,
@@ -653,9 +653,9 @@
 /area/medical/treatment)
 "abG" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
-	tag = "icon-map_on (EAST)";
+	dir = 4;
 	icon_state = "map_on";
-	dir = 4
+	tag = "icon-map_on (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/treatment)
@@ -687,12 +687,12 @@
 /obj/item/weapon/storage/firstaid/adv,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 8
+	dir = 8;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/item/device/healthanalyzer,
 /turf/simulated/floor/tiled/white,
@@ -707,8 +707,8 @@
 	},
 /obj/structure/iv_drip,
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 4
+	dir = 4;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -840,8 +840,8 @@
 "ach" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
@@ -955,12 +955,12 @@
 /area/medical/surgery)
 "acs" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 8
+	dir = 8;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1000,8 +1000,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 4
+	dir = 4;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -1030,8 +1030,8 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/white,
@@ -1084,8 +1084,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/centp)
@@ -1170,8 +1170,8 @@
 /obj/random/medical/lite,
 /obj/random/medical/lite,
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /obj/item/device/healthanalyzer,
 /turf/simulated/floor/tiled/white,
@@ -1213,8 +1213,8 @@
 "acW" = (
 /obj/structure/bed/roller,
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /obj/effect/floor_decal/corner/pink{
 	dir = 10
@@ -1241,8 +1241,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 10
+	dir = 10;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
@@ -1281,8 +1281,8 @@
 /area/medical/surgery)
 "ada" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 6
+	dir = 6;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
@@ -1390,9 +1390,9 @@
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/ointment,
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb2 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb2";
-	dir = 1
+	tag = "icon-cobweb2 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
@@ -1415,8 +1415,8 @@
 /obj/random/maintenance,
 /obj/random/medical,
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb1";
-	icon_state = "cobweb1"
+	icon_state = "cobweb1";
+	tag = "icon-cobweb1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
@@ -1501,8 +1501,8 @@
 /area/medical/treatment)
 "adB" = (
 /obj/machinery/bodyscanner{
-	icon_state = "body_scanner_0";
-	dir = 1
+	dir = 1;
+	icon_state = "body_scanner_0"
 	},
 /obj/effect/floor_decal/corner/pink{
 	dir = 10
@@ -1584,8 +1584,8 @@
 /area/medical/morgue)
 "adI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
@@ -1608,9 +1608,9 @@
 /area/medical/morgue)
 "adL" = (
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/interrogation)
@@ -1619,18 +1619,18 @@
 	c_tag = "Interrogation Room"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/interrogation)
 "adN" = (
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/interrogation)
@@ -1644,8 +1644,8 @@
 /obj/item/weapon/gun/energy/stunrevolver/rifle,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1659,8 +1659,8 @@
 /obj/item/weapon/gun/energy/ionrifle/small,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1692,8 +1692,8 @@
 /area/security/armoury)
 "adS" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/structure/closet/secure_closet/nervaammo,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1705,8 +1705,8 @@
 /obj/item/weapon/gun/energy/gun,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1719,8 +1719,8 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/beanbags,
@@ -1793,8 +1793,8 @@
 /area/medical/treatment)
 "aed" = (
 /obj/machinery/body_scanconsole{
-	icon_state = "body_scannerconsole";
-	dir = 1
+	dir = 1;
+	icon_state = "body_scannerconsole"
 	},
 /obj/effect/floor_decal/corner/pink{
 	dir = 10
@@ -1979,8 +1979,8 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 9
+	dir = 9;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue,
 /obj/machinery/door/window/northleft{
@@ -1993,8 +1993,8 @@
 /area/medical/morgue)
 "aeu" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 1
+	dir = 1;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -2021,8 +2021,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 5
+	dir = 5;
+	icon_state = "edge"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -2034,9 +2034,9 @@
 /area/medical/morgue)
 "aew" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -2052,9 +2052,9 @@
 "aey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -2070,8 +2070,8 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -2083,8 +2083,8 @@
 "aeA" = (
 /obj/structure/bed/nice,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/item/weapon/bedsheet/red,
 /turf/simulated/floor/tiled/dark,
@@ -2101,8 +2101,8 @@
 "aeC" = (
 /obj/structure/bed/nice,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -2211,9 +2211,9 @@
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/storage/pill_bottle/dice,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb1";
-	dir = 1
+	tag = "icon-cobweb1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
@@ -2314,9 +2314,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/pink{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/treatment)
@@ -2448,12 +2448,12 @@
 /area/medical/morgue)
 "afi" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 8
+	dir = 8;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
@@ -2466,12 +2466,12 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 4
+	dir = 4;
+	icon_state = "edge"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2484,9 +2484,9 @@
 /area/medical/morgue)
 "afl" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -2507,9 +2507,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair_preview (NORTH)";
+	dir = 1;
 	icon_state = "wooden_chair_preview";
-	dir = 1
+	tag = "icon-wooden_chair_preview (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/interrogation)
@@ -2541,8 +2541,8 @@
 "afr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/flasher{
 	id = "brigflasher";
@@ -2553,8 +2553,8 @@
 /area/security/brig)
 "afs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Brig Cell 3";
@@ -2575,9 +2575,9 @@
 "afu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
@@ -2588,9 +2588,9 @@
 "afw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
@@ -2633,9 +2633,9 @@
 /area/maintenance/third_deck/afp)
 "afB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -2809,8 +2809,8 @@
 	name = "Medical Forms"
 	},
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -2891,15 +2891,15 @@
 /obj/item/weapon/autopsy_scanner,
 /obj/item/weapon/scalpel,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
 "afW" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 10
+	dir = 10;
+	icon_state = "edge"
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
@@ -2949,8 +2949,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 6
+	dir = 6;
+	icon_state = "edge"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -2975,9 +2975,9 @@
 "aga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-supply";
-	dir = 6
+	tag = "icon-intact-supply (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /obj/structure/cable{
@@ -2991,8 +2991,8 @@
 /area/security/interrogation)
 "agb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/black/three_quarters{
 	dir = 4
@@ -3001,21 +3001,21 @@
 /area/security/interrogation)
 "agc" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "agd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /turf/simulated/floor/tiled/dark,
@@ -3023,9 +3023,9 @@
 "age" = (
 /obj/structure/cable,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -3040,8 +3040,8 @@
 /area/security/brig)
 "agf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/black/border,
@@ -3049,8 +3049,8 @@
 /area/security/brig)
 "agg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /turf/simulated/floor/tiled/dark,
@@ -3063,8 +3063,8 @@
 /area/security/brig)
 "agi" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /turf/simulated/floor/tiled/dark,
@@ -3092,14 +3092,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
@@ -3112,13 +3112,13 @@
 /area/security/armoury)
 "agm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /turf/simulated/floor/tiled/techmaint,
@@ -3158,8 +3158,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
@@ -3250,8 +3250,8 @@
 /obj/structure/lattice,
 /obj/structure/disposalpipe/down,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /turf/simulated/open{
 	initial_gas = null
@@ -3516,8 +3516,8 @@
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/securestorage)
@@ -3543,9 +3543,9 @@
 /area/engineering/securestorage)
 "ahm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -4049,9 +4049,9 @@
 /area/maintenance/third_deck/centp)
 "ahU" = (
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/techmaint,
@@ -4060,8 +4060,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4078,22 +4078,22 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
 "ahX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Brig Hall Aft"
@@ -4102,8 +4102,8 @@
 /area/security/brig)
 "ahY" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4111,15 +4111,15 @@
 /area/security/brig)
 "ahZ" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
 "aia" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4132,8 +4132,8 @@
 /area/security/brig)
 "aib" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4144,8 +4144,8 @@
 /area/security/brig)
 "aic" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4161,21 +4161,21 @@
 /area/security/brig)
 "aid" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
 "aie" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4186,9 +4186,9 @@
 /area/security/brig)
 "aif" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -4199,14 +4199,14 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -4215,17 +4215,17 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -4240,39 +4240,39 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "aij" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "aik" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -4282,9 +4282,9 @@
 	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Armory Entrance";
@@ -4315,31 +4315,31 @@
 /area/hallway/commandport)
 "ais" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
 "ait" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -4356,9 +4356,9 @@
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -4369,13 +4369,13 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -4387,8 +4387,8 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -4473,20 +4473,20 @@
 /area/engineering/securestorage)
 "aiF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 4
+	dir = 4;
+	icon_state = "map_vent_out"
 	},
 /obj/structure/engineeringcart,
 /turf/simulated/floor/plating,
 /area/engineering/securestorage)
 "aiG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/closet/crate,
 /obj/item/stack/material/phoron{
@@ -4505,8 +4505,8 @@
 /area/engineering/securestorage)
 "aiH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/closet/crate/solar,
 /turf/simulated/floor/plating,
@@ -4572,17 +4572,17 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
@@ -4594,9 +4594,9 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4613,9 +4613,9 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4637,12 +4637,12 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -4876,8 +4876,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/hallway)
@@ -4891,8 +4891,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/hallway)
@@ -5005,8 +5005,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -5034,12 +5034,12 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/floor_decal/corner/black{
 	dir = 10
@@ -5053,15 +5053,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
@@ -5088,12 +5088,12 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/floor_decal/corner/black{
 	dir = 10
@@ -5114,17 +5114,17 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
@@ -5145,20 +5145,20 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
 "ajD" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
@@ -5167,9 +5167,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
@@ -5208,8 +5208,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -5220,13 +5220,13 @@
 "ajH" = (
 /obj/effect/floor_decal/corner/black/border,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5258,9 +5258,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5273,13 +5273,13 @@
 "ajK" = (
 /obj/effect/floor_decal/corner/black/border,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5292,8 +5292,8 @@
 "ajL" = (
 /obj/effect/floor_decal/corner/black/border,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5302,9 +5302,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -5314,13 +5314,13 @@
 	req_access = list(1)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5334,9 +5334,9 @@
 "ajN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5345,8 +5345,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -5355,13 +5355,13 @@
 /area/security/lockers)
 "ajO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5373,13 +5373,13 @@
 /area/security/lockers)
 "ajP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	tag = "icon-map-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "map-scrubbers";
-	dir = 4
+	tag = "icon-map-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5399,13 +5399,13 @@
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5424,16 +5424,16 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_white";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfloor_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "ajS" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Bridge Hallway Port - Gun Bay";
@@ -5444,9 +5444,9 @@
 /area/hallway/commandport)
 "ajT" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -5455,9 +5455,9 @@
 /area/hallway/commandport)
 "ajU" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
@@ -5467,9 +5467,9 @@
 	req_access = list(19)
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -5479,16 +5479,16 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
 "ajX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -5517,16 +5517,16 @@
 	dir = 4
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Third Deck Substation";
@@ -5872,8 +5872,8 @@
 "akQ" = (
 /obj/effect/floor_decal/corner/red/half,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
@@ -5883,8 +5883,8 @@
 	},
 /obj/effect/floor_decal/corner/red/half,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
@@ -5893,8 +5893,8 @@
 /area/security/evidence)
 "akU" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5902,8 +5902,8 @@
 /area/security/office)
 "akX" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5911,40 +5911,40 @@
 /area/security/office)
 "akY" = (
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "akZ" = (
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (WEST)";
+	dir = 8;
 	icon_state = "bordercolorhalf";
-	dir = 8
+	tag = "icon-bordercolorhalf (WEST)"
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "alb" = (
 /obj/effect/floor_decal/corner/black/three_quarters,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
@@ -5953,9 +5953,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -5973,15 +5973,15 @@
 	},
 /obj/machinery/vending/security,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
 "ale" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -6001,9 +6001,9 @@
 /area/hallway/commandport)
 "alf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6019,9 +6019,9 @@
 /area/hallway/commandport)
 "alg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6033,8 +6033,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/door/airlock/command{
 	name = "Port Gun Bay";
@@ -6044,9 +6044,9 @@
 /area/security/portgun)
 "alh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -6060,8 +6060,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -6073,8 +6073,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -6089,8 +6089,8 @@
 	shipid = "nerva"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/structure/shipweapons/hardpoint/nerva{
 	attached = 1
@@ -6102,9 +6102,9 @@
 /area/space)
 "all" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -6112,8 +6112,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/third_deck)
@@ -6259,8 +6259,8 @@
 /area/medical/lobby)
 "alC" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/white,
@@ -6310,8 +6310,8 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /obj/structure/bed/chair{
 	dir = 8
@@ -6483,8 +6483,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -6497,8 +6497,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -6561,8 +6561,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/entrance)
@@ -6570,15 +6570,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/entrance)
 "alX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -6588,9 +6588,9 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/techmaint,
@@ -6637,9 +6637,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -6659,9 +6659,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -6680,9 +6680,9 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6723,14 +6723,14 @@
 /area/security/office)
 "amk" = (
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (WEST)";
+	dir = 8;
 	icon_state = "bordercolorhalf";
-	dir = 8
+	tag = "icon-bordercolorhalf (WEST)"
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -6759,8 +6759,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
@@ -6783,8 +6783,8 @@
 "ams" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
@@ -6809,8 +6809,8 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
@@ -6889,9 +6889,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
@@ -6900,8 +6900,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
@@ -6913,25 +6913,25 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
 "amF" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
@@ -7150,8 +7150,8 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
@@ -7190,8 +7190,8 @@
 /area/security/entrance)
 "ane" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7204,13 +7204,13 @@
 /area/security/entrance)
 "anf" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (EAST)";
+	dir = 4;
 	icon_state = "bordercolorhalf";
-	dir = 4
+	tag = "icon-bordercolorhalf (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/filingcabinet,
@@ -7256,8 +7256,8 @@
 /area/security/evidence)
 "anl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/alarm{
 	pixel_y = 25
@@ -7278,8 +7278,8 @@
 "ann" = (
 /obj/effect/floor_decal/corner/red/full,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -7291,22 +7291,22 @@
 "anp" = (
 /obj/effect/floor_decal/corner/red/full,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "anq" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (WEST)";
+	dir = 8;
 	icon_state = "bordercolorhalf";
-	dir = 8
+	tag = "icon-bordercolorhalf (WEST)"
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
@@ -7373,8 +7373,8 @@
 /area/hallway/commandport)
 "any" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
@@ -7446,16 +7446,16 @@
 	pixel_y = -25
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "robotics_solar_pump";
-	tag_exterior_door = "robotics_solar_outer";
 	frequency = 1379;
 	id_tag = "robotics_solar_airlock";
-	tag_interior_door = "robotics_solar_inner";
 	layer = 3.3;
 	pixel_x = 0;
 	pixel_y = -25;
 	req_access = list(13);
-	tag_chamber_sensor = "robotics_solar_sensor"
+	tag_airpump = "robotics_solar_pump";
+	tag_chamber_sensor = "robotics_solar_sensor";
+	tag_exterior_door = "robotics_solar_outer";
+	tag_interior_door = "robotics_solar_inner"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
@@ -7475,9 +7475,9 @@
 /area/maintenance/third_deck/afp)
 "anH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -7493,52 +7493,52 @@
 /area/maintenance/third_deck/afp)
 "anI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
 "anJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
 "anK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7549,19 +7549,19 @@
 /area/maintenance/third_deck/afp)
 "anL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/catwalk,
@@ -7569,18 +7569,18 @@
 /area/maintenance/third_deck/afp)
 "anM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
@@ -7589,13 +7589,13 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
@@ -7619,12 +7619,12 @@
 /area/engineering/tool)
 "anR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -7638,8 +7638,8 @@
 /area/engineering/tool)
 "anS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -7651,8 +7651,8 @@
 /area/engineering/tool)
 "anT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
@@ -7663,8 +7663,8 @@
 /area/engineering/tool)
 "anU" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7686,15 +7686,15 @@
 /area/engineering/locker)
 "anX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
 "anY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -7715,12 +7715,12 @@
 "aob" = (
 /obj/machinery/suit_storage_unit/engineering,
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -7729,8 +7729,8 @@
 /area/engineering/locker)
 "aoc" = (
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -7928,8 +7928,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -7946,25 +7946,25 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/entrance)
 "aoB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/entrance)
@@ -7987,24 +7987,24 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (EAST)";
+	dir = 4;
 	icon_state = "bordercolorhalf";
-	dir = 4
+	tag = "icon-bordercolorhalf (EAST)"
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
 "aoE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8024,15 +8024,15 @@
 /area/security/checkpoint)
 "aoI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/evidence)
 "aoJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -8041,9 +8041,9 @@
 /area/security/evidence)
 "aoK" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/security/office)
@@ -8063,14 +8063,14 @@
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (WEST)";
+	dir = 8;
 	icon_state = "bordercolorhalf";
-	dir = 8
+	tag = "icon-bordercolorhalf (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -8090,8 +8090,8 @@
 /area/security/boardarmoury)
 "aoQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -8129,8 +8129,8 @@
 "aoT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8148,12 +8148,12 @@
 /area/hallway/commandport)
 "aoU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -8247,8 +8247,8 @@
 	amount = 50
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/stack/rods/fifty,
 /turf/simulated/floor/tiled/dark,
@@ -8258,8 +8258,8 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -8279,12 +8279,12 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8296,8 +8296,8 @@
 /area/engineering/tool)
 "api" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8335,9 +8335,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
@@ -8349,9 +8349,9 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
@@ -8374,21 +8374,21 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
 "app" = (
 /obj/machinery/suit_storage_unit/engineering,
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
@@ -8559,8 +8559,8 @@
 /area/medical/examroom)
 "apA" = (
 /obj/machinery/body_scanconsole{
-	icon_state = "body_scannerconsole";
-	dir = 4
+	dir = 4;
+	icon_state = "body_scannerconsole"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/examroom)
@@ -8571,8 +8571,8 @@
 	},
 /obj/machinery/light,
 /obj/machinery/bodyscanner{
-	icon_state = "body_scanner_0";
-	dir = 4
+	dir = 4;
+	icon_state = "body_scanner_0"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -8742,8 +8742,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -8762,8 +8762,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8773,12 +8773,12 @@
 /area/security/entrance)
 "apP" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/entrance)
@@ -8814,9 +8814,9 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (NORTH)";
+	dir = 1;
 	icon_state = "bordercolorhalf";
-	dir = 1
+	tag = "icon-bordercolorhalf (NORTH)"
 	},
 /obj/effect/floor_decal/corner/black{
 	dir = 10
@@ -8832,13 +8832,13 @@
 /obj/item/weapon/folder/red,
 /obj/item/weapon/handcuffs,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (NORTH)";
+	dir = 1;
 	icon_state = "bordercolorhalf";
-	dir = 1
+	tag = "icon-bordercolorhalf (NORTH)"
 	},
 /obj/effect/floor_decal/corner/black{
 	dir = 10
@@ -8865,8 +8865,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/black/three_quarters{
 	dir = 4
@@ -8933,14 +8933,14 @@
 "aqc" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (WEST)";
+	dir = 8;
 	icon_state = "bordercolorhalf";
-	dir = 8
+	tag = "icon-bordercolorhalf (WEST)"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
@@ -9028,8 +9028,8 @@
 /area/hallway/commandport)
 "aqj" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -9049,23 +9049,23 @@
 /area/space)
 "aqm" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/space,
 /area/space)
 "aqn" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/structure/lattice,
 /turf/space,
 /area/space)
 "aqo" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -9091,8 +9091,8 @@
 /area/engineering/engine_waste)
 "aqs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
@@ -9121,9 +9121,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
@@ -9139,9 +9139,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
@@ -9173,9 +9173,9 @@
 /area/engineering/engine)
 "aqy" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -9206,18 +9206,18 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -9232,23 +9232,23 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smes)
@@ -9259,35 +9259,35 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
 "aqF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -9296,13 +9296,13 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9310,28 +9310,28 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
 "aqH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -9466,8 +9466,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/loading{
-	icon_state = "loadingarea";
-	dir = 1
+	dir = 1;
+	icon_state = "loadingarea"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/storage)
@@ -9585,8 +9585,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/entrance)
@@ -9594,8 +9594,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/entrance)
@@ -9702,8 +9702,8 @@
 /area/hallway/commandport)
 "ark" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/super;
@@ -9722,11 +9722,11 @@
 /obj/structure/ladder,
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/machinery/door/blast/regular/open{
-	tag = "icon-pdoor0 (WEST)";
-	name = "Bridge Lockdown";
-	icon_state = "pdoor0";
 	dir = 8;
-	id = "bridgelock"
+	icon_state = "pdoor0";
+	id = "bridgelock";
+	name = "Bridge Lockdown";
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -9746,12 +9746,12 @@
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9826,27 +9826,27 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "arw" = (
 /obj/machinery/atmospherics/omni/filter{
-	use_power = 0;
 	tag_east = 1;
 	tag_north = 0;
 	tag_south = 4;
-	tag_west = 2
+	tag_west = 2;
+	use_power = 0
 	},
 /obj/effect/engine_setup/filter,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "arx" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -9881,9 +9881,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smes)
@@ -9937,13 +9937,13 @@
 	pixel_x = 0
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -9963,16 +9963,16 @@
 	pixel_x = 0
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -9995,8 +9995,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -10014,8 +10014,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -10033,8 +10033,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -10046,9 +10046,9 @@
 	pixel_x = 0
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -10062,17 +10062,17 @@
 	pixel_x = 0
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -10087,13 +10087,13 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -10111,9 +10111,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -10132,18 +10132,18 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -10165,9 +10165,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -10185,9 +10185,9 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/borderfloor{
-	tag = "icon-borderfloor_white (NORTH)";
+	dir = 1;
 	icon_state = "borderfloor_white";
-	dir = 1
+	tag = "icon-borderfloor_white (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -10275,8 +10275,8 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -10517,8 +10517,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -10603,8 +10603,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Fore Hallway - Aft Port"
@@ -10619,14 +10619,14 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/borderfloor{
-	tag = "icon-borderfloor_white (NORTH)";
+	dir = 1;
 	icon_state = "borderfloor_white";
-	dir = 1
+	tag = "icon-borderfloor_white (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
@@ -10650,17 +10650,17 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (WEST)";
+	dir = 8;
 	icon_state = "pipe-j2";
-	dir = 8
+	tag = "icon-pipe-j2 (WEST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -10675,13 +10675,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -10699,9 +10699,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
@@ -10710,8 +10710,8 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10726,13 +10726,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10747,13 +10747,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -10783,8 +10783,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -10814,13 +10814,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -10841,13 +10841,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Fore Hallway - Bar Port"
@@ -10868,8 +10868,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -10884,17 +10884,17 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (WEST)";
+	dir = 8;
 	icon_state = "pipe-j2";
-	dir = 8
+	tag = "icon-pipe-j2 (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "ast" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -10918,13 +10918,13 @@
 /area/hallway/fore/third_deck)
 "asu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -10942,8 +10942,8 @@
 /area/hallway/fore/third_deck)
 "asv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -10960,16 +10960,16 @@
 	sortType = "Security"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "asw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -10978,8 +10978,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -10991,18 +10991,18 @@
 /area/hallway/fore/third_deck)
 "asx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/bordercorner{
-	tag = "icon-bordercolorcorner (NORTH)";
+	dir = 1;
 	icon_state = "bordercolorcorner";
-	dir = 1
+	tag = "icon-bordercolorcorner (NORTH)"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -11021,9 +11021,9 @@
 /area/hallway/fore/third_deck)
 "asy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11032,12 +11032,12 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11068,13 +11068,13 @@
 /area/hallway/fore/third_deck)
 "asz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11091,20 +11091,20 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "asB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
@@ -11127,12 +11127,12 @@
 /area/hallway/commandport)
 "asC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11144,16 +11144,16 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "asD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -11172,12 +11172,12 @@
 /area/hallway/commandport)
 "asE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -11198,8 +11198,8 @@
 /area/hallway/commandport)
 "asF" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -11211,9 +11211,9 @@
 /area/hallway/commandport)
 "asG" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -11222,9 +11222,9 @@
 /area/command/bridge)
 "asH" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -11235,14 +11235,14 @@
 /area/command/bridge)
 "asJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -11311,8 +11311,8 @@
 "asQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -11325,19 +11325,19 @@
 "asS" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "asT" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Engine 1";
 	charge = 1e+007;
 	cur_coils = 4;
 	output_attempt = 1;
-	outputting = 2;
-	RCon_tag = "Engine 1"
+	outputting = 2
 	},
 /obj/effect/engine_setup/smes,
 /obj/machinery/light{
@@ -11355,15 +11355,15 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
@@ -11424,17 +11424,17 @@
 "asZ" = (
 /obj/effect/floor_decal/corner/yellow,
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
 "ata" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -11445,17 +11445,17 @@
 	req_access = list(10)
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
 "atc" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -11466,21 +11466,21 @@
 /area/engineering/tool)
 "atd" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
 "ate" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering Entrance";
@@ -11491,9 +11491,9 @@
 /area/engineering/tool)
 "atf" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -11507,9 +11507,9 @@
 /area/engineering/tool)
 "atg" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -11520,18 +11520,18 @@
 "ath" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -11541,9 +11541,9 @@
 /area/engineering/tool)
 "ati" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -11561,9 +11561,9 @@
 /area/hallway/aft/third_deck)
 "atk" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -11574,9 +11574,9 @@
 	pixel_y = -28
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -11591,9 +11591,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -11603,26 +11603,26 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "ato" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "atp" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -11633,9 +11633,9 @@
 "atr" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
 	dir = 8;
@@ -11647,9 +11647,9 @@
 /area/hallway/aft/third_deck)
 "ats" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -11660,29 +11660,29 @@
 /area/hallway/central/third_deck)
 "att" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "atu" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "atv" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -11693,9 +11693,9 @@
 /area/hallway/central/third_deck)
 "atw" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -11708,9 +11708,9 @@
 /area/hallway/central/third_deck)
 "atx" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
@@ -11719,9 +11719,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -11745,8 +11745,8 @@
 /area/hallway/central/third_deck)
 "atB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -11755,8 +11755,8 @@
 /area/hallway/fore/third_deck)
 "atD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -11851,15 +11851,15 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "atQ" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/commandport)
@@ -11872,30 +11872,30 @@
 	tag = "icon-pdoor1"
 	},
 /obj/machinery/door/airlock/multi_tile/glass/command{
-	tag = "icon-closed (WEST)";
-	name = "Bridge";
-	icon_state = "closed";
 	dir = 8;
-	req_access = list(19)
+	icon_state = "closed";
+	name = "Bridge";
+	req_access = list(19);
+	tag = "icon-closed (WEST)"
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "atS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "atT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -11933,8 +11933,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11947,8 +11947,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
@@ -11958,9 +11958,9 @@
 	req_access = list(19)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11987,9 +11987,9 @@
 /area/command/bridge)
 "atX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12009,9 +12009,9 @@
 /area/command/bridge)
 "atY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12045,12 +12045,12 @@
 /area/command/bridge)
 "aua" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -12058,9 +12058,9 @@
 /obj/structure/table/glass,
 /obj/random/drinkbottle,
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -12069,8 +12069,8 @@
 /obj/random/smokes,
 /obj/item/weapon/flame/lighter/zippo,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/dark,
@@ -12078,9 +12078,9 @@
 "aud" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -12161,18 +12161,18 @@
 "aul" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aum" = (
 /obj/machinery/atmospherics/omni/filter{
-	use_power = 0;
 	tag_east = 1;
 	tag_north = 4;
 	tag_south = 0;
-	tag_west = 2
+	tag_west = 2;
+	use_power = 0
 	},
 /obj/effect/engine_setup/filter,
 /turf/simulated/floor/plating,
@@ -12195,20 +12195,20 @@
 /area/engineering/engine)
 "auo" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Engine 2";
 	charge = 800000;
 	cur_coils = 4;
 	output_attempt = 1;
-	outputting = 2;
-	RCon_tag = "Engine 2"
+	outputting = 2
 	},
 /obj/structure/sign/warning/secure_area{
-	tag = "icon-shock (EAST)";
-	name = "HIGH VOLTAGE";
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
 	dir = 4;
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
 	pixel_x = -32;
-	pixel_y = 0
+	pixel_y = 0;
+	tag = "icon-shock (EAST)"
 	},
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -12222,17 +12222,17 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smes)
@@ -12338,9 +12338,9 @@
 /area/civilian/cryo1)
 "auy" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -12354,9 +12354,9 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/sign/directions/security{
 	dir = 4;
@@ -12384,9 +12384,9 @@
 /area/hallway/aft/third_deck)
 "auB" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -12405,8 +12405,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -12573,15 +12573,15 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "auZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/structure/cable{
@@ -12595,8 +12595,8 @@
 /area/command/bridge)
 "ava" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -12632,8 +12632,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -12641,9 +12641,9 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -12693,16 +12693,16 @@
 /area/engineering/engine)
 "avk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "avl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -12720,12 +12720,12 @@
 /area/engineering/engine)
 "avn" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Engine 3";
 	charge = 3e+006;
 	cur_coils = 4;
 	output_attempt = 1;
 	output_level = 100000;
-	outputting = 2;
-	RCon_tag = "Engine 3"
+	outputting = 2
 	},
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -12739,12 +12739,12 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smes)
@@ -12816,9 +12816,9 @@
 /area/civilian/cryo1)
 "avw" = (
 /obj/structure/cryofeed{
-	tag = "icon-cryo_rear (EAST)";
+	dir = 4;
 	icon_state = "cryo_rear";
-	dir = 4
+	tag = "icon-cryo_rear (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -12831,9 +12831,9 @@
 	dir = 1
 	},
 /obj/machinery/cryopod{
-	tag = "icon-body_scanner_0 (EAST)";
+	dir = 4;
 	icon_state = "body_scanner_0";
-	dir = 4
+	tag = "icon-body_scanner_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -12846,8 +12846,8 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -12859,8 +12859,8 @@
 	c_tag = "Primary Cryogenic Storage Port"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -12877,13 +12877,13 @@
 /area/civilian/cryo1)
 "avC" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -12901,9 +12901,9 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12934,26 +12934,26 @@
 /area/hallway/aft/third_deck)
 "avG" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "avH" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva3 (NORTH)";
+	dir = 1;
 	icon_state = "nerva3";
-	dir = 1
+	tag = "icon-nerva3 (NORTH)"
 	},
 /obj/structure/sign/directions/evac{
 	pixel_x = 32;
@@ -12988,8 +12988,8 @@
 /area/civilian/hydro)
 "avK" = (
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -13025,32 +13025,32 @@
 "avO" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
 /area/civilian/messhall)
 "avP" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
 /area/civilian/messhall)
 "avQ" = (
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -13058,9 +13058,9 @@
 "avR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -13070,9 +13070,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/camera/network/third_deck{
@@ -13086,9 +13086,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13100,9 +13100,9 @@
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/messhall)
@@ -13111,26 +13111,26 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
 /area/civilian/messhall)
 "avW" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -13146,9 +13146,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -13184,8 +13184,8 @@
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light_switch{
@@ -13213,9 +13213,9 @@
 /area/civilian/bar)
 "awd" = (
 /obj/machinery/light/warmtint{
-	tag = "icon-tube_map (NORTH)";
+	dir = 1;
 	icon_state = "tube_map";
-	dir = 1
+	tag = "icon-tube_map (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -13233,8 +13233,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -13255,8 +13255,8 @@
 "awi" = (
 /obj/structure/bed/chair/couch/left/black,
 /turf/simulated/floor/wood{
-	tag = "icon-wood_broken6";
-	icon_state = "wood_broken6"
+	icon_state = "wood_broken6";
+	tag = "icon-wood_broken6"
 	},
 /area/civilian/bar)
 "awj" = (
@@ -13265,9 +13265,9 @@
 /area/civilian/bar)
 "awk" = (
 /obj/structure/bed/chair/couch/left/black{
-	tag = "icon-couch_left (SOUTHWEST)";
+	dir = 10;
 	icon_state = "couch_left";
-	dir = 10
+	tag = "icon-couch_left (SOUTHWEST)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -13294,15 +13294,15 @@
 /area/command/meeting)
 "awp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/firealarm{
 	dir = 2;
@@ -13312,8 +13312,8 @@
 /area/command/meeting)
 "awq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -13385,17 +13385,17 @@
 "aww" = (
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "awx" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva3 (NORTH)";
+	dir = 1;
 	icon_state = "nerva3";
-	dir = 1
+	tag = "icon-nerva3 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -13411,8 +13411,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -13449,8 +13449,8 @@
 "awD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -13465,11 +13465,11 @@
 /area/engineering/engine)
 "awF" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Engine 4";
 	charge = 1e+006;
 	cur_coils = 4;
 	output_attempt = 1;
-	outputting = 2;
-	RCon_tag = "Engine 4"
+	outputting = 2
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/tiled/dark,
@@ -13479,8 +13479,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -13511,8 +13511,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/lobby)
@@ -13534,17 +13534,17 @@
 /area/engineering/lobby)
 "awL" = (
 /obj/machinery/cryopod{
-	tag = "icon-body_scanner_0 (EAST)";
+	dir = 4;
 	icon_state = "body_scanner_0";
-	dir = 4
+	tag = "icon-body_scanner_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
 "awM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -13553,8 +13553,8 @@
 	name = "JoinLateCryo"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -13564,9 +13564,9 @@
 /area/civilian/cryo1)
 "awP" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/structure/sign/deck/third{
 	dir = 4;
@@ -13586,40 +13586,40 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "awR" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2 (NORTH)";
+	dir = 1;
 	icon_state = "nerva2";
-	dir = 1
+	tag = "icon-nerva2 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "awS" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "awT" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/sign/deck/third{
 	dir = 8;
@@ -13636,8 +13636,8 @@
 	},
 /obj/effect/floor_decal/corner/green/full,
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -13660,15 +13660,15 @@
 "awX" = (
 /obj/effect/floor_decal/corner/green/full,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
 "awY" = (
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13702,8 +13702,8 @@
 "axc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -13729,26 +13729,26 @@
 /area/hallway/central/third_deck)
 "axe" = (
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/messhall)
 "axf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -13756,9 +13756,9 @@
 "axg" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -13768,9 +13768,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -13780,9 +13780,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -13790,9 +13790,9 @@
 "axj" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/messhall)
@@ -13808,16 +13808,16 @@
 "axl" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "axm" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -13843,8 +13843,8 @@
 /area/civilian/kitchen)
 "axp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -13867,16 +13867,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
 "axt" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair";
-	dir = 4
+	tag = "icon-wooden_chair (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -13886,9 +13886,9 @@
 /area/civilian/bar)
 "axv" = (
 /obj/structure/bed/chair/couch/middle/black{
-	tag = "icon-couch_middle (WEST)";
+	dir = 8;
 	icon_state = "couch_middle";
-	dir = 8
+	tag = "icon-couch_middle (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -13938,16 +13938,16 @@
 	},
 /obj/effect/floor_decal/corner/fadeblue,
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "axD" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -13955,25 +13955,25 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "axE" = (
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2 (NORTH)";
+	dir = 1;
 	icon_state = "nerva2";
-	dir = 1
+	tag = "icon-nerva2 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "axF" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -14004,8 +14004,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -14124,8 +14124,8 @@
 	pixel_y = -10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -14163,36 +14163,36 @@
 	name = "JoinLateCryo"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
 "axV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
 "axW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -14202,30 +14202,30 @@
 	name = "Cryogenic Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
 "axY" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "axZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	tag = "icon-map-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "map-scrubbers";
-	dir = 4
+	tag = "icon-map-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -14235,9 +14235,9 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -14251,18 +14251,18 @@
 /area/turbolift/main_third_deck)
 "ayc" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "ayd" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -14289,8 +14289,8 @@
 /area/civilian/hydro)
 "ayg" = (
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/door/window/westleft,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14331,8 +14331,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/sign/hydro{
 	dir = 4;
@@ -14382,9 +14382,9 @@
 /area/civilian/messhall)
 "ayn" = (
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/cable{
@@ -14399,9 +14399,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -14409,9 +14409,9 @@
 "ayp" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -14421,9 +14421,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -14434,9 +14434,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -14447,9 +14447,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -14460,9 +14460,9 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -14470,8 +14470,8 @@
 "ayu" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -14491,9 +14491,9 @@
 /area/civilian/kitchen)
 "ayx" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/open,
@@ -14528,12 +14528,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood_broken1";
-	icon_state = "wood_broken1"
+	icon_state = "wood_broken1";
+	tag = "icon-wood_broken1"
 	},
 /area/civilian/bar)
 "ayC" = (
@@ -14541,9 +14541,9 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair";
-	dir = 4
+	tag = "icon-wooden_chair (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -14563,9 +14563,9 @@
 /area/civilian/bar)
 "ayF" = (
 /obj/structure/bed/chair/couch/left/black{
-	tag = "icon-couch_left (WEST)";
+	dir = 8;
 	icon_state = "couch_left";
-	dir = 8
+	tag = "icon-couch_left (WEST)"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -14573,9 +14573,9 @@
 	pixel_x = 24
 	},
 /obj/machinery/light/warmtint{
-	tag = "icon-tube_map (EAST)";
+	dir = 4;
 	icon_state = "tube_map";
-	dir = 4
+	tag = "icon-tube_map (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -14631,9 +14631,9 @@
 	tag = "icon-intercom (EAST)"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
@@ -14647,13 +14647,13 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
@@ -14664,8 +14664,8 @@
 /area/command/bridge)
 "ayO" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -14674,8 +14674,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -14685,9 +14685,9 @@
 /area/engineering/engine)
 "ayR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
@@ -14705,16 +14705,16 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "ayU" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
-	tag = "icon-map_on (WEST)";
+	dir = 8;
 	icon_state = "map_on";
-	dir = 8
+	tag = "icon-map_on (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -14811,8 +14811,8 @@
 /area/engineering/lobby)
 "azc" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -14832,9 +14832,9 @@
 /area/civilian/cryo1)
 "azg" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Aft Hallway - Primary Cryogenic Storage";
@@ -14861,8 +14861,8 @@
 /area/civilian/hydro)
 "azj" = (
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -14873,8 +14873,8 @@
 	pixel_y = -24
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
@@ -14883,12 +14883,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
@@ -14936,12 +14936,12 @@
 /area/civilian/hydro)
 "azo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -14964,13 +14964,13 @@
 /area/hallway/central/third_deck)
 "azq" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/power/apc{
@@ -14991,9 +14991,9 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -15008,9 +15008,9 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/landmark{
@@ -15024,8 +15024,8 @@
 	},
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/bar_alc/full{
-	icon_state = "booze_dispenser";
-	dir = 4
+	dir = 4;
+	icon_state = "booze_dispenser"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -15038,8 +15038,8 @@
 "azx" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood{
-	tag = "icon-wood_broken3";
-	icon_state = "wood_broken3"
+	icon_state = "wood_broken3";
+	tag = "icon-wood_broken3"
 	},
 /area/civilian/bar)
 "azy" = (
@@ -15077,9 +15077,9 @@
 /area/command/meeting)
 "azD" = (
 /obj/structure/bed/chair/comfy/captain{
-	tag = "icon-capchair_preview (EAST)";
+	dir = 4;
 	icon_state = "capchair_preview";
-	dir = 4
+	tag = "icon-capchair_preview (EAST)"
 	},
 /obj/structure/fireaxecabinet{
 	pixel_x = -32;
@@ -15094,8 +15094,8 @@
 /area/command/bridge)
 "azE" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15108,9 +15108,9 @@
 	icon_state = "1-4"
 	},
 /obj/item/modular_computer/console/preset/nervacommand{
-	tag = "icon-console (WEST)";
+	dir = 8;
 	icon_state = "console";
-	dir = 8
+	tag = "icon-console (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
@@ -15154,8 +15154,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -15193,8 +15193,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for the engine charging port.";
@@ -15226,8 +15226,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -15277,8 +15277,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -15301,8 +15301,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -15328,8 +15328,8 @@
 /area/engineering/lobby)
 "azU" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15350,12 +15350,12 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/lobby)
@@ -15379,8 +15379,8 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -15447,9 +15447,9 @@
 /area/civilian/cryo1)
 "aAc" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15468,8 +15468,8 @@
 "aAd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15483,13 +15483,13 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -15552,8 +15552,8 @@
 /area/civilian/hydro)
 "aAj" = (
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15588,12 +15588,12 @@
 "aAm" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15628,8 +15628,8 @@
 	tag = "icon-intercom (EAST)"
 	},
 /obj/machinery/chemical_dispenser/bar_soft/full{
-	icon_state = "soda_dispenser";
-	dir = 4
+	dir = 4;
+	icon_state = "soda_dispenser"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -15643,8 +15643,8 @@
 /area/civilian/bar)
 "aAr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -15666,8 +15666,8 @@
 	pixel_x = -25
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -15732,8 +15732,8 @@
 	},
 /obj/effect/floor_decal/corner/black/border,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
@@ -15742,8 +15742,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -15773,9 +15773,9 @@
 "aAG" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/engine)
@@ -15906,15 +15906,15 @@
 /area/engineering/lobby)
 "aAT" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/lobby)
 "aAU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15930,8 +15930,8 @@
 /area/engineering/lobby)
 "aAV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -15955,8 +15955,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -15968,8 +15968,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -15977,8 +15977,8 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -15997,9 +15997,9 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
@@ -16014,27 +16014,27 @@
 	pixel_x = -25
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "aBd" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva3 (NORTH)";
+	dir = 1;
 	icon_state = "nerva3";
-	dir = 1
+	tag = "icon-nerva3 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -16064,8 +16064,8 @@
 /area/maintenance/third_deck/central)
 "aBi" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -16102,8 +16102,8 @@
 /area/civilian/hydro)
 "aBm" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
@@ -16122,12 +16122,12 @@
 "aBp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -16189,8 +16189,8 @@
 "aBv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/item/weapon/storage/box/donkpockets{
 	pixel_x = 3;
@@ -16202,8 +16202,8 @@
 "aBw" = (
 /obj/item/weapon/stool/bar/padded,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -16211,19 +16211,19 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood_broken6";
-	icon_state = "wood_broken6"
+	icon_state = "wood_broken6";
+	tag = "icon-wood_broken6"
 	},
 /area/civilian/bar)
 "aBy" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -16247,20 +16247,20 @@
 	pixel_x = -24
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "aBC" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -16277,8 +16277,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/item/weapon/storage/firstaid/regular{
 	pixel_x = 5;
@@ -16325,8 +16325,8 @@
 	output = 63
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/reinforced/airless,
@@ -16346,8 +16346,8 @@
 /area/engineering/engine)
 "aBK" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -16367,8 +16367,8 @@
 "aBM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -16390,13 +16390,13 @@
 /area/engineering/engine)
 "aBO" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Engine - SMES";
 	charge = 3e+006;
 	input_attempt = 1;
 	input_level = 200000;
 	inputting = 1;
 	output_level = 100000;
-	outputting = 2;
-	RCon_tag = "Engine - SMES"
+	outputting = 2
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -16459,9 +16459,9 @@
 /area/engineering/lobby)
 "aBV" = (
 /obj/machinery/cryopod{
-	tag = "icon-body_scanner_0 (EAST)";
+	dir = 4;
 	icon_state = "body_scanner_0";
-	dir = 4
+	tag = "icon-body_scanner_0 (EAST)"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/freezer,
@@ -16476,8 +16476,8 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -16494,8 +16494,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -16525,9 +16525,9 @@
 /area/civilian/cryo1)
 "aCa" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -16550,9 +16550,9 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -16596,22 +16596,22 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2 (NORTH)";
+	dir = 1;
 	icon_state = "nerva2";
-	dir = 1
+	tag = "icon-nerva2 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -16626,9 +16626,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -16686,8 +16686,8 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/central)
@@ -16708,28 +16708,28 @@
 "aCl" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (WEST)";
+	dir = 8;
 	icon_state = "down-supply";
-	dir = 8
+	tag = "icon-down-supply (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "down-scrubbers";
-	dir = 8
+	tag = "icon-down-scrubbers (WEST)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /turf/simulated/open,
 /area/maintenance/third_deck/central)
 "aCm" = (
 /obj/structure/ladder/updown,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb1";
-	dir = 1
+	tag = "icon-cobweb1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/central)
@@ -16752,8 +16752,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -16764,9 +16764,9 @@
 "aCr" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -16774,9 +16774,9 @@
 "aCs" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
@@ -16784,9 +16784,9 @@
 "aCt" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/camera/network/third_deck{
@@ -16798,23 +16798,23 @@
 "aCu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
 /area/civilian/messhall)
 "aCv" = (
 /obj/effect/floor_decal/corner/beige/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-05";
-	icon_state = "plant-05"
+	icon_state = "plant-05";
+	tag = "icon-plant-05"
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -16826,8 +16826,8 @@
 /area/civilian/messhall)
 "aCw" = (
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
@@ -16909,8 +16909,8 @@
 /area/civilian/bar)
 "aCE" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16918,9 +16918,9 @@
 /area/civilian/bar)
 "aCF" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair_preview (NORTH)";
+	dir = 1;
 	icon_state = "wooden_chair_preview";
-	dir = 1
+	tag = "icon-wooden_chair_preview (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/bar)
@@ -16952,8 +16952,8 @@
 "aCK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -16969,8 +16969,8 @@
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/device/multitool,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -16979,8 +16979,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "boarding_armory";
@@ -17036,9 +17036,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/engine)
@@ -17077,9 +17077,9 @@
 /area/engineering/engine)
 "aCU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -17172,9 +17172,9 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/sign/directions/bridge{
 	dir = 4;
@@ -17198,9 +17198,9 @@
 /area/hallway/aft/third_deck)
 "aDb" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -17239,8 +17239,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -17342,8 +17342,8 @@
 	pixel_x = 0
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -17359,15 +17359,15 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -17411,9 +17411,9 @@
 "aDw" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
@@ -17422,17 +17422,17 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering Storage Port"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
@@ -17446,42 +17446,42 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
 "aDz" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
 "aDA" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17494,9 +17494,9 @@
 	req_access = list(10)
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17505,21 +17505,21 @@
 	dir = 2
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
 "aDC" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17528,9 +17528,9 @@
 /area/hallway/aft/third_deck)
 "aDD" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -17546,9 +17546,9 @@
 /area/hallway/aft/third_deck)
 "aDE" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -17560,9 +17560,9 @@
 /area/hallway/aft/third_deck)
 "aDF" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/alarm{
 	pixel_y = 25
@@ -17574,9 +17574,9 @@
 /area/hallway/aft/third_deck)
 "aDG" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17588,14 +17588,14 @@
 /area/hallway/aft/third_deck)
 "aDH" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/structure/disposalpipe/sortjunction/untagged/flipped{
-	tag = "icon-pipe-j2s (WEST)";
+	dir = 8;
 	icon_state = "pipe-j2s";
-	dir = 8
+	tag = "icon-pipe-j2s (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -17609,9 +17609,9 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -17623,16 +17623,16 @@
 /area/hallway/aft/third_deck)
 "aDJ" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/tagger/partial{
-	tag = "icon-pipe-tagger-partial (EAST)";
-	name = "Disposals";
-	icon_state = "pipe-tagger-partial";
 	dir = 4;
-	sort_tag = "Disposals"
+	icon_state = "pipe-tagger-partial";
+	name = "Disposals";
+	sort_tag = "Disposals";
+	tag = "icon-pipe-tagger-partial (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -17645,9 +17645,9 @@
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17662,9 +17662,9 @@
 	c_tag = "Third Deck Aft Hallway - Starboard"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17676,9 +17676,9 @@
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17687,9 +17687,9 @@
 /area/hallway/aft/third_deck)
 "aDN" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17704,9 +17704,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -17719,9 +17719,9 @@
 "aDQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17730,9 +17730,9 @@
 /area/hallway/aft/third_deck)
 "aDR" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -17742,17 +17742,17 @@
 /area/hallway/central/third_deck)
 "aDS" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aDT" = (
 /obj/effect/floor_decal/borderfloor{
-	tag = "icon-borderfloor_white (NORTH)";
+	dir = 1;
 	icon_state = "borderfloor_white";
-	dir = 1
+	tag = "icon-borderfloor_white (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17760,9 +17760,9 @@
 /area/hallway/central/third_deck)
 "aDU" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/device/radio/intercom{
@@ -17776,9 +17776,9 @@
 /area/hallway/central/third_deck)
 "aDV" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -17787,9 +17787,9 @@
 /area/hallway/central/third_deck)
 "aDW" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/alarm{
 	pixel_y = 25
@@ -17798,9 +17798,9 @@
 /area/hallway/central/third_deck)
 "aDX" = (
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
@@ -17809,9 +17809,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -17884,8 +17884,8 @@
 /area/hallway/fore/third_deck)
 "aEl" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/commandstarboard)
@@ -17903,16 +17903,16 @@
 "aEn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aEo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
@@ -17942,8 +17942,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -17961,8 +17961,8 @@
 	req_access = list(19)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17986,8 +17986,8 @@
 /area/command/bridge)
 "aEs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18004,8 +18004,8 @@
 /area/command/bridge)
 "aEt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18021,12 +18021,12 @@
 /area/command/bridge)
 "aEu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
 /turf/simulated/floor/tiled/dark,
@@ -18041,8 +18041,8 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -18050,25 +18050,25 @@
 /obj/structure/table/glass,
 /obj/item/modular_computer/laptop/preset/records,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "aEy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/lattice,
 /turf/space,
 /area/space)
 "aEz" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -18080,9 +18080,9 @@
 /area/space)
 "aEB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -18106,9 +18106,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -18179,8 +18179,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -18232,9 +18232,9 @@
 "aEO" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -18246,9 +18246,9 @@
 /area/engineering/genstorage)
 "aEP" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/high;
@@ -18268,37 +18268,37 @@
 	req_access = list(10)
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 2
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
 "aER" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "aES" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
@@ -18316,8 +18316,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -18330,18 +18330,18 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /obj/effect/floor_decal/corner/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "aEW" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18350,13 +18350,13 @@
 /area/hallway/aft/third_deck)
 "aEX" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -18432,20 +18432,20 @@
 	sortType = "Robotics"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aFf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
@@ -18458,13 +18458,13 @@
 /area/hallway/central/third_deck)
 "aFg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
@@ -18480,13 +18480,13 @@
 /area/hallway/central/third_deck)
 "aFh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
@@ -18498,9 +18498,9 @@
 /area/hallway/central/third_deck)
 "aFi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/floor_decal/corner/beige{
@@ -18513,13 +18513,13 @@
 /area/hallway/central/third_deck)
 "aFj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
@@ -18532,13 +18532,13 @@
 /area/hallway/central/third_deck)
 "aFk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
@@ -18558,43 +18558,43 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aFm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/purple,
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aFn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
 	dir = 8;
@@ -18606,44 +18606,44 @@
 /area/hallway/central/third_deck)
 "aFo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/sign/science_1{
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Fore Hallway - Aft Starboard";
@@ -18656,25 +18656,25 @@
 "aFr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFs" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/floor_decal/corner/purple{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -18684,24 +18684,24 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFu" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFv" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /obj/effect/floor_decal/corner/black,
 /turf/simulated/floor/tiled,
@@ -18714,15 +18714,15 @@
 /area/hallway/fore/third_deck)
 "aFy" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFz" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/newscaster{
 	pixel_y = -28
@@ -18731,8 +18731,8 @@
 /area/hallway/fore/third_deck)
 "aFA" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Fore Hallway - Bar Starboard";
@@ -18746,12 +18746,12 @@
 /area/hallway/fore/third_deck)
 "aFB" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -18760,40 +18760,40 @@
 /area/hallway/fore/third_deck)
 "aFC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFD" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFE" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -18805,8 +18805,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -18816,13 +18816,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
@@ -18835,13 +18835,13 @@
 /area/hallway/fore/third_deck)
 "aFH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -18864,8 +18864,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -18887,13 +18887,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/commandstarboard)
@@ -18902,17 +18902,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass/command{
-	tag = "icon-closed (WEST)";
-	name = "Bridge";
-	icon_state = "closed";
 	dir = 8;
-	req_access = list(19)
+	icon_state = "closed";
+	name = "Bridge";
+	req_access = list(19);
+	tag = "icon-closed (WEST)"
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/machinery/door/blast/regular/open{
@@ -18929,16 +18929,16 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aFM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated/dark,
@@ -18946,12 +18946,12 @@
 /area/hallway/commandstarboard)
 "aFN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -18970,8 +18970,8 @@
 /area/hallway/commandstarboard)
 "aFO" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/super;
@@ -18989,21 +18989,21 @@
 "aFP" = (
 /obj/structure/stairs/west,
 /obj/machinery/door/blast/regular/open{
-	tag = "icon-pdoor0 (WEST)";
-	name = "Bridge Lockdown";
-	icon_state = "pdoor0";
 	dir = 8;
-	id = "bridgelock"
+	icon_state = "pdoor0";
+	id = "bridgelock";
+	name = "Bridge Lockdown";
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "aFQ" = (
 /obj/machinery/door/blast/regular/open{
-	tag = "icon-pdoor0 (WEST)";
-	name = "Bridge Lockdown";
-	icon_state = "pdoor0";
 	dir = 8;
-	id = "bridgelock"
+	icon_state = "pdoor0";
+	id = "bridgelock";
+	name = "Bridge Lockdown";
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -19017,8 +19017,8 @@
 /area/command/bridge)
 "aFS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
 /turf/simulated/floor/tiled/dark,
@@ -19026,8 +19026,8 @@
 "aFT" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -19040,9 +19040,9 @@
 	tag = "icon-xraycam (NORTH)"
 	},
 /obj/item/modular_computer/console/preset/nervacommand{
-	tag = "icon-console (NORTH)";
+	dir = 1;
 	icon_state = "console";
-	dir = 1
+	tag = "icon-console (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -19079,9 +19079,9 @@
 /area/engineering/engine)
 "aGa" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -19157,8 +19157,8 @@
 /area/engineering/genstorage)
 "aGk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -19262,8 +19262,8 @@
 /area/logistics/robotics)
 "aGx" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
@@ -19273,9 +19273,9 @@
 /area/hallway/central/third_deck)
 "aGy" = (
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -19397,12 +19397,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
-	icon_state = "borderfloorcorner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "borderfloorcorner_white"
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	icon_state = "bordercolorcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolorcorner"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -19453,8 +19453,8 @@
 	tag = "icon-intercom (WEST)"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
@@ -19474,18 +19474,18 @@
 /area/engineering/engine)
 "aGU" = (
 /obj/machinery/atmospherics/binary/circulator{
-	tag = "icon-circ-off (EAST)";
-	icon_state = "circ-off";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "circ-off";
+	tag = "icon-circ-off (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aGV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -19517,8 +19517,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -19534,8 +19534,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -19544,16 +19544,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor,
 /area/engineering/engine)
 "aHc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -19602,9 +19602,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
@@ -19620,9 +19620,9 @@
 	req_one_access = list(11,24)
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 2
@@ -19631,31 +19631,31 @@
 /area/engineering/genstorage)
 "aHh" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/fuel{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	tag = "icon-up-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "up-scrubbers";
-	dir = 4
+	tag = "icon-up-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	tag = "icon-up-supply (EAST)";
+	dir = 4;
 	icon_state = "up-supply";
-	dir = 4
+	tag = "icon-up-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "16-0";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "16-0"
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -19675,13 +19675,13 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Pipe Access"
@@ -19691,9 +19691,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/genstorage)
@@ -19709,16 +19709,16 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/janitor)
 "aHl" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -19861,9 +19861,9 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mechbay)
@@ -19872,8 +19872,8 @@
 /obj/item/weapon/storage/firstaid/surgery,
 /obj/item/device/robotanalyzer,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -19895,9 +19895,9 @@
 /area/logistics/robotics)
 "aHC" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
@@ -19907,8 +19907,8 @@
 	},
 /obj/effect/floor_decal/corner/paleblue,
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 9
+	dir = 9;
+	icon_state = "edge"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
@@ -19925,16 +19925,16 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 5
+	dir = 5;
+	icon_state = "edge"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
 "aHG" = (
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -19992,9 +19992,9 @@
 	pixel_x = 24
 	},
 /obj/item/modular_computer/console/preset/nervasci{
-	tag = "icon-console (WEST)";
+	dir = 8;
 	icon_state = "console";
-	dir = 8
+	tag = "icon-console (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/rnd/office)
@@ -20010,8 +20010,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
@@ -20034,16 +20034,16 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
 "aHS" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	tag = "icon-warningcorner (NORTH)";
+	dir = 1;
 	icon_state = "warningcorner";
-	dir = 1
+	tag = "icon-warningcorner (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
@@ -20078,8 +20078,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet,
 /area/security/cosoffice)
@@ -20106,8 +20106,8 @@
 	c_tag = "First Officer's Office"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet,
 /area/command/fo)
@@ -20136,20 +20136,20 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_white";
-	dir = 8
+	dir = 8;
+	icon_state = "borderfloor_white"
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
-	icon_state = "bordercolor";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aId" = (
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_white";
-	dir = 4
+	dir = 4;
+	icon_state = "borderfloor_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -20239,8 +20239,8 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
@@ -20268,8 +20268,8 @@
 	anchored = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -20287,8 +20287,8 @@
 	anchored = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -20361,29 +20361,29 @@
 "aIx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/fuel{
-	tag = "icon-down (EAST)";
+	dir = 4;
 	icon_state = "down";
-	dir = 4
+	tag = "icon-down (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "down-scrubbers";
-	dir = 4
+	tag = "icon-down-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (EAST)";
+	dir = 4;
 	icon_state = "down-supply";
-	dir = 4
+	tag = "icon-down-supply (EAST)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "32-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "32-4"
 	},
 /turf/simulated/open,
 /area/engineering/genstorage)
@@ -20395,14 +20395,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
+	dir = 8;
 	icon_state = "pipe-j1";
-	dir = 8
+	tag = "icon-pipe-j1 (WEST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/genstorage)
@@ -20411,13 +20411,13 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -20456,8 +20456,8 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/janitor)
@@ -20521,9 +20521,9 @@
 /obj/item/weapon/stool/padded,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/orange{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -20532,8 +20532,8 @@
 /area/logistics/mailing)
 "aII" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -20550,9 +20550,9 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box,
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/item/weapon/storage/box,
 /obj/item/weapon/storage/box,
@@ -20594,16 +20594,16 @@
 /area/logistics/mechbay)
 "aIO" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mechbay)
@@ -20625,8 +20625,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
@@ -20638,8 +20638,8 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 8
+	dir = 8;
+	icon_state = "edge"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
@@ -20652,15 +20652,15 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 4
+	dir = 4;
+	icon_state = "edge"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
 "aIV" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -20711,8 +20711,8 @@
 "aJb" = (
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack,
@@ -20821,12 +20821,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorblack{
-	icon_state = "borderfloor_white";
-	dir = 8
+	dir = 8;
+	icon_state = "borderfloor_white"
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
-	icon_state = "bordercolor";
-	dir = 8
+	dir = 8;
+	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -20875,8 +20875,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/landmark{
 	name = "lightsout"
@@ -20913,12 +20913,12 @@
 /area/hallway/commandstarboard)
 "aJw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -20943,26 +20943,26 @@
 /area/hallway/commandstarboard)
 "aJz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aJA" = (
 /obj/machinery/atmospherics/binary/circulator{
-	tag = "icon-circ-off (WEST)";
-	icon_state = "circ-off";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "circ-off";
+	tag = "icon-circ-off (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aJB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -21021,8 +21021,8 @@
 /area/engineering/genstorage)
 "aJI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 4
+	dir = 4;
+	icon_state = "map_vent_out"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -21095,24 +21095,24 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aJO" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aJP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
@@ -21131,9 +21131,9 @@
 /obj/item/stack/package_wrap/twenty_five,
 /obj/item/stack/package_wrap/twenty_five,
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -21173,8 +21173,8 @@
 /area/logistics/mechbay)
 "aJV" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "roboprivacy";
@@ -21183,13 +21183,13 @@
 	pixel_y = -26
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mechbay)
@@ -21222,8 +21222,8 @@
 	},
 /obj/item/device/flash/synthetic,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
@@ -21233,29 +21233,29 @@
 /area/logistics/robotics)
 "aJY" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
 "aJZ" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
 "aKb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -21264,9 +21264,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -21302,8 +21302,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/item/weapon/tank/jetpack/oxygen,
 /obj/item/weapon/tank/jetpack/oxygen,
@@ -21330,16 +21330,16 @@
 /area/security/cosoffice)
 "aKi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/carpet,
 /area/security/cosoffice)
 "aKj" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -21372,8 +21372,8 @@
 "aKm" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -21427,8 +21427,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet,
 /area/command/hop)
@@ -21478,8 +21478,8 @@
 /area/hallway/commandstarboard)
 "aKx" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
@@ -21504,34 +21504,34 @@
 /area/engineering/engine)
 "aKC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aKD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aKE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aKF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
@@ -21617,8 +21617,8 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -21637,9 +21637,9 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -21663,9 +21663,9 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 2
@@ -21694,9 +21694,9 @@
 "aKP" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21760,14 +21760,14 @@
 "aKS" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -21803,9 +21803,9 @@
 /area/logistics/mailing)
 "aKW" = (
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
@@ -21826,8 +21826,8 @@
 /area/logistics/mechbay)
 "aLa" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/button/windowtint{
 	pixel_x = 22;
@@ -21839,9 +21839,9 @@
 	pixel_y = -6
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mechbay)
@@ -21849,8 +21849,8 @@
 /obj/machinery/vending/robotics,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
@@ -21904,9 +21904,9 @@
 /area/logistics/robotics)
 "aLg" = (
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -21933,13 +21933,13 @@
 /area/rnd/office)
 "aLj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -21956,13 +21956,13 @@
 /area/rnd/office)
 "aLk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21977,13 +21977,13 @@
 /area/rnd/office)
 "aLl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/maintenance{
@@ -22002,8 +22002,8 @@
 /area/rnd/office)
 "aLm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -22119,8 +22119,8 @@
 /area/command/fo)
 "aLy" = (
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22129,8 +22129,8 @@
 "aLz" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandoffices)
@@ -22172,8 +22172,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
@@ -22254,9 +22254,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
@@ -22278,9 +22278,9 @@
 	req_access = list(10)
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
@@ -22326,9 +22326,9 @@
 /area/engineering/genstorage)
 "aLR" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -22347,14 +22347,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
@@ -22364,9 +22364,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/genstorage)
@@ -22392,8 +22392,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -22427,9 +22427,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor_switch{
@@ -22446,15 +22446,15 @@
 	pixel_y = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aMb" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22470,8 +22470,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -22505,8 +22505,8 @@
 /area/logistics/mailing)
 "aMe" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -22522,16 +22522,16 @@
 /area/logistics/mechbay)
 "aMf" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -22543,8 +22543,8 @@
 /area/logistics/mechbay)
 "aMg" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -22559,8 +22559,8 @@
 /area/logistics/mechbay)
 "aMh" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/super;
@@ -22574,9 +22574,9 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mechbay)
@@ -22586,8 +22586,8 @@
 	pixel_x = -22
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /obj/effect/floor_decal/corner/black/three_quarters,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -22648,8 +22648,8 @@
 /area/logistics/robotics)
 "aMn" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Cargo Hallway";
@@ -22660,9 +22660,9 @@
 "aMo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -22705,9 +22705,9 @@
 /area/rnd/office)
 "aMs" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/sign/urist/nt{
 	pixel_y = -32
@@ -22716,9 +22716,9 @@
 /area/rnd/office)
 "aMt" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/light,
 /turf/simulated/open,
@@ -22755,8 +22755,8 @@
 "aMw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
@@ -22801,17 +22801,17 @@
 /area/command/fo)
 "aMB" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandoffices)
 "aMC" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22819,16 +22819,16 @@
 /area/hallway/commandoffices)
 "aMD" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandoffices)
 "aME" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -22840,22 +22840,22 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandoffices)
 "aMG" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22870,9 +22870,9 @@
 /area/hallway/commandoffices)
 "aMH" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -22884,9 +22884,9 @@
 	req_access = list(19)
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandoffices)
@@ -22917,9 +22917,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22935,9 +22935,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22956,9 +22956,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22973,8 +22973,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23032,9 +23032,9 @@
 /area/security/starboardgun)
 "aMT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -23047,9 +23047,9 @@
 /area/space)
 "aMV" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -23111,9 +23111,9 @@
 "aNd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
@@ -23130,8 +23130,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -23154,8 +23154,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -23174,8 +23174,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -23194,8 +23194,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/light,
 /obj/effect/catwalk_plated/dark,
@@ -23223,9 +23223,9 @@
 /area/engineering/genstorage)
 "aNj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
@@ -23374,21 +23374,21 @@
 	layer = 2.4
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aNy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -23429,13 +23429,13 @@
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23447,12 +23447,12 @@
 /area/command/eva)
 "aND" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23464,8 +23464,8 @@
 /area/command/eva)
 "aNE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23493,23 +23493,23 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/command/eva)
 "aNG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23529,12 +23529,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23555,8 +23555,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23566,8 +23566,8 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/commandoffices)
@@ -23590,12 +23590,12 @@
 /area/hallway/commandoffices)
 "aNL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23626,8 +23626,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23642,12 +23642,12 @@
 /area/hallway/commandoffices)
 "aNN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23692,8 +23692,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23716,12 +23716,12 @@
 /area/hallway/commandoffices)
 "aNQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23752,12 +23752,12 @@
 "aNS" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23772,8 +23772,8 @@
 /area/hallway/commandoffices)
 "aNT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23792,12 +23792,12 @@
 /area/hallway/commandoffices)
 "aNU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23827,12 +23827,12 @@
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23853,12 +23853,12 @@
 "aNW" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23902,8 +23902,8 @@
 /area/hallway/commandoffices)
 "aNY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23920,12 +23920,12 @@
 "aNZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -23944,9 +23944,9 @@
 /area/hallway/commandoffices)
 "aOa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -23972,8 +23972,8 @@
 /area/hallway/commandstarboard)
 "aOb" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Bridge Hallway Starboard - Gun Bay";
@@ -23984,16 +23984,16 @@
 /area/hallway/commandstarboard)
 "aOc" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aOd" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
@@ -24003,24 +24003,24 @@
 	req_access = list(19)
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/starboardgun)
 "aOf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/security/starboardgun)
 "aOg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/plating,
 /area/security/starboardgun)
@@ -24047,16 +24047,16 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aOl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -24093,12 +24093,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -24111,8 +24111,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
@@ -24122,8 +24122,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated/dark,
@@ -24140,13 +24140,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engine Monitering";
@@ -24174,10 +24174,10 @@
 /area/engineering/tcommsmon)
 "aOu" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Telecommunications Subnet";
 	charge = 5e+006;
 	input_attempt = 1;
-	output_attempt = 1;
-	RCon_tag = "Telecommunications Subnet"
+	output_attempt = 1
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/cable/fadeblue{
@@ -24240,8 +24240,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lockers)
@@ -24258,8 +24258,8 @@
 	req_access = 1
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -24273,8 +24273,8 @@
 "aOG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -24287,9 +24287,9 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/beige/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -24301,15 +24301,15 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/cargo{
 	c_tag = "Upper Cargo Bay Main"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -24318,8 +24318,8 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -24327,8 +24327,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -24340,8 +24340,8 @@
 /area/logistics/uppercargo)
 "aOL" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -24358,16 +24358,16 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
 "aON" = (
 /obj/effect/floor_decal/corner/beige/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /obj/structure/ladder,
 /obj/machinery/light{
@@ -24380,8 +24380,8 @@
 /area/logistics/uppercargo)
 "aOP" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -24392,9 +24392,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -24453,12 +24453,12 @@
 "aOY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
@@ -24473,15 +24473,15 @@
 /area/command/eva)
 "aPb" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandoffices)
 "aPc" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -24489,8 +24489,8 @@
 /area/hallway/commandoffices)
 "aPd" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -24503,8 +24503,8 @@
 /area/hallway/commandoffices)
 "aPe" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -24514,15 +24514,15 @@
 "aPf" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandoffices)
 "aPg" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -24537,19 +24537,19 @@
 /area/hallway/commandoffices)
 "aPh" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandoffices)
 "aPi" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Command Offices Hallway - Centre";
@@ -24615,8 +24615,8 @@
 "aPo" = (
 /obj/item/trash/pistachios,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -24732,25 +24732,25 @@
 /obj/item/device/radio,
 /obj/item/clothing/glasses/meson,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
 "aPB" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
 "aPC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/yellow/three_quarters{
 	dir = 1
@@ -24771,13 +24771,13 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
@@ -24787,9 +24787,9 @@
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
@@ -24802,9 +24802,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
@@ -24815,13 +24815,13 @@
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/nitrogen/prechilled,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
@@ -24840,16 +24840,16 @@
 	req_access = list(61)
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
 "aPJ" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/yellow{
@@ -24882,19 +24882,19 @@
 	pixel_x = -25
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lockers)
 "aPO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -24915,8 +24915,8 @@
 "aPP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -24928,12 +24928,12 @@
 /area/logistics/lockers)
 "aPQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -24942,20 +24942,20 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lockers)
 "aPR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Lockers";
@@ -24972,12 +24972,12 @@
 /area/logistics/lockers)
 "aPS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -24990,8 +24990,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -25010,16 +25010,16 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
 "aPU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25031,12 +25031,12 @@
 /area/logistics/uppercargo)
 "aPV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25048,12 +25048,12 @@
 /area/logistics/uppercargo)
 "aPW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -25073,8 +25073,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25102,13 +25102,13 @@
 /area/logistics/uppercargo)
 "aPZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25121,8 +25121,8 @@
 "aQa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25134,14 +25134,14 @@
 /area/logistics/uppercargo)
 "aQb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25153,9 +25153,9 @@
 /area/logistics/uppercargo)
 "aQc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/beige/full,
 /obj/machinery/door/airlock/mining{
@@ -25173,13 +25173,13 @@
 /area/logistics/uppercargo)
 "aQd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25242,9 +25242,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -25276,8 +25276,8 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
@@ -25288,8 +25288,8 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/command/storage)
@@ -25300,8 +25300,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -25321,8 +25321,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/command/storage)
@@ -25333,8 +25333,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -25399,14 +25399,14 @@
 	department = "Bodyguard"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bodyguard)
@@ -25415,21 +25415,21 @@
 	c_tag = "Bodyguard Office"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bodyguard)
 "aQA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -25444,16 +25444,16 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bodyguard)
 "aQB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
@@ -25464,14 +25464,14 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -25513,9 +25513,9 @@
 "aQF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
@@ -25533,15 +25533,15 @@
 	req_access = list(19)
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aQI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -25564,9 +25564,9 @@
 /area/engineering/smmon)
 "aQL" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
@@ -25606,20 +25606,20 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
 "aQO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -25639,12 +25639,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable/fadeblue{
 	d1 = 2;
@@ -25660,8 +25660,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
@@ -25678,8 +25678,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
@@ -25695,8 +25695,8 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /turf/simulated/floor/bluegrid/server,
 /area/engineering/tcomms)
@@ -25768,8 +25768,8 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -25785,9 +25785,9 @@
 	req_access = 1
 	},
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -25827,21 +25827,21 @@
 /area/logistics/uppercargo)
 "aRk" = (
 /obj/machinery/atmospherics/valve/shutoff{
-	tag = "icon-map_vclamp0 (WEST)";
+	dir = 8;
 	icon_state = "map_vclamp0";
-	dir = 8
+	tag = "icon-map_vclamp0 (WEST)"
 	},
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
 "aRl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/beige/full,
 /obj/machinery/door/airlock/mining{
@@ -25853,25 +25853,25 @@
 /area/logistics/uppercargo)
 "aRm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aRn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -25967,8 +25967,8 @@
 /area/command/storage)
 "aRy" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -25979,8 +25979,8 @@
 /area/command/storage)
 "aRA" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -26003,9 +26003,9 @@
 /area/command/storage)
 "aRC" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/item/weapon/rig/medical/equipped,
 /obj/structure/table/rack,
@@ -26015,8 +26015,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/item/weapon/storage/belt/medical,
 /obj/item/weapon/storage/fancy/vials,
@@ -26025,9 +26025,9 @@
 /area/medical/cmo)
 "aRD" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -26039,9 +26039,9 @@
 /area/medical/cmo)
 "aRE" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26059,9 +26059,9 @@
 /area/medical/cmo)
 "aRF" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26074,9 +26074,9 @@
 /obj/item/weapon/pen,
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bodyguard)
@@ -26114,9 +26114,9 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bodyguard)
@@ -26193,12 +26193,12 @@
 	tag = "icon-intercom (NORTH)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
@@ -26210,8 +26210,8 @@
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
@@ -26230,8 +26230,8 @@
 	tag = "icon-freezer_0 (NORTH)"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
@@ -26254,8 +26254,8 @@
 /area/engineering/tcommsmon)
 "aRX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /obj/structure/cable/fadeblue{
 	d1 = 1;
@@ -26283,9 +26283,9 @@
 /area/maintenance/third_deck/afs)
 "aSa" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j1";
-	dir = 1
+	tag = "icon-pipe-j1 (NORTH)"
 	},
 /obj/random/maintenance/clean,
 /obj/structure/closet/crate,
@@ -26305,8 +26305,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -26331,16 +26331,16 @@
 /area/logistics/uppercargo)
 "aSj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
 "aSk" = (
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -26367,9 +26367,9 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/purple/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/effect/floor_decal/borderfloor,
 /turf/simulated/floor/tiled,
@@ -26396,36 +26396,36 @@
 /area/civilian/abandonedoffice)
 "aSp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/abandonedoffice)
 "aSq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/abandonedoffice)
 "aSr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -26440,13 +26440,13 @@
 /area/civilian/abandonedoffice)
 "aSs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -26466,8 +26466,8 @@
 /area/civilian/abandonedoffice)
 "aSt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -26491,9 +26491,9 @@
 /area/maintenance/third_deck/cents)
 "aSu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -26503,8 +26503,8 @@
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
@@ -26516,8 +26516,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -26525,20 +26525,20 @@
 "aSw" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/command/eva)
 "aSx" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/command/eva)
@@ -26570,8 +26570,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
@@ -26586,12 +26586,12 @@
 /area/command/storage)
 "aSD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -26613,9 +26613,9 @@
 /area/command/storage)
 "aSF" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -26625,28 +26625,28 @@
 /area/medical/cmo)
 "aSG" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /mob/living/simple_animal/cat/fluff/Runtime,
 /turf/simulated/floor/tiled/white,
 /area/medical/cmo)
 "aSH" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -26655,9 +26655,9 @@
 /area/medical/cmo)
 "aSI" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -26666,9 +26666,9 @@
 /area/medical/cmo)
 "aSJ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/machinery/disposal,
 /obj/machinery/light_switch{
@@ -26678,8 +26678,8 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/cmo)
@@ -26692,9 +26692,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /turf/simulated/floor/tiled/techmaint,
@@ -26734,9 +26734,9 @@
 	tag = "icon-intercom (WEST)"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -26792,8 +26792,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -26808,9 +26808,9 @@
 /area/maintenance/third_deck/afs)
 "aSX" = (
 /obj/structure/disposalpipe/sortjunction/untagged{
-	tag = "icon-pipe-j1s (WEST)";
+	dir = 8;
 	icon_state = "pipe-j1s";
-	dir = 8
+	tag = "icon-pipe-j1s (WEST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -26819,25 +26819,25 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
 "aSY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -26857,13 +26857,13 @@
 /area/maintenance/third_deck/afs)
 "aSZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -26886,8 +26886,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -26931,9 +26931,9 @@
 /area/logistics/qm)
 "aTe" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -26942,8 +26942,8 @@
 /area/logistics/qm)
 "aTf" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -26974,14 +26974,14 @@
 /area/logistics/uppercargo)
 "aTk" = (
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/computer/shuttle_control/liftnerva,
 /turf/simulated/floor/tiled,
@@ -27000,8 +27000,8 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/abandonedoffice)
@@ -27043,8 +27043,8 @@
 /area/command/storage)
 "aTu" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
@@ -27061,8 +27061,8 @@
 /area/command/storage)
 "aTw" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -27082,9 +27082,9 @@
 /area/command/storage)
 "aTy" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -27149,9 +27149,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/snack,
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb2 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb2";
-	dir = 1
+	tag = "icon-cobweb2 (NORTH)"
 	},
 /obj/item/device/flashlight,
 /turf/simulated/floor/plating,
@@ -27252,9 +27252,9 @@
 /area/maintenance/third_deck/afs)
 "aTU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
@@ -27277,9 +27277,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -27293,9 +27293,9 @@
 /area/logistics/qm)
 "aTW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27313,9 +27313,9 @@
 /area/logistics/qm)
 "aTY" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -27325,8 +27325,8 @@
 /area/logistics/qm)
 "aTZ" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -27344,9 +27344,9 @@
 /area/logistics/uppercargo)
 "aUc" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -27400,12 +27400,12 @@
 /area/command/storage)
 "aUj" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/storage)
@@ -27417,8 +27417,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/storage)
@@ -27429,8 +27429,8 @@
 	pixel_y = -28
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -27456,9 +27456,9 @@
 /area/command/storage)
 "aUn" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -27467,9 +27467,9 @@
 /area/medical/cmo)
 "aUo" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -27481,9 +27481,9 @@
 /area/medical/cmo)
 "aUp" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/machinery/keycard_auth{
 	pixel_y = -26
@@ -27498,9 +27498,9 @@
 /area/medical/cmo)
 "aUq" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/machinery/button/windowtint{
 	dir = 4;
@@ -27514,8 +27514,8 @@
 	pixel_y = -24
 	},
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-18";
-	icon_state = "plant-18"
+	icon_state = "plant-18";
+	tag = "icon-plant-18"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/cmo)
@@ -27599,9 +27599,9 @@
 /area/logistics/qm)
 "aUB" = (
 /obj/item/modular_computer/console/preset/nervasupply{
-	tag = "icon-console (WEST)";
+	dir = 8;
 	icon_state = "console";
-	dir = 8
+	tag = "icon-console (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/qm)
@@ -27614,20 +27614,20 @@
 /area/logistics/qm)
 "aUD" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/qm)
 "aUE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/airlock/glass/mining{
 	name = "Quartermaster";
@@ -27638,36 +27638,36 @@
 /area/logistics/qm)
 "aUF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
 "aUG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
 "aUH" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/logistics/uppercargo)
 "aUI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
@@ -27681,8 +27681,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -27718,13 +27718,13 @@
 /area/maintenance/third_deck/cents)
 "aUM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -27741,13 +27741,13 @@
 /area/maintenance/third_deck/cents)
 "aUN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -27763,9 +27763,9 @@
 /area/maintenance/third_deck/cents)
 "aUO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -27779,8 +27779,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
@@ -27791,8 +27791,8 @@
 	id_tag = "primarydeck_vent"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/command/eva)
@@ -27807,12 +27807,12 @@
 	tag_interior_door = "primarydeck_interior"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 5
+	dir = 5;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/command/eva)
@@ -27843,9 +27843,9 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
@@ -27889,25 +27889,25 @@
 /area/logistics/qm)
 "aUZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/qm)
 "aVa" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/qm)
 "aVb" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
@@ -27937,8 +27937,8 @@
 /area/maintenance/third_deck/cents)
 "aVf" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
+	dir = 10;
+	icon_state = "warning"
 	},
 /obj/machinery/airlock_sensor{
 	id_tag = "primarydeck_sensor";
@@ -27954,20 +27954,20 @@
 	id_tag = "primarydeck_vent"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plating,
 /area/command/eva)
 "aVh" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
@@ -27991,8 +27991,8 @@
 /area/maintenance/third_deck/afs)
 "aVl" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-22";
-	icon_state = "plant-22"
+	icon_state = "plant-22";
+	tag = "icon-plant-22"
 	},
 /obj/effect/floor_decal/corner/yellow/three_quarters,
 /obj/machinery/button/windowtint{
@@ -28036,9 +28036,9 @@
 "aVo" = (
 /obj/structure/filingcabinet,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/qm)
@@ -28093,9 +28093,9 @@
 "aVu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/tinted{
-	tag = "icon-window (EAST)";
+	dir = 4;
 	icon_state = "window";
-	dir = 4
+	tag = "icon-window (EAST)"
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/structure/bed/chair/urist/barber,
@@ -28136,9 +28136,9 @@
 "aVz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
@@ -28202,16 +28202,16 @@
 "aVJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/tinted{
-	tag = "icon-window (EAST)";
+	dir = 4;
 	icon_state = "window";
-	dir = 4
+	tag = "icon-window (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
 "aVK" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 10
+	dir = 10;
+	icon_state = "warning"
 	},
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "primarydeck_airlock";
@@ -28235,8 +28235,8 @@
 /area/command/eva)
 "aVM" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 6
+	dir = 6;
+	icon_state = "warning"
 	},
 /obj/structure/handrai,
 /turf/simulated/floor/reinforced/airless,
@@ -28294,8 +28294,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -28312,8 +28312,8 @@
 "aVU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -28329,13 +28329,13 @@
 /area/maintenance/third_deck/cents)
 "aVV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -28351,14 +28351,14 @@
 /area/maintenance/third_deck/cents)
 "aVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -28367,8 +28367,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
@@ -28395,9 +28395,9 @@
 "aVZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/urist/barber{
-	tag = "icon-barber_pole (WEST)";
+	dir = 8;
 	icon_state = "barber_pole";
-	dir = 8
+	tag = "icon-barber_pole (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
@@ -28450,8 +28450,8 @@
 /area/maintenance/third_deck/afp)
 "bzS" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Fore Hallway - Fore Starboard";
@@ -28475,13 +28475,13 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (WEST)";
+	dir = 8;
 	icon_state = "bordercolorhalf";
-	dir = 8
+	tag = "icon-bordercolorhalf (WEST)"
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
@@ -28501,8 +28501,8 @@
 	pixel_y = -28
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/item/clothing/accessory/armband/cargo,
 /turf/simulated/floor/tiled/dark,
@@ -28514,9 +28514,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
@@ -28524,33 +28524,33 @@
 /obj/structure/closet/secure_closet/nervasec,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security Locker Room"
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/item/clothing/accessory/armband,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
 "cFl" = (
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (WEST)";
+	dir = 8;
 	icon_state = "bordercolorhalf";
-	dir = 8
+	tag = "icon-bordercolorhalf (WEST)"
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -28600,8 +28600,8 @@
 /area/security/checkpoint)
 "dkt" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -28648,8 +28648,8 @@
 /area/security/brig)
 "dOY" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28674,13 +28674,13 @@
 	req_access = list(29)
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
@@ -28694,26 +28694,26 @@
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/item/clothing/accessory/armband,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
 "eik" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -28737,19 +28737,19 @@
 "emS" = (
 /obj/item/trash/cigbutt/rand,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
 "eou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -28804,9 +28804,9 @@
 /area/security/office)
 "esi" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /obj/structure/table/standard,
 /obj/item/weapon/hand_labeler,
@@ -28823,8 +28823,8 @@
 	sortType = "Research"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
@@ -28852,15 +28852,15 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
 "eJz" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Fore Hallway - Fore Port";
@@ -28874,8 +28874,8 @@
 /area/hallway/fore/third_deck)
 "fng" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -28901,9 +28901,9 @@
 /area/command/eva)
 "fqm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -28940,8 +28940,8 @@
 /area/security/cosoffice)
 "fGH" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -28976,12 +28976,12 @@
 /area/civilian/kitchen)
 "fRw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -28990,8 +28990,8 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandoffices)
@@ -29001,9 +29001,9 @@
 /area/logistics/robotics)
 "fWA" = (
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /obj/effect/floor_decal/corner/fadeblue,
 /turf/simulated/floor/tiled,
@@ -29057,9 +29057,9 @@
 /area/civilian/kitchen)
 "gVr" = (
 /obj/effect/floor_decal/corner/beige{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -29074,25 +29074,25 @@
 	},
 /obj/item/weapon/mining_scanner,
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/item/clothing/accessory/armband/cargo,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lockers)
 "hpL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29143,13 +29143,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -29207,9 +29207,9 @@
 /area/security/checkpoint)
 "jxA" = (
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -29281,12 +29281,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/door/airlock/security{
 	name = "Security Office";
@@ -29325,9 +29325,9 @@
 /obj/item/weapon/storage/backpack/duffel/duffel_norm,
 /obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/machinery/alarm{
 	pixel_y = 25
@@ -29348,9 +29348,9 @@
 "kFS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -29368,21 +29368,21 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
 "kKt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -29401,16 +29401,16 @@
 "lkt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
 "lmx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
-	tag = "icon-corner_white_diagonal (EAST)";
+	dir = 4;
 	icon_state = "corner_white_diagonal";
-	dir = 4
+	tag = "icon-corner_white_diagonal (EAST)"
 	},
 /obj/structure/closet/secure_closet/CMO,
 /obj/item/device/megaphone,
@@ -29438,9 +29438,9 @@
 /area/maintenance/third_deck/afp)
 "lAn" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -29450,8 +29450,8 @@
 /area/security/office)
 "mcq" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atm{
 	pixel_x = 30
@@ -29465,14 +29465,14 @@
 "mqS" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /obj/item/weapon/folder/red,
 /obj/item/weapon/pen,
@@ -29495,8 +29495,8 @@
 "mvm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
@@ -29524,9 +29524,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -29550,20 +29550,20 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
 "nbG" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (WEST)";
+	dir = 8;
 	icon_state = "bordercolorhalf";
-	dir = 8
+	tag = "icon-bordercolorhalf (WEST)"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -29592,8 +29592,8 @@
 /obj/item/device/flash,
 /obj/item/weapon/handcuffs,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -29638,13 +29638,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -29658,14 +29658,14 @@
 /area/hallway/fore/third_deck)
 "ogN" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
@@ -29710,33 +29710,33 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/device/taperecorder,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "oPu" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
 "oSO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
@@ -29752,9 +29752,9 @@
 /area/civilian/kitchen)
 "puU" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
@@ -29763,8 +29763,8 @@
 /area/security/boardarmoury)
 "pVb" = (
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -29775,9 +29775,9 @@
 	icon_state = "camera"
 	},
 /obj/machinery/light/warmtint{
-	tag = "icon-tube_map (EAST)";
+	dir = 4;
 	icon_state = "tube_map";
-	dir = 4
+	tag = "icon-tube_map (EAST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -29795,13 +29795,13 @@
 "qlE" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (EAST)";
+	dir = 4;
 	icon_state = "bordercolorhalf";
-	dir = 4
+	tag = "icon-bordercolorhalf (EAST)"
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
@@ -29820,8 +29820,8 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
@@ -29831,8 +29831,8 @@
 /area/medical/lobby)
 "qBP" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
@@ -29854,8 +29854,8 @@
 /obj/item/weapon/storage/backpack/duffel/duffel_norm,
 /obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 1
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
 /obj/machinery/camera/network/cargo{
 	c_tag = "Cargo Locker Room";
@@ -29863,8 +29863,8 @@
 	icon_state = "camera"
 	},
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/item/clothing/accessory/armband/cargo,
 /turf/simulated/floor/tiled/dark,
@@ -29874,12 +29874,12 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 6
+	dir = 6;
+	icon_state = "edge"
 	},
 /obj/machinery/computer/operating{
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
@@ -29897,20 +29897,20 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
 "smN" = (
 /obj/effect/floor_decal/corner/black/bordercorner{
-	tag = "icon-bordercolorcorner (EAST)";
+	dir = 4;
 	icon_state = "bordercolorcorner";
-	dir = 4
+	tag = "icon-bordercolorcorner (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
@@ -29928,13 +29928,13 @@
 /area/logistics/robotics)
 "spk" = (
 /obj/effect/floor_decal/corner/paleblue{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /obj/effect/floor_decal/floordetail/edgedrain{
-	icon_state = "edge";
-	dir = 10
+	dir = 10;
+	icon_state = "edge"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
@@ -29996,20 +29996,20 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
 "tcQ" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
@@ -30036,9 +30036,9 @@
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/effect/floor_decal/corner/red,
 /obj/item/clothing/accessory/armband,
@@ -30046,24 +30046,24 @@
 /area/security/lockers)
 "tCO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/beige/three_quarters{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	tag = "icon-warningcorner (EAST)";
+	dir = 4;
 	icon_state = "warningcorner";
-	dir = 4
+	tag = "icon-warningcorner (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
 "tWi" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
@@ -30084,9 +30084,9 @@
 /area/security/lockers)
 "usp" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -30102,9 +30102,9 @@
 /area/maintenance/third_deck/afp)
 "uIr" = (
 /obj/effect/floor_decal/corner/red/half{
-	tag = "icon-bordercolorhalf (NORTH)";
+	dir = 1;
 	icon_state = "bordercolorhalf";
-	dir = 1
+	tag = "icon-bordercolorhalf (NORTH)"
 	},
 /obj/effect/floor_decal/corner/black{
 	dir = 10
@@ -30143,8 +30143,8 @@
 /area/logistics/robotics)
 "vfR" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/vending/assist,
 /obj/machinery/alarm{
@@ -30179,8 +30179,8 @@
 	req_access = list(63)
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
@@ -30199,15 +30199,15 @@
 /area/maintenance/third_deck/cents)
 "vDQ" = (
 /obj/effect/floor_decal/corner/beige{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/uppercargo)
 "vGr" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/newscaster{
 	pixel_x = 28
@@ -30236,8 +30236,8 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
@@ -30256,19 +30256,19 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /obj/item/clothing/accessory/armband,
 /turf/simulated/floor/tiled/techmaint,
@@ -30309,8 +30309,8 @@
 	},
 /obj/effect/floor_decal/corner/red/half,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
@@ -30354,13 +30354,13 @@
 /area/logistics/robotics)
 "xyC" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
@@ -30374,9 +30374,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -853,26 +853,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/cryo2)
-"cf" = (
+"cj" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/area/hallway/aft/second_deck)
 "cl" = (
 /obj/item/stack/rods/ten,
 /turf/simulated/floor/reinforced/airless,
@@ -1739,12 +1740,31 @@
 /obj/item/taperoll/engineering/applied,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"ec" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
+"ee" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "eh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/machinery/meter,
@@ -1906,6 +1926,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"eu" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "ev" = (
 /obj/structure/closet/walllocker/emerglocker/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2110,15 +2156,6 @@
 "fc" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "fe" = (
@@ -2352,68 +2389,43 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
-"fG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"fF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
 	tag = ""
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fP" = (
-/obj/machinery/vending/urist/autodrobe,
 /turf/simulated/floor/wood,
 /area/civilian/entertainer)
-"gc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"gf" = (
+"gd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atm{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/area/hallway/aft/second_deck)
 "gg" = (
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Auxiliary Storage";
-	dir = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/logistics/auxtool)
-"gi" = (
-/obj/structure/bed/nice,
-/obj/structure/curtain/open/bed,
-/obj/item/weapon/bedsheet/mime,
-/obj/effect/landmark/start{
-	name = "Mime"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
 "gq" = (
 /obj/item/weapon/soap/deluxe,
 /obj/item/weapon/bikehorn/rubberducky,
@@ -2656,16 +2668,44 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
+"gP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "gQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"gR" = (
-/obj/item/weapon/stool,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
+"he" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/obj/structure/bed/chair/comfy,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "hk" = (
 /obj/item/weapon/storage/mirror{
 	pixel_x = -28;
@@ -2899,13 +2939,28 @@
 /turf/simulated/floor/plating,
 /area/command/headquarters)
 "hR" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 8;
-	icon_state = "map_vclamp0";
-	tag = "icon-map_vclamp0 (WEST)"
+/obj/machinery/door/airlock/glass{
+	name = "Auxiliary Storage"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/auxtool)
 "hS" = (
 /turf/simulated/wall/r_wall,
 /area/command/teleporter)
@@ -3142,6 +3197,22 @@
 	icon_state = "camera"
 	},
 /turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"iv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "iw" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -3485,6 +3556,30 @@
 /obj/item/weapon/bedsheet/green,
 /turf/simulated/floor/wood,
 /area/civilian/dorms)
+"jn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "jo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8;
@@ -4577,6 +4672,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
+"lu" = (
+/obj/item/stack/cable_coil,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "lv" = (
 /obj/machinery/teleport/station{
 	dir = 1
@@ -5392,6 +5491,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
+"nf" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
 "ng" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5572,6 +5681,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/command/captain)
+"nx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "ny" = (
 /turf/simulated/wall/r_wall,
 /area/command/fobedroom)
@@ -5758,6 +5884,14 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
+"nU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "nV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -5773,18 +5907,6 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
-"nY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "nZ" = (
 /obj/machinery/light,
@@ -6314,6 +6436,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
+"oU" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "oV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -6724,6 +6855,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
+"pS" = (
+/obj/machinery/light_construct,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "pT" = (
 /obj/machinery/light{
 	dir = 1
@@ -6735,35 +6871,6 @@
 	icon_state = "camera"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"pU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"pX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "pZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8591,9 +8698,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
-"ta" = (
-/turf/simulated/floor/plating,
-/area/civilian/personal)
 "tb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
@@ -9514,10 +9618,6 @@
 "uF" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
-/area/civilian/personal)
-"uG" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/plating,
 /area/civilian/personal)
 "uH" = (
 /obj/machinery/alarm{
@@ -12122,17 +12222,6 @@
 /obj/effect/shuttle_landmark/ninja/deck2,
 /turf/space,
 /area/space)
-"Aa" = (
-/obj/item/stack/tile/floor,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Entertainer's Room";
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
 "Ac" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -12150,6 +12239,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
+"Ai" = (
+/obj/machinery/papershredder,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Al" = (
 /obj/effect/floor_decal/corner/red/three_quarters,
 /obj/structure/cable{
@@ -12170,12 +12266,6 @@
 /obj/item/weapon/papercrafts/oragami/swan,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"As" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "Ax" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Atmospherics Substation";
@@ -12216,29 +12306,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"AA" = (
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+"Az" = (
+/obj/structure/table/woodentable,
+/obj/item/device/camera,
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "AB" = (
 /obj/machinery/door/airlock/glass{
 	name = "Prison Observatory"
@@ -12258,61 +12333,23 @@
 "AE" = (
 /turf/simulated/wall/r_wall,
 /area/security/prison)
-"AI" = (
+"AG" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
-"AL" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/light{
-	dir = 4
-	},
+"AM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
-"AM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
-"AN" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/computer/arcade/orion_trail,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "AP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12335,81 +12372,86 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"AT" = (
-/obj/machinery/light/broken,
+"AY" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Fore";
+	dir = 1;
+	icon_state = "camera"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
+"Bb" = (
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Cryo";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "Bc" = (
 /obj/effect/floor_decal/chapel,
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"Bj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Bm" = (
 /obj/item/weapon/material/shard,
 /turf/simulated/floor/plating,
 /area/civilian/observatory)
-"Bp" = (
-/obj/machinery/door/airlock/glass{
-	name = "Auxiliary Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+"Bt" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/auxtool)
-"Bt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0;
-	tag = ""
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
-"Bw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"BE" = (
 /obj/structure/table/woodentable,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
-"Bx" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
+/obj/item/weapon/storage/pill_bottle/dice,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "BJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12421,6 +12463,36 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
+"BK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"BL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (NORTHWEST)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "BM" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4;
@@ -12429,6 +12501,46 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"BP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"BQ" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 22
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"BT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "BU" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -12442,6 +12554,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/chapel)
+"BV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "BW" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/yellow{
@@ -12459,11 +12581,47 @@
 "BZ" = (
 /turf/simulated/wall,
 /area/civilian/counselor)
+"Cd" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/landmark/costume,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"Cg" = (
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Ch" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/civilian/exercise)
+"Cj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Cl" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -12472,6 +12630,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"Ct" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Cu" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -12497,33 +12675,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/civilian/counselor)
-"Cz" = (
-/obj/item/weapon/material/shard{
-	icon_state = "small"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"CG" = (
-/turf/simulated/floor/reinforced/airless,
-/area/security/prison)
-"CJ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+"CD" = (
+/obj/item/stack/tile/floor,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Entertainer's Room";
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/blue,
 /area/civilian/entertainer)
-"CL" = (
-/obj/structure/table/woodentable,
-/obj/item/device/camera,
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+"CG" = (
+/turf/simulated/floor/reinforced/airless,
+/area/security/prison)
 "CO" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/weapon/material/minihoe,
@@ -12546,6 +12711,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"CU" = (
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Library";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Da" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12558,22 +12731,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Dd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "Df" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12586,26 +12743,57 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"Dt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"Dl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"Dt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"Dw" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/bed/chair/couch/right/brown,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "Dx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -12619,21 +12807,50 @@
 /obj/random/toolbox,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"DH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -28
+"DF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 25
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
-"DM" = (
-/obj/item/stack/rods/ten,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+"DG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"DN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/item/device/taperecorder,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "DP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -12691,47 +12908,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
-"DT" = (
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Cryo";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
-"DU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"DS" = (
+/obj/machinery/vending/games,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"DV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"DX" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "DY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12854,11 +13054,7 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
-"Ex" = (
-/obj/structure/ladder/updown,
-/turf/simulated/floor/plating,
-/area/maintenance/second_deck/fp)
-"EA" = (
+"Ev" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12871,6 +13067,16 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
+"Ex" = (
+/obj/structure/ladder/updown,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/fp)
+"EG" = (
+/obj/machinery/newscaster{
+	pixel_y = -28
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "EJ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -12882,11 +13088,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"EL" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/storage/pill_bottle/dice,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "EM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
@@ -12926,21 +13127,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
-"EY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "Fa" = (
 /obj/effect/floor_decal/corner/red/three_quarters{
 	dir = 1
@@ -12964,10 +13150,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
-"Fb" = (
-/obj/random/toolbox,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "Fd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13006,19 +13188,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"Fi" = (
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/obj/structure/bed/chair/couch/middle/brown,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
-"Fk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "Fl" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -13033,17 +13202,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Fr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "Fu" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/flame/candle,
@@ -13073,26 +13231,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"FB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Aft-Centre"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "FD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -13112,20 +13250,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
+"FH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Aft-Centre"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "FI" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"FM" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
 "FN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13136,11 +13286,6 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
-"FO" = (
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "FR" = (
 /obj/structure/closet/emcloset,
@@ -13168,14 +13313,30 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
-"Gr" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
+"Gm" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/structure/bed/chair/comfy,
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"Gs" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "Gv" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1;
@@ -13211,10 +13372,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"GB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
 "GF" = (
 /obj/effect/floor_decal/corner/black/three_quarters{
 	dir = 1;
@@ -13234,41 +13391,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"GH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/broken{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"GN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "GO" = (
 /obj/effect/shuttle_landmark/nerva/deck2/hadrian,
 /turf/space,
@@ -13294,6 +13416,33 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"GW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "GX" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4;
@@ -13303,49 +13452,6 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"GY" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"Hb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
-"Hg" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/machinery/door/window/northleft,
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13367,6 +13473,30 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"Hk" = (
+/obj/structure/foamedmetal,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Hn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Hq" = (
 /obj/machinery/light{
 	dir = 8
@@ -13383,6 +13513,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"Hv" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
 "Hy" = (
 /obj/structure/bed/chair/urist/bench/bench1/right,
 /obj/effect/floor_decal/chapel{
@@ -13422,36 +13556,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"HF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"HH" = (
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
+"HI" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
 "HJ" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"HK" = (
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
 "HP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -13465,19 +13587,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
-"HT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "HU" = (
 /obj/machinery/door/blast/regular{
 	dir = 2;
@@ -13494,25 +13603,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/security/boardarmoury)
-"HV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "Id" = (
 /obj/item/stack/rods/ten,
 /turf/simulated/floor/tiled/dark,
@@ -13541,13 +13631,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/command/captain)
-"Ih" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+"In" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "Io" = (
 /obj/structure/cable/yellow{
@@ -13558,6 +13650,59 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"Iq" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"Iu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"Iw" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/pen,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"Iz" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
+"ID" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "IE" = (
 /turf/simulated/wall/r_wall,
 /area/civilian/entertainer)
@@ -13577,25 +13722,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/command/captain)
-"IH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "IJ" = (
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/second_deck/fs)
@@ -13625,6 +13751,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"IQ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "IT" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 1;
@@ -13674,51 +13817,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"Jb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"Jc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+"Ja" = (
+/obj/machinery/vending/urist/autodrobe,
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "Jg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13762,6 +13864,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Jo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Fore-Centre"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Jv" = (
 /obj/structure/fitness/weightlifter,
 /obj/effect/floor_decal/corner/black/border{
@@ -13774,6 +13899,20 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"Jw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Jy" = (
 /obj/effect/floor_decal/chapel{
 	dir = 8;
@@ -13783,6 +13922,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"JD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "JE" = (
 /obj/item/weapon/table_parts/wood,
 /obj/structure/cable{
@@ -13824,6 +13967,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"JN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "JQ" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -13868,19 +14019,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
 "Kb" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/bed/chair/couch/left/brown,
-/obj/machinery/atm{
-	pixel_x = -28
-	},
+/obj/structure/synthesized_instrument/synthesizer/piano,
 /turf/simulated/floor/wood,
-/area/logistics/auxtool)
+/area/civilian/lounge)
 "Kd" = (
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
@@ -13891,46 +14035,6 @@
 /obj/item/weapon/cell/super,
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
-"Kh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm8";
-	name = "Entertainer's Room";
-	req_access = list(46)
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/civilian/entertainer)
-"Kr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "Kw" = (
 /obj/machinery/door/blast/regular{
 	dir = 2;
@@ -13957,27 +14061,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"KF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "KG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"KH" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/structure/bookcase,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "KJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14033,35 +14129,10 @@
 "KN" = (
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"KR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"KU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+"KP" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "KV" = (
 /obj/structure/bed/nice,
 /obj/item/weapon/bedsheet/white,
@@ -14075,12 +14146,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"KZ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
 "Lc" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -14111,6 +14176,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
+"Lh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/table/woodentable,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "Lj" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck Fore Port Maintenance APC";
@@ -14196,21 +14279,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
-"LH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/newscaster{
-	hitstaken = 1;
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "LI" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
@@ -14218,21 +14286,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"LN" = (
-/obj/item/modular_computer/console/preset/civilian{
-	dir = 8
+"LK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Rec Room - Fore";
-	dir = 8;
-	icon_state = "camera"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/wood,
-/area/civilian/lounge)
+/area/civilian/entertainer)
 "LO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -14275,14 +14338,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/wall/r_wall,
 /area/chapel)
-"LY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/second_deck/fs)
-"Ma" = (
+"LX" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -14307,21 +14363,28 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
-"Mc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"LY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
 	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/fs)
+"Mb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/area/hallway/aft/second_deck)
+"Md" = (
+/obj/item/stack/tile/floor,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/aft/second_deck)
 "Mg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14362,6 +14425,31 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"Mk" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/item/device/camera/tvcamera,
+/obj/structure/closet/cabinet,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/obj/item/clothing/accessory/badge/press,
+/obj/item/clothing/suit/armor/vest/press,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "Mn" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/breakerbox/activated{
@@ -14369,14 +14457,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
-"Mo" = (
-/obj/machinery/light_construct{
-	dir = 4;
-	icon_state = "tube-construct-stage1";
-	tag = "icon-tube-construct-stage1 (EAST)"
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
 "Mp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -14392,7 +14472,7 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"Mt" = (
+"Mv" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -14404,14 +14484,16 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (EAST)"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/area/hallway/fore/second_deck)
 "Mx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14454,21 +14536,26 @@
 /turf/simulated/floor/carpet,
 /area/chapel)
 "MF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm8";
+	name = "Entertainer's Room";
+	req_access = list(46)
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/tiled/dark,
+/area/civilian/entertainer)
 "MG" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8;
@@ -14499,33 +14586,12 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"MM" = (
-/obj/item/stack/tile/floor,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
-"MN" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/second_deck/fs)
-"MS" = (
-/obj/structure/table/woodentable,
-/obj/item/device/camera_film,
-/obj/effect/floor_decal/spline/fancy/wood{
+"MO" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/aft/second_deck)
 "MV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -14567,11 +14633,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"Nc" = (
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Library";
-	dir = 1;
-	icon_state = "camera"
+"Nd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -14590,24 +14667,33 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
+"Nj" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "Nk" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/standard,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
-"Nn" = (
-/obj/item/device/flashlight/lamp/lava/pink{
-	on = 1
+"Np" = (
+/obj/structure/bed/nice,
+/obj/structure/curtain/open/bed,
+/obj/item/weapon/bedsheet/mime,
+/obj/effect/landmark/start{
+	name = "Mime"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue,
 /area/civilian/entertainer)
+"Nq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	icon_state = "map-supply"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Nr" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -14629,6 +14715,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
+"Ns" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Fore Hallway - Port"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Nu" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -14668,10 +14778,70 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"NG" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/fs)
 "NI" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
+"NJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"NL" = (
+/obj/item/weapon/bikehorn,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/lipstick/black{
+	pixel_y = 5
+	},
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/purple{
+	pixel_y = -5
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "NO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Second Deck Substation";
@@ -14742,6 +14912,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"NY" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "Ob" = (
 /obj/structure/hygiene/sink{
 	dir = 8;
@@ -14778,23 +14952,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"Ok" = (
-/obj/item/stack/cable_coil,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "Op" = (
@@ -14812,10 +14979,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
-"Oq" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "Os" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -14859,10 +15022,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"Ox" = (
-/obj/machinery/vending/games,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
+"OB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "OC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -14871,12 +15045,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"OE" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "OG" = (
 /obj/item/modular_computer/console/preset/library,
 /obj/machinery/light{
@@ -14884,43 +15052,34 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"OO" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/pen,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"Pa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
+"OQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin,
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 5
-	},
-/obj/item/device/taperecorder,
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
-"Pd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/area/hallway/fore/second_deck)
 "Pe" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -14933,7 +15092,7 @@
 "Ph" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/substation/atmos)
-"Pk" = (
+"Pm" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -14945,15 +15104,9 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/broken{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	dir = 4;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -14976,57 +15129,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"Pt" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
-"Pu" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/landmark/costume,
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
-"PB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "PC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -15035,18 +15137,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"PK" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+"PG" = (
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"PJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/stack/tile/floor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Fore";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "PN" = (
 /obj/random/maintenance,
 /turf/simulated/floor/reinforced,
@@ -15114,13 +15221,44 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"PX" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
+"PZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Qd" = (
 /turf/simulated/wall/r_wall,
 /area/civilian/exercise)
+"Qe" = (
+/obj/item/weapon/material/shard{
+	icon_state = "small"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Qf" = (
+/obj/item/stack/material/steel/ten,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Qg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -15142,9 +15280,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
-"Qh" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/aft/second_deck)
 "Qo" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Second Deck"
@@ -15159,6 +15294,40 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
+"Qp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Qr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Qv" = (
 /obj/effect/floor_decal/chapel{
 	dir = 8;
@@ -15186,6 +15355,9 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"Qx" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/aft/second_deck)
 "QF" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -15241,13 +15413,6 @@
 /obj/structure/ladder,
 /turf/simulated/floor/plating,
 /area/security/boardarmoury)
-"QP" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/synthesized_instrument/synthesizer/piano,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "QV" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8;
@@ -15256,25 +15421,68 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"QW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"QX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "QY" = (
 /obj/machinery/vending/urist/sustenance,
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"QZ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"Ra" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"Rf" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/obj/structure/bed/chair/couch/left/brown,
+/obj/machinery/atm{
+	pixel_x = -28
+	},
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
+"Rh" = (
+/obj/structure/bookcase/manuals/xenoarchaeology,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Ri" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "stickyweb2";
@@ -15317,28 +15525,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
-"Rr" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/item/device/camera/tvcamera,
-/obj/structure/closet/cabinet,
-/obj/item/device/camera,
+"Rx" = (
+/obj/structure/table/woodentable,
 /obj/item/device/camera_film,
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	dir = 1
-	},
-/obj/item/clothing/accessory/badge/press,
-/obj/item/clothing/suit/armor/vest/press,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /turf/simulated/floor/carpet/orange,
 /area/logistics/auxtool)
@@ -15358,6 +15549,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/boardarmoury)
+"RD" = (
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 8;
+	icon_state = "map_vclamp0";
+	tag = "icon-map_vclamp0 (WEST)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "RF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
@@ -15366,6 +15565,23 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"RI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atm{
+	pixel_x = 30
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "RK" = (
 /obj/machinery/door/airlock/glass{
 	name = "Prison Hydroponics"
@@ -15387,22 +15603,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"RL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "RM" = (
 /obj/structure/inflatable/wall,
 /turf/simulated/floor/plating,
@@ -15421,6 +15621,10 @@
 	name = "Counselor's Office"
 	},
 /turf/simulated/floor/tiled/dark,
+/area/hallway/aft/second_deck)
+"RP" = (
+/obj/random/maintenance,
+/turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "RR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15448,23 +15652,33 @@
 /obj/structure/bookcase,
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
-"Sb" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"RV" = (
+/obj/item/modular_computer/console/preset/civilian{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Rec Room - Fore";
+	dir = 8;
+	icon_state = "camera"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"RX" = (
+/obj/structure/bed/nice,
+/obj/structure/curtain/open/bed,
+/obj/item/weapon/bedsheet/clown,
+/obj/item/weapon/storage/backpack/duffel/duffel_clown,
+/obj/machinery/light/small/red,
+/obj/effect/landmark/start{
+	name = "Clown"
+	},
+/obj/effect/floor_decal/spline/fancy/wood/corner,
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -15499,26 +15713,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Su" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -15527,65 +15721,19 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
-"SH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+"SG" = (
+/obj/item/device/flashlight/lamp/lava/pink{
+	on = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10;
-	icon_state = "intact-supply"
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
-"SJ" = (
-/obj/random/maintenance,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"SK" = (
-/obj/item/weapon/crowbar,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"SL" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"SN" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "SS" = (
 /obj/structure/bed/chair/wood{
 	dir = 1;
@@ -15622,8 +15770,16 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"Ta" = (
-/obj/structure/firedoor_assembly,
+"Tb" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "Tc" = (
@@ -15644,46 +15800,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"Tl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"Tm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"Tr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"Tg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"Ts" = (
-/obj/machinery/door/firedoor,
+/area/hallway/aft/second_deck)
+"Tu" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -15697,16 +15830,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Ty" = (
 /obj/random/junk,
 /obj/machinery/light/small/red,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
+"Tz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "TA" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1;
@@ -15726,30 +15868,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"TI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+"TJ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"TJ" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -28
+/obj/machinery/newscaster{
+	hitstaken = 1;
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "TM" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -15777,10 +15910,27 @@
 	opacity = 1
 	},
 /area/maintenance/second_deck/afs)
-"TS" = (
-/obj/item/weapon/material/shard,
+"TR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/area/hallway/fore/second_deck)
 "Ub" = (
 /obj/machinery/vending/tool,
 /turf/simulated/floor/tiled,
@@ -15788,38 +15938,20 @@
 "Uc" = (
 /turf/simulated/wall/r_wall,
 /area/chapel)
-"Ue" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"Uh" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"Uj" = (
 /obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Fore-Centre"
-	},
-/obj/structure/disposalpipe/segment{
+	c_tag = "Auxiliary Storage";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"Uk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	icon_state = "map-supply"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "Ul" = (
 /obj/item/ammo_magazine/c44,
 /obj/structure/closet/secure_closet/nervacap,
@@ -15866,6 +15998,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Uw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Uy" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/cornseed,
@@ -15881,13 +16026,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"Uz" = (
-/obj/machinery/papershredder,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "UA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -15908,6 +16046,37 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"UC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"UH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "UI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15934,34 +16103,10 @@
 	icon_state = "rfalse"
 	},
 /area/maintenance/second_deck/fp)
-"UN" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/second_deck/fp)
-"UP" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/obj/structure/bed/chair/couch/right/brown,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
+"UQ" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "UR" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/machinery/requests_console{
@@ -15978,6 +16123,34 @@
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
+"UT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (EAST)"
+	},
+/obj/machinery/light/broken{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"UV" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "UW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -15999,24 +16172,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"Vd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "Vg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16028,29 +16183,13 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
-"Vh" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 22
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
 "Vi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Vl" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/polarized/full{
@@ -16076,99 +16215,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
-"VD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/dark,
+"Vz" = (
+/obj/item/stack/rods/ten,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
+"VJ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/door/window/northleft,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "VN" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
-"VS" = (
-/obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"VV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"VY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"Wb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "Wc" = (
 /obj/machinery/door/morgue{
 	name = "Confessional Booth"
@@ -16196,10 +16257,22 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
-"Wf" = (
-/obj/item/stack/material/steel/ten,
+"We" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/area/hallway/fore/second_deck)
 "Wh" = (
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -16226,17 +16299,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Ws" = (
+"Wq" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Aft Hallway - Tech Storage"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16261,32 +16335,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
 "Wy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Wz" = (
 /obj/structure/closet/firecloset,
 /obj/structure/catwalk,
@@ -16300,6 +16353,38 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
+"WE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"WG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "WH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -16319,10 +16404,6 @@
 "WL" = (
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
-"WM" = (
-/obj/structure/foamedmetal,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "WP" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -16336,39 +16417,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"WQ" = (
-/obj/structure/bed/nice,
-/obj/structure/curtain/open/bed,
-/obj/item/weapon/bedsheet/clown,
-/obj/item/weapon/storage/backpack/duffel/duffel_clown,
-/obj/machinery/light/small/red,
-/obj/effect/landmark/start{
-	name = "Clown"
-	},
-/obj/effect/floor_decal/spline/fancy/wood/corner,
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
 "WS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Aft Hallway - Tech Storage"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/area/hallway/aft/second_deck)
 "WW" = (
 /obj/item/stack/tile/floor,
 /turf/simulated/floor/plating,
@@ -16454,27 +16520,23 @@
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
-"Xm" = (
-/obj/machinery/light{
-	dir = 8
+"Xp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
 	},
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"Xn" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
-"Xr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/stack/tile/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
@@ -16492,10 +16554,20 @@
 /obj/effect/floor_decal/corner/red/full,
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"XI" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+"XH" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/fp)
 "XJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -16543,6 +16615,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
+"XO" = (
+/obj/structure/firedoor_assembly,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "XT" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -16555,11 +16631,13 @@
 /turf/simulated/floor/plating,
 /area/civilian/counselor)
 "XY" = (
-/obj/machinery/newscaster{
-	pixel_y = -28
+/obj/machinery/light_construct{
+	dir = 4;
+	icon_state = "tube-construct-stage1";
+	tag = "icon-tube-construct-stage1 (EAST)"
 	},
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "Ya" = (
 /obj/machinery/power/sensor{
 	name_tag = "Second Deck Power"
@@ -16587,30 +16665,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"Ye" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
-	},
-/obj/machinery/light/broken{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "Yf" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -16638,31 +16692,6 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"Ym" = (
-/obj/item/weapon/bikehorn,
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/lipstick/black{
-	pixel_y = 5
-	},
-/obj/item/weapon/lipstick/random,
-/obj/item/weapon/lipstick/purple{
-	pixel_y = -5
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
 "Yo" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -16680,56 +16709,24 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"Yq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
-"Yr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (NORTHWEST)"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"YF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/obj/effect/catwalk_plated,
+"Yv" = (
+/obj/item/weapon/material/shard,
 /turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Yw" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"YH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
-"YL" = (
+"YD" = (
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
@@ -16737,22 +16734,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Fore Hallway - Port"
-	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
+"YE" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "YO" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16762,59 +16757,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"YT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"YQ" = (
+/obj/machinery/alarm{
+	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	icon_state = "intact-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"YW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/obj/structure/bed/chair/couch/middle/brown,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "YY" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -16835,6 +16784,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"Zf" = (
+/obj/machinery/light/broken,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Zh" = (
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor/plating,
@@ -16871,6 +16824,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
+"Zr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Zu" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 2;
@@ -16878,14 +16848,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"Zv" = (
+"Zy" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "ZA" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-21";
@@ -16897,7 +16877,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"ZJ" = (
+"ZI" = (
+/obj/item/weapon/crowbar,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"ZK" = (
+/obj/structure/table/standard,
+/obj/structure/bedsheetbin,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/security/prison)
+"ZN" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16908,21 +16898,19 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
-"ZK" = (
-/obj/structure/table/standard,
-/obj/structure/bedsheetbin,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/security/prison)
-"ZN" = (
-/obj/machinery/light_construct,
-/obj/machinery/light,
-/turf/simulated/floor/carpet/orange,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"ZO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
 /area/logistics/auxtool)
 "ZP" = (
 /obj/structure/cable{
@@ -16937,17 +16925,22 @@
 "ZQ" = (
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"ZV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"ZT" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "ZW" = (
 /obj/random/tool,
@@ -34828,7 +34821,7 @@ de
 de
 ep
 fa
-fG
+Oh
 gG
 jY
 ih
@@ -35030,7 +35023,7 @@ df
 dG
 eq
 bI
-Vi
+Qp
 gG
 hD
 Dh
@@ -35232,7 +35225,7 @@ dg
 dH
 er
 bI
-Pt
+Gs
 gG
 ii
 ij
@@ -35434,7 +35427,7 @@ bI
 bI
 bI
 bI
-Ws
+WS
 gH
 hC
 hE
@@ -35636,7 +35629,7 @@ aQ
 aQ
 aQ
 fb
-MF
+BP
 gG
 hE
 eC
@@ -35838,7 +35831,7 @@ hC
 hC
 hC
 hC
-KU
+Wq
 gI
 hC
 eC
@@ -36040,7 +36033,7 @@ Ay
 dI
 es
 RO
-IH
+QW
 gG
 hC
 eC
@@ -36242,7 +36235,7 @@ YY
 dJ
 et
 fc
-DU
+WE
 gG
 hC
 hE
@@ -36444,7 +36437,7 @@ BZ
 hC
 hC
 hC
-DU
+WE
 Ps
 hF
 ik
@@ -36646,7 +36639,7 @@ BZ
 dL
 ev
 Uq
-DX
+iv
 gJ
 hG
 il
@@ -36848,7 +36841,7 @@ BZ
 dM
 ew
 hC
-Sb
+IQ
 gK
 hC
 im
@@ -37050,7 +37043,7 @@ BZ
 hC
 hC
 hC
-DU
+WE
 gJ
 hH
 hH
@@ -37067,7 +37060,7 @@ ro
 sc
 sZ
 tR
-ta
+sd
 sd
 vW
 wF
@@ -37252,7 +37245,7 @@ cA
 cA
 cc
 cc
-Dt
+Cj
 gJ
 hH
 in
@@ -37267,10 +37260,10 @@ gJ
 qw
 ro
 sd
-ta
-ta
-ta
-ta
+sd
+sd
+sd
+sd
 vX
 wG
 xj
@@ -37454,7 +37447,7 @@ dh
 dh
 ex
 cc
-DU
+WE
 gJ
 hH
 io
@@ -37471,8 +37464,8 @@ Lg
 sd
 tb
 tS
-uG
-uG
+tS
+tS
 tS
 wH
 xk
@@ -37656,7 +37649,7 @@ di
 dN
 ey
 fe
-Kr
+UH
 gJ
 hH
 io
@@ -37858,8 +37851,8 @@ dj
 dO
 ez
 ff
-EA
-DT
+Ev
+Bb
 hH
 io
 jk
@@ -38060,7 +38053,7 @@ dk
 dk
 eA
 cc
-DU
+WE
 gJ
 hH
 in
@@ -38262,8 +38255,8 @@ cF
 cF
 cc
 cc
-SN
-Bx
+Tu
+UQ
 hH
 hH
 hH
@@ -38464,7 +38457,7 @@ cc
 cc
 cc
 cc
-Yq
+ZT
 gN
 hH
 in
@@ -38666,7 +38659,7 @@ dl
 aX
 bB
 eB
-DU
+WE
 gJ
 hH
 ip
@@ -38868,7 +38861,7 @@ Um
 aX
 aX
 fg
-HV
+DF
 gO
 hH
 iq
@@ -39063,14 +39056,14 @@ al
 Um
 Um
 Um
-Rr
-HK
-XI
+Mk
+HH
+NY
 Um
 dP
 aX
 fg
-Mt
+NJ
 gJ
 hH
 io
@@ -39263,16 +39256,16 @@ ah
 ah
 Um
 Um
-Kb
-gg
-Hg
-HK
-ZN
+Ra
+Uj
+VJ
+HH
+pS
 Um
 aG
 aX
 fg
-ZJ
+BT
 gJ
 hH
 in
@@ -39465,16 +39458,16 @@ ah
 ah
 Um
 Um
-Fi
-GB
-Bw
-Gr
-XY
+YQ
+JD
+Lh
+he
+EG
 Um
 dQ
 Ty
 fg
-FB
+FH
 gJ
 hH
 hH
@@ -39659,24 +39652,24 @@ ah
 ah
 ah
 ah
-FO
-FO
-FO
-FO
-Qh
-Qh
-Qh
+Cg
+Cg
+Cg
+Cg
+Qx
+Qx
+Qx
 Um
-UP
-Zv
-Pa
-MS
-CL
+Dw
+ZO
+DN
+Rx
+Az
 Um
 aH
 aX
 fg
-DU
+WE
 gJ
 hH
 ir
@@ -39861,25 +39854,25 @@ ah
 ah
 ah
 ah
-FO
+Cg
 eC
 eC
-SK
-Ta
-Ok
-WM
+ZI
+XO
+lu
+Hk
 Um
-FM
-PX
-AM
-ec
-ec
+gg
+Nj
+DV
+Iz
+Iz
 Um
 dR
 aX
 fg
-DU
-Bx
+WE
+UQ
 hH
 is
 jk
@@ -40063,24 +40056,24 @@ ah
 ah
 ah
 ah
-FO
+Cg
 WW
 eC
-DM
-TS
+Vz
+Yv
 RM
 eC
 Um
 fp
 fp
-Bp
+hR
 fp
 fp
 Um
 al
 eB
 fg
-KF
+nx
 gK
 hH
 hH
@@ -40265,7 +40258,7 @@ ah
 ah
 ah
 ah
-FO
+Cg
 eC
 eC
 eC
@@ -40274,27 +40267,27 @@ eC
 eC
 dm
 ii
-MM
-Su
+Md
+Xp
 ii
-KZ
+MO
 Hq
 JU
 ii
 rt
-Oh
-Pd
+cj
+ID
 gQ
-Fr
-pU
-Pd
+Mb
+Tb
+ID
 lh
-fd
-DH
-Uk
+Tg
+Tz
+Nq
 oN
-Fk
-Fk
+AM
+AM
 rs
 sk
 tj
@@ -40467,24 +40460,24 @@ ah
 ah
 ah
 ah
-FO
+Cg
 eC
-Fb
+PG
 eC
-Cz
+Qe
 eC
 eC
 dn
 ii
-AL
-Wy
-Xr
+YE
+GW
+PJ
 MW
-ZV
-VD
-nY
+gd
+Jw
+UC
 Yb
-PB
+BK
 gJ
 oO
 iu
@@ -40669,24 +40662,24 @@ ah
 ah
 ah
 ah
-FO
+Cg
 WW
 eC
 WW
-SJ
+RP
 eC
 RM
 IE
 IE
 IE
-Kh
+MF
 IE
 IE
 IE
 bs
 eD
 fi
-Ts
+Ct
 LA
 hJ
 hJ
@@ -40871,33 +40864,33 @@ ah
 ah
 ah
 ah
-FO
+Cg
 eC
 eC
 eC
 eC
-Wf
-WM
+Qf
+Hk
 IE
-Ym
-Nn
-Bt
-Aa
-gi
+NL
+SG
+fF
+CD
+Np
 IE
 dU
 cR
 fi
-VY
-Tm
+gP
+nU
 hJ
 iw
 jp
 ke
 lj
-TJ
-Xm
-VS
+KH
+Uh
+Rh
 hJ
 iK
 iK
@@ -41073,25 +41066,25 @@ ah
 ah
 ah
 ah
-FO
-FO
-FO
-FO
-FO
-Qh
-Qh
+Cg
+Cg
+Cg
+Cg
+Cg
+Qx
+Qx
 IE
-Pu
-YH
-SH
-Hb
-WQ
+Cd
+DG
+LK
+HI
+RX
 IE
 dV
 cR
 eD
-pX
-hR
+ZN
+RD
 hK
 jq
 iz
@@ -41283,19 +41276,19 @@ ah
 aq
 IE
 IE
-fP
-Vh
-Mo
-CJ
-Xn
+Ja
+BQ
+XY
+nf
+Hv
 PS
 cR
 eE
 fi
-YT
-Yr
+OQ
+BL
 hK
-EL
+BE
 kg
 iz
 iz
@@ -41494,8 +41487,8 @@ IE
 bs
 cR
 fi
-Ue
-gc
+Jo
+Vi
 hK
 js
 iz
@@ -41503,7 +41496,7 @@ iz
 lk
 RU
 Zh
-Oq
+KP
 hK
 pI
 qK
@@ -41696,7 +41689,7 @@ ah
 bs
 eD
 fi
-AA
+YD
 iK
 hL
 iz
@@ -41898,10 +41891,10 @@ ah
 dW
 cR
 fj
-cf
+Hn
 qJ
 hK
-QP
+Kb
 iz
 iz
 jq
@@ -42100,10 +42093,10 @@ ah
 dX
 cR
 fk
-cf
+Hn
 iK
 hK
-gR
+UV
 iz
 iy
 mg
@@ -42302,10 +42295,10 @@ ah
 dW
 cR
 fj
-Tl
+Nd
 qJ
 hK
-OE
+Wy
 iz
 iy
 Xd
@@ -42504,7 +42497,7 @@ ah
 bs
 eF
 fi
-cf
+Hn
 iK
 hL
 iz
@@ -42706,10 +42699,10 @@ AE
 AE
 cR
 fi
-AI
-As
+Qr
+Gm
 hK
-Ox
+DS
 iz
 iz
 LC
@@ -42908,10 +42901,10 @@ KK
 AE
 Os
 Ov
-YF
+Bt
 iK
 hK
-OO
+Iw
 iz
 iz
 iz
@@ -43110,13 +43103,13 @@ Nr
 LO
 UA
 fi
-Pk
-Nc
+jn
+CU
 hK
 MI
 iz
-gR
-gR
+UV
+UV
 iz
 ni
 od
@@ -43312,13 +43305,13 @@ dp
 AE
 cR
 fi
-cf
+Hn
 iK
 hJ
 iE
-Uz
-AN
-LN
+Ai
+oU
+RV
 mi
 nj
 oe
@@ -43514,8 +43507,8 @@ dq
 AE
 cR
 fi
-VV
-gc
+QX
+Vi
 hN
 hN
 hN
@@ -43716,7 +43709,7 @@ Sn
 AE
 cR
 fi
-cf
+Hn
 iK
 hN
 iF
@@ -43918,8 +43911,8 @@ ds
 AE
 cR
 fi
-Tl
-AT
+Nd
+Zf
 hN
 iG
 jv
@@ -44120,7 +44113,7 @@ dt
 AE
 cR
 fi
-cf
+Hn
 iK
 hN
 hN
@@ -44322,8 +44315,8 @@ du
 AE
 cR
 fi
-YW
-KR
+PZ
+Dt
 hO
 iH
 jx
@@ -44524,7 +44517,7 @@ dv
 AE
 cR
 fi
-cf
+Hn
 iK
 hP
 iI
@@ -44726,8 +44719,8 @@ dw
 AE
 cR
 fi
-Jb
-PK
+Zy
+AY
 hN
 hN
 jz
@@ -44928,7 +44921,7 @@ AE
 AE
 cR
 fi
-cf
+Hn
 iK
 hN
 iG
@@ -45130,7 +45123,7 @@ Ob
 AE
 cR
 fi
-cf
+Hn
 iK
 hN
 iF
@@ -45332,7 +45325,7 @@ dC
 AE
 cR
 fi
-Ts
+Ct
 LA
 ls
 ls
@@ -45534,7 +45527,7 @@ AE
 AE
 Yp
 fi
-GH
+ee
 iK
 oT
 iJ
@@ -45736,7 +45729,7 @@ QM
 RC
 cR
 XM
-cf
+Hn
 iK
 oi
 iK
@@ -45938,18 +45931,18 @@ En
 HU
 cR
 XM
-GY
-QZ
-HT
-Tr
-SL
-EY
-Ma
-TI
-Dd
-LH
-gf
-RL
+eu
+BV
+Uw
+AG
+Zr
+OB
+LX
+Iq
+We
+TJ
+RI
+Iu
 iK
 ru
 sq
@@ -46140,7 +46133,7 @@ bs
 bs
 cR
 fi
-Jc
+Dl
 qJ
 hS
 TM
@@ -46151,7 +46144,7 @@ hS
 hS
 hS
 hS
-Ye
+UT
 qQ
 ru
 sq
@@ -46342,7 +46335,7 @@ bs
 MK
 cR
 fi
-YL
+Ns
 iK
 Kw
 kr
@@ -46353,7 +46346,7 @@ jF
 ns
 ok
 hS
-Vd
+Pm
 qU
 ru
 sq
@@ -46543,9 +46536,9 @@ dy
 eh
 HP
 eQ
-UN
-WS
-GN
+XH
+TR
+In
 hT
 Qg
 Gj
@@ -46555,9 +46548,9 @@ LF
 nt
 ol
 oV
-Wb
-Mc
-MN
+Bj
+WG
+NG
 sD
 ru
 tB
@@ -46746,8 +46739,8 @@ bs
 RH
 eR
 fi
-Rf
-Ih
+Yw
+JN
 hS
 iO
 jH
@@ -46757,7 +46750,7 @@ mq
 nu
 om
 hS
-HF
+Mv
 qW
 ru
 sE

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -592,17 +592,6 @@
 /obj/item/weapon/circuitboard/helm,
 /turf/simulated/floor/plating,
 /area/engineering/stech)
-"by" = (
-/obj/structure/bed/nice,
-/obj/structure/curtain/open/bed,
-/obj/item/weapon/bedsheet/clown,
-/obj/item/weapon/storage/backpack/duffel/duffel_clown,
-/obj/machinery/light/small/red,
-/obj/effect/landmark/start{
-	name = "Clown"
-	},
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
 "bz" = (
 /obj/structure/bed/psych,
 /obj/machinery/alarm{
@@ -622,18 +611,6 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"bC" = (
-/obj/item/weapon/crowbar,
-/turf/simulated/floor/airless,
-/area/space)
-"bD" = (
-/obj/item/stack/rods/ten,
-/turf/simulated/floor/airless,
-/area/space)
-"bE" = (
-/obj/item/stack/tile/floor,
-/turf/simulated/floor/airless,
-/area/space)
 "bF" = (
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/fuelbay)
@@ -680,20 +657,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/stech)
-"bK" = (
-/obj/structure/firedoor_assembly,
-/turf/simulated/floor/airless,
-/area/space)
-"bL" = (
-/obj/item/weapon/material/shard,
-/turf/simulated/floor/airless,
-/area/space)
-"bM" = (
-/obj/item/weapon/material/shard{
-	icon_state = "small"
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "bN" = (
 /obj/random/tool,
 /turf/simulated/floor/reinforced/airless,
@@ -890,33 +853,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/cryo2)
-"ce" = (
-/obj/item/stack/cable_coil,
-/turf/simulated/floor/airless,
-/area/space)
 "cf" = (
-/obj/structure/inflatable/wall,
-/turf/simulated/floor/airless,
-/area/space)
-"cg" = (
-/obj/structure/inflatable/door,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/space)
-"ch" = (
-/obj/structure/inflatable/wall,
-/turf/simulated/floor/plating,
-/area/space)
-"ci" = (
-/obj/item/stack/material/steel/ten,
-/turf/simulated/floor/airless,
-/area/space)
-"cj" = (
-/obj/structure/foamedmetal,
-/turf/simulated/floor/airless,
-/area/space)
-"ck" = (
-/turf/simulated/wall/r_wall,
-/area/space)
+/area/hallway/fore/second_deck)
 "cl" = (
 /obj/item/stack/rods/ten,
 /turf/simulated/floor/reinforced/airless,
@@ -1175,9 +1131,6 @@
 /obj/structure/cryofeed,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
-"cG" = (
-/turf/simulated/floor/plating,
-/area/space)
 "cH" = (
 /obj/item/weapon/material/shard,
 /turf/simulated/floor/reinforced/airless,
@@ -1204,10 +1157,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
-"cJ" = (
-/obj/structure/bed/nice,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
 "cK" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable{
@@ -1281,32 +1230,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"cN" = (
-/obj/structure/largecrate,
-/obj/random/soap,
-/obj/random/junk,
-/obj/random/maintenance,
-/obj/random/smokes,
-/obj/random/smokes,
-/obj/random/medical/lite,
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/random/medical/lite,
-/obj/random/toolbox,
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
-"cO" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
 "cP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1565,9 +1488,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
-"dr" = (
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
 "ds" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -1788,18 +1708,6 @@
 /obj/item/weapon/storage/toolbox/emergency,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"dT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/stack/tile/floor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "dU" = (
 /obj/structure/table/rack{
 	dir = 1
@@ -1831,6 +1739,12 @@
 /obj/item/taperoll/engineering/applied,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"ec" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "eh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/machinery/meter,
@@ -2198,6 +2112,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
+"fd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "fe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -2239,21 +2162,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
-"fq" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/second_deck/fp)
 "fr" = (
 /turf/simulated/wall/r_wall,
 /area/command/captain)
@@ -2444,8 +2352,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
-"fD" = (
-/obj/structure/catwalk,
+"fG" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -2460,744 +2367,53 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fE" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fF" = (
-/obj/structure/catwalk,
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fG" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Aft Hallway - Tech Storage"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fH" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fI" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fJ" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fK" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fL" = (
-/obj/structure/catwalk,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fO" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "fP" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fQ" = (
-/obj/structure/catwalk,
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fR" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fS" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fT" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fU" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Aft-Centre"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fV" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fW" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fX" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"fY" = (
-/obj/structure/catwalk,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"fZ" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"ga" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gb" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	icon_state = "intact-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/obj/machinery/vending/urist/autodrobe,
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "gc" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Fore-Centre"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
-	icon_state = "map-supply"
+	icon_state = "map_vent_out"
 	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gd" = (
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"ge" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
 "gf" = (
-/obj/structure/catwalk,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
+/obj/machinery/atm{
+	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "gg" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Auxiliary Storage";
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/broken{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gh" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "gi" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/bed/nice,
+/obj/structure/curtain/open/bed,
+/obj/item/weapon/bedsheet/mime,
+/obj/effect/landmark/start{
+	name = "Mime"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gj" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gk" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gm" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gn" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"go" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gp" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
 "gq" = (
 /obj/item/weapon/soap/deluxe,
 /obj/item/weapon/bikehorn/rubberducky,
@@ -3419,19 +2635,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"gL" = (
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Cryo";
-	dir = 1;
-	icon_state = "camera"
-	},
-/obj/item/weapon/caution/cone,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"gM" = (
-/obj/machinery/light,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "gN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -3453,16 +2656,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"gP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/civilian{
-	dir = 8;
-	icon_state = "closed";
-	name = "\improper Central Access";
-	tag = "icon-closed (WEST)"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "gQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3470,142 +2663,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "gR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/civilian{
-	dir = 8;
-	icon_state = "closed";
-	name = "\improper Central Access";
-	tag = "icon-closed (WEST)"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gT" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 8;
-	icon_state = "map_vclamp0";
-	tag = "icon-map_vclamp0 (WEST)"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (NORTHWEST)"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gW" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gX" = (
-/obj/machinery/light,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gZ" = (
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"ha" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/structure/bookcase,
+/obj/item/weapon/stool,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
-"hb" = (
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Library";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"hc" = (
-/obj/machinery/light/broken,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"hd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"hf" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Fore";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"hg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"hh" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"hi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"hj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "hk" = (
 /obj/item/weapon/storage/mirror{
 	pixel_x = -28;
@@ -3796,12 +2856,6 @@
 "hH" = (
 /turf/simulated/wall,
 /area/civilian/dorms)
-"hI" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "hJ" = (
 /turf/simulated/wall,
 /area/civilian/lounge)
@@ -3816,13 +2870,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
-/area/civilian/lounge)
-"hM" = (
-/obj/machinery/door/airlock/glass{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "hN" = (
 /turf/simulated/wall,
@@ -3851,25 +2898,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/command/headquarters)
-"hQ" = (
-/obj/structure/sign/deck/second{
-	dir = 4;
-	icon_state = "deck-2";
-	pixel_x = -32;
-	tag = "icon-deck-2 (EAST)"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "hR" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 8;
+	icon_state = "map_vclamp0";
+	tag = "icon-map_vclamp0 (WEST)"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
 "hS" = (
 /turf/simulated/wall/r_wall,
@@ -4100,16 +3135,6 @@
 /obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/wood,
 /area/civilian/dorms)
-"it" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "iu" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck Central Hallway - Port";
@@ -4122,34 +3147,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
-"ix" = (
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "iy" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "iz" = (
 /turf/simulated/floor/wood,
-/area/civilian/lounge)
-"iA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
-"iB" = (
-/obj/machinery/vending/games,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
-"iC" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/pen,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "iE" = (
 /obj/structure/table/woodentable,
@@ -4201,22 +3204,6 @@
 /area/hallway/fore/second_deck)
 "iK" = (
 /turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"iL" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "iM" = (
 /obj/item/weapon/hand_labeler,
@@ -4498,17 +3485,6 @@
 /obj/item/weapon/bedsheet/green,
 /turf/simulated/floor/wood,
 /area/civilian/dorms)
-"jn" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "jo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8;
@@ -4538,13 +3514,6 @@
 	tag = "icon-wooden_chair (WEST)"
 	},
 /turf/simulated/floor/wood,
-/area/civilian/lounge)
-"jt" = (
-/obj/machinery/papershredder,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "ju" = (
 /obj/structure/bed/chair/office/dark{
@@ -4654,23 +3623,6 @@
 	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"jE" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "jF" = (
 /obj/structure/table/standard,
@@ -4945,19 +3897,6 @@
 "kh" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
-/area/civilian/lounge)
-"ki" = (
-/obj/item/weapon/stool,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
-"kj" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/computer/arcade/orion_trail,
-/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "kk" = (
 /obj/structure/undies_wardrobe,
@@ -5585,25 +4524,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
-"lo" = (
-/obj/item/stack/material/wood/ten,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
-"lp" = (
-/obj/item/modular_computer/console/preset/civilian{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Rec Room - Fore";
-	dir = 8;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "lq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -5656,31 +4576,6 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"lu" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Fore Hallway - Central";
-	dir = 8;
-	icon_state = "camera"
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "lv" = (
 /obj/machinery/teleport/station{
@@ -5982,14 +4877,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
-"md" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "mg" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/deck/cards,
@@ -6052,21 +4939,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
-"mn" = (
-/obj/structure/catwalk,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "mo" = (
 /obj/machinery/computer/teleporter{
 	dir = 4
@@ -6516,16 +5388,6 @@
 /obj/item/weapon/scissors,
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
-"nc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "ne" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -6641,22 +5503,6 @@
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
-/area/hallway/fore/second_deck)
-"nr" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "ns" = (
 /obj/structure/table/standard,
@@ -6912,14 +5758,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
-"nU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	icon_state = "map-supply"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "nV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -6935,6 +5773,18 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"nY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "nZ" = (
 /obj/machinery/light,
@@ -7006,22 +5856,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"oj" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/newscaster{
-	hitstaken = 1;
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "ok" = (
 /obj/structure/closet/crate,
@@ -7480,23 +6314,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"oU" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atm{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "oV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -7920,92 +6737,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
 "pU" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"pV" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"pW" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
-	},
-/obj/machinery/light/broken{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/area/hallway/aft/second_deck)
 "pX" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"pY" = (
-/obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8015,15 +6758,11 @@
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "pZ" = (
@@ -8563,21 +7302,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"qV" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "qW" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -8920,22 +7644,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
-"rD" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/second_deck/fs)
 "rE" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -13414,6 +12122,17 @@
 /obj/effect/shuttle_landmark/ninja/deck2,
 /turf/space,
 /area/space)
+"Aa" = (
+/obj/item/stack/tile/floor,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Entertainer's Room";
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
 "Ac" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -13451,6 +12170,12 @@
 /obj/item/weapon/papercrafts/oragami/swan,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
+"As" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Ax" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Atmospherics Substation";
@@ -13491,6 +12216,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"AA" = (
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "AB" = (
 /obj/machinery/door/airlock/glass{
 	name = "Prison Observatory"
@@ -13510,6 +12258,61 @@
 "AE" = (
 /turf/simulated/wall/r_wall,
 /area/security/prison)
+"AI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"AL" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"AM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
+"AN" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "AP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13532,69 +12335,81 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"AX" = (
-/obj/structure/grille,
-/turf/simulated/floor/airless,
-/area/space)
+"AT" = (
+/obj/machinery/light/broken,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Bc" = (
 /obj/effect/floor_decal/chapel,
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"Bh" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "Bm" = (
 /obj/item/weapon/material/shard,
 /turf/simulated/floor/plating,
 /area/civilian/observatory)
-"Bt" = (
-/turf/simulated/wall/false{
-	density = 1;
-	icon_state = "metal12";
-	opacity = 1
+"Bp" = (
+/obj/machinery/door/airlock/glass{
+	name = "Auxiliary Storage"
 	},
-/area/logistics/auxtool)
-"BE" = (
-/obj/item/weapon/caution/cone,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"BF" = (
-/obj/machinery/light_construct,
-/obj/structure/bed/chair/office/dark{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
-"BH" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/random/tech_supply,
-/obj/random/tool,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/logistics/auxtool)
+"Bt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"Bw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/table/woodentable,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
+"Bx" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "BJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13614,17 +12429,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"BP" = (
-/obj/structure/firedoor_assembly,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
-"BT" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "BU" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -13693,13 +12497,33 @@
 	},
 /turf/simulated/floor/wood,
 /area/civilian/counselor)
+"Cz" = (
+/obj/item/weapon/material/shard{
+	icon_state = "small"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "CG" = (
 /turf/simulated/floor/reinforced/airless,
 /area/security/prison)
-"CI" = (
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/hallway/fore/second_deck)
+"CJ" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
+"CL" = (
+/obj/structure/table/woodentable,
+/obj/item/device/camera,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "CO" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/weapon/material/minihoe,
@@ -13734,6 +12558,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Dd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Df" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13746,14 +12586,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"Dl" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+"Dt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/logistics/auxtool)
+/area/hallway/aft/second_deck)
 "Dx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -13767,10 +12619,21 @@
 /obj/random/toolbox,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"DE" = (
-/obj/random/toolbox,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
+"DH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"DM" = (
+/obj/item/stack/rods/ten,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "DP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -13828,6 +12691,47 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
+"DT" = (
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Cryo";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"DU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"DX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "DY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13954,6 +12858,19 @@
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"EA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "EJ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -13965,6 +12882,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"EL" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/pill_bottle/dice,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "EM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
@@ -14004,6 +12926,21 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
+"EY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Fa" = (
 /obj/effect/floor_decal/corner/red/three_quarters{
 	dir = 1
@@ -14027,6 +12964,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
+"Fb" = (
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Fd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14065,6 +13006,19 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"Fi" = (
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/obj/structure/bed/chair/couch/middle/brown,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
+"Fk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Fl" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -14079,6 +13033,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Fr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Fu" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/flame/candle,
@@ -14108,6 +13073,26 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"FB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Aft-Centre"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "FD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -14133,6 +13118,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"FM" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "FN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14143,6 +13136,11 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
+/area/hallway/aft/second_deck)
+"FO" = (
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "FR" = (
 /obj/structure/closet/emcloset,
@@ -14157,29 +13155,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"Gb" = (
-/obj/machinery/door/airlock/glass{
-	name = "Auxiliary Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
 "Gj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -14193,11 +13168,14 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
-"Gn" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/storage/pill_bottle/dice,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
+"Gr" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/obj/structure/bed/chair/comfy,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "Gv" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1;
@@ -14209,10 +13187,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"Gx" = (
-/obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "Gy" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -14237,6 +13211,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
+"GB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "GF" = (
 /obj/effect/floor_decal/corner/black/three_quarters{
 	dir = 1;
@@ -14256,6 +13234,41 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"GH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"GN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "GO" = (
 /obj/effect/shuttle_landmark/nerva/deck2/hadrian,
 /turf/space,
@@ -14268,17 +13281,6 @@
 /obj/random/tech_supply,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"GR" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/landmark/costume,
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
 "GS" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/potatoseed,
@@ -14301,6 +13303,49 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"GY" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"Hb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
+"Hg" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/door/window/northleft,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14377,11 +13422,36 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"HF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (EAST)"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "HJ" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
+"HK" = (
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "HP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -14395,6 +13465,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
+"HT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "HU" = (
 /obj/machinery/door/blast/regular{
 	dir = 2;
@@ -14411,6 +13494,25 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/security/boardarmoury)
+"HV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Id" = (
 /obj/item/stack/rods/ten,
 /turf/simulated/floor/tiled/dark,
@@ -14439,6 +13541,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/command/captain)
+"Ih" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Io" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -14448,10 +13558,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"Ip" = (
-/obj/random/maintenance,
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
 "IE" = (
 /turf/simulated/wall/r_wall,
 /area/civilian/entertainer)
@@ -14471,6 +13577,25 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/command/captain)
+"IH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "IJ" = (
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/second_deck/fs)
@@ -14549,6 +13674,51 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"Jb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"Jc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Jg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -14576,17 +13746,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"Jh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
 "Ji" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -14624,10 +13783,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"JB" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "JE" = (
 /obj/item/weapon/table_parts/wood,
 /obj/structure/cable{
@@ -14712,6 +13867,20 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
+"Kb" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/structure/bed/chair/couch/left/brown,
+/obj/machinery/atm{
+	pixel_x = -28
+	},
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "Kd" = (
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
@@ -14722,25 +13891,46 @@
 /obj/item/weapon/cell/super,
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
-"Kk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"Kh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
-"Ko" = (
-/obj/item/stack/tile/floor,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Entertainer's Room";
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock{
+	id_tag = "Dorm8";
+	name = "Entertainer's Room";
+	req_access = list(46)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
 /area/civilian/entertainer)
+"Kr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "Kw" = (
 /obj/machinery/door/blast/regular{
 	dir = 2;
@@ -14767,6 +13957,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"KF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "KG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -14826,6 +14033,35 @@
 "KN" = (
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"KR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"KU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "KV" = (
 /obj/structure/bed/nice,
 /obj/item/weapon/bedsheet/white,
@@ -14839,15 +14075,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"KX" = (
-/obj/structure/computerframe,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"KZ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/aft/second_deck)
 "Lc" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -14903,19 +14136,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
-"Ls" = (
-/obj/item/device/flashlight/lamp/lava/pink{
-	on = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
 "Lt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14976,6 +14196,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
+"LH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/newscaster{
+	hitstaken = 1;
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "LI" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
@@ -14983,12 +14218,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"LJ" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
+"LN" = (
+/obj/item/modular_computer/console/preset/civilian{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Rec Room - Fore";
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "LO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -15039,12 +14283,45 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "Ma" = (
-/obj/item/stack/tile/floor,
-/obj/structure/closet,
-/obj/item/stack/rods/ten,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Fore Hallway - Central";
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/logistics/auxtool)
+/area/hallway/fore/second_deck)
+"Mc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Mg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -15092,6 +14369,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
+"Mo" = (
+/obj/machinery/light_construct{
+	dir = 4;
+	icon_state = "tube-construct-stage1";
+	tag = "icon-tube-construct-stage1 (EAST)"
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "Mp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -15107,10 +14392,26 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"Mw" = (
-/obj/structure/bed/chair/office/dark,
+"Mt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/logistics/auxtool)
+/area/hallway/aft/second_deck)
 "Mx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15152,6 +14453,22 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
+"MF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "MG" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8;
@@ -15182,25 +14499,33 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"MQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+"MM" = (
+/obj/item/stack/tile/floor,
+/turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"MN" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/fs)
+"MS" = (
+/obj/structure/table/woodentable,
+/obj/item/device/camera_film,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "MV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -15242,6 +14567,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
+"Nc" = (
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Library";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Ne" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Second Deck Bypass"
@@ -15262,6 +14595,19 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
+"Nn" = (
+/obj/item/device/flashlight/lamp/lava/pink{
+	on = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "Nr" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -15326,13 +14672,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"NN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/synthesized_instrument/synthesizer/piano,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "NO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Second Deck Substation";
@@ -15403,27 +14742,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"NY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm8";
-	name = "Entertainer's Room";
-	req_access = list(46)
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
 "Ob" = (
 /obj/structure/hygiene/sink{
 	dir = 8;
@@ -15454,15 +14772,31 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"Of" = (
-/obj/structure/bed/chair/wood,
+"Oh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/civilian/lounge)
+/area/hallway/aft/second_deck)
 "Ok" = (
-/obj/random/junk,
-/obj/structure/disposalpipe/segment,
+/obj/item/stack/cable_coil,
 /turf/simulated/floor/plating,
-/area/logistics/auxtool)
+/area/hallway/aft/second_deck)
 "Op" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10;
@@ -15478,6 +14812,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
+"Oq" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Os" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -15521,6 +14859,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"Ox" = (
+/obj/machinery/vending/games,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "OC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -15529,6 +14871,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"OE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "OG" = (
 /obj/item/modular_computer/console/preset/library,
 /obj/machinery/light{
@@ -15536,6 +14884,43 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"OO" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/pen,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"Pa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/item/device/taperecorder,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
+"Pd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Pe" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -15545,8 +14930,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/prison)
-"Pg" = (
-/obj/structure/catwalk,
+"Ph" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/substation/atmos)
+"Pk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
@@ -15555,23 +14947,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Fore Hallway - Port"
+/obj/machinery/light/broken{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"Ph" = (
-/turf/simulated/wall/r_wall,
-/area/engineering/substation/atmos)
 "Pn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15591,14 +14976,43 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"PA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
+"Pt" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"Pu" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/landmark/costume,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"PB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -15606,8 +15020,13 @@
 	pixel_x = 0;
 	tag = ""
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/civilian/entertainer)
+/area/hallway/aft/second_deck)
 "PC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -15616,12 +15035,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"PM" = (
+"PK" = (
+/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Fore";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "PN" = (
 /obj/random/maintenance,
 /turf/simulated/floor/reinforced,
@@ -15689,19 +15114,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"Qa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"PX" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "Qd" = (
 /turf/simulated/wall/r_wall,
 /area/civilian/exercise)
@@ -15726,31 +15142,8 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
-"Qk" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
+"Qh" = (
+/turf/simulated/wall/r_wall,
 /area/hallway/aft/second_deck)
 "Qo" = (
 /obj/machinery/power/smes/buildable{
@@ -15848,31 +15241,13 @@
 /obj/structure/ladder,
 /turf/simulated/floor/plating,
 /area/security/boardarmoury)
-"QQ" = (
-/obj/item/weapon/bikehorn,
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
+"QP" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/weapon/lipstick/black{
-	pixel_y = 5
-	},
-/obj/item/weapon/lipstick/random,
-/obj/item/weapon/lipstick/purple{
-	pixel_y = -5
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
+/obj/structure/synthesized_instrument/synthesizer/piano,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "QV" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8;
@@ -15881,20 +15256,25 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"QW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
-	},
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
 "QY" = (
 /obj/machinery/vending/urist/sustenance,
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Rh" = (
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
+"QZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"Rf" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Ri" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "stickyweb2";
@@ -15937,10 +15317,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
-"RB" = (
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/hallway/aft/second_deck)
+"Rr" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/item/device/camera/tvcamera,
+/obj/structure/closet/cabinet,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/obj/item/clothing/accessory/badge/press,
+/obj/item/clothing/suit/armor/vest/press,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "RC" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -15986,6 +15387,22 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"RL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "RM" = (
 /obj/structure/inflatable/wall,
 /turf/simulated/floor/plating,
@@ -16031,6 +15448,23 @@
 /obj/structure/bookcase,
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
+"Sb" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -16065,6 +15499,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Su" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -16073,6 +15527,65 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
+"SH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"SJ" = (
+/obj/random/maintenance,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"SK" = (
+/obj/item/weapon/crowbar,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"SL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"SN" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "SS" = (
 /obj/structure/bed/chair/wood{
 	dir = 1;
@@ -16109,6 +15622,10 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"Ta" = (
+/obj/structure/firedoor_assembly,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Tc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16124,6 +15641,64 @@
 	dir = 9;
 	icon_state = "intact-supply";
 	tag = "icon-intact-supply (NORTHWEST)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"Tl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"Tm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"Tr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"Ts" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -16151,6 +15726,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"TI" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"TJ" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/structure/bookcase,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "TM" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -16178,24 +15777,8 @@
 	opacity = 1
 	},
 /area/maintenance/second_deck/afs)
-"TT" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+"TS" = (
+/obj/item/weapon/material/shard,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "Ub" = (
@@ -16205,6 +15788,38 @@
 "Uc" = (
 /turf/simulated/wall/r_wall,
 /area/chapel)
+"Ue" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Fore-Centre"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"Uk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	icon_state = "map-supply"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Ul" = (
 /obj/item/ammo_magazine/c44,
 /obj/structure/closet/secure_closet/nervacap,
@@ -16266,6 +15881,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"Uz" = (
+/obj/machinery/papershredder,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "UA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -16286,13 +15908,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"UC" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
 "UI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16319,14 +15934,34 @@
 	icon_state = "rfalse"
 	},
 /area/maintenance/second_deck/fp)
-"UQ" = (
-/obj/machinery/light_construct{
-	dir = 4;
-	icon_state = "tube-construct-stage1";
-	tag = "icon-tube-construct-stage1 (EAST)"
+"UN" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
-/area/civilian/entertainer)
+/area/maintenance/second_deck/fp)
+"UP" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/bed/chair/couch/right/brown,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "UR" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/machinery/requests_console{
@@ -16364,15 +15999,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"UZ" = (
-/obj/structure/bed/nice,
-/obj/structure/curtain/open/bed,
-/obj/item/weapon/bedsheet/mime,
-/obj/effect/landmark/start{
-	name = "Mime"
+"Vd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (EAST)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Vg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16384,6 +16028,29 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
+"Vh" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 22
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"Vi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Vl" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/polarized/full{
@@ -16391,15 +16058,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/counselor)
-"Vn" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light_construct{
-	dir = 1;
-	icon_state = "tube-construct-stage1"
-	},
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
 "Vq" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -16418,28 +16076,99 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
-"Vw" = (
-/obj/structure/inflatable/door,
+"VD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "VN" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
-"VO" = (
+"VS" = (
+/obj/structure/bookcase/manuals/xenoarchaeology,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"VV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"VY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10;
-	icon_state = "intact-supply"
+	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/civilian/entertainer)
-"VX" = (
-/obj/machinery/vending/urist/autodrobe,
+/area/hallway/fore/second_deck)
+"Wb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/civilian/entertainer)
+/area/hallway/fore/second_deck)
 "Wc" = (
 /obj/machinery/door/morgue{
 	name = "Confessional Booth"
@@ -16467,6 +16196,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
+"Wf" = (
+/obj/item/stack/material/steel/ten,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Wh" = (
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -16493,14 +16226,24 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Wo" = (
-/obj/item/stack/rods/ten,
+"Ws" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /obj/machinery/camera/network/second_deck{
-	c_tag = "Auxiliary Storage";
+	c_tag = "Second Deck Aft Hallway - Tech Storage"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/logistics/auxtool)
+/area/hallway/aft/second_deck)
 "Wu" = (
 /obj/effect/floor_decal/corner/red/three_quarters{
 	dir = 1
@@ -16517,6 +16260,33 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
+"Wy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Wz" = (
 /obj/structure/closet/firecloset,
 /obj/structure/catwalk,
@@ -16549,12 +16319,8 @@
 "WL" = (
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
-"WN" = (
-/obj/machinery/light_construct{
-	dir = 4;
-	icon_state = "tube-construct-stage1";
-	tag = "icon-tube-construct-stage1 (EAST)"
-	},
+"WM" = (
+/obj/structure/foamedmetal,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "WP" = (
@@ -16570,6 +16336,39 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"WQ" = (
+/obj/structure/bed/nice,
+/obj/structure/curtain/open/bed,
+/obj/item/weapon/bedsheet/clown,
+/obj/item/weapon/storage/backpack/duffel/duffel_clown,
+/obj/machinery/light/small/red,
+/obj/effect/landmark/start{
+	name = "Clown"
+	},
+/obj/effect/floor_decal/spline/fancy/wood/corner,
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
+"WS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "WW" = (
 /obj/item/stack/tile/floor,
 /turf/simulated/floor/plating,
@@ -16595,10 +16394,6 @@
 /area/engineering/substation/atmos)
 "Xd" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"Xe" = (
-/obj/item/stack/material/wood/ten,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "Xg" = (
@@ -16659,10 +16454,30 @@
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
-"Xo" = (
-/obj/random/maintenance,
-/turf/simulated/floor/airless,
-/area/space)
+"Xm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"Xn" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
+"Xr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/stack/tile/floor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Xt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/cobweb{
@@ -16672,28 +16487,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"Xv" = (
-/obj/item/stack/material/wood/ten,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
-	},
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
 "Xy" = (
 /obj/machinery/biogenerator,
 /obj/effect/floor_decal/corner/red/full,
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"XF" = (
-/obj/machinery/light,
-/obj/item/weapon/caution/cone,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "XI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
+/obj/machinery/papershredder,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "XJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -16752,6 +16554,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/counselor)
+"XY" = (
+/obj/machinery/newscaster{
+	pixel_y = -28
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "Ya" = (
 /obj/machinery/power/sensor{
 	name_tag = "Second Deck Power"
@@ -16779,6 +16587,30 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"Ye" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (EAST)"
+	},
+/obj/machinery/light/broken{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Yf" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -16806,22 +16638,31 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"Yl" = (
-/obj/random/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
+"Ym" = (
+/obj/item/weapon/bikehorn,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/weapon/lipstick/black{
+	pixel_y = 5
+	},
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/purple{
+	pixel_y = -5
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "Yo" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -16839,27 +16680,62 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"Yt" = (
+"Yq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/logistics/auxtool)
-"YF" = (
-/obj/random/toolbox,
-/turf/simulated/floor/airless,
-/area/space)
-"YN" = (
-/obj/item/weapon/caution/cone,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
-	icon_state = "intact-supply"
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"Yr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (NORTHWEST)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"YF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"YH" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"YL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -16869,11 +16745,14 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Fore Hallway - Port"
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/logistics/auxtool)
+/area/hallway/fore/second_deck)
 "YO" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16883,6 +16762,59 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"YT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"YW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "YY" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -16946,6 +16878,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"Zv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "ZA" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-21";
@@ -16957,20 +16897,33 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"ZI" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 22
+"ZJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/civilian/entertainer)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "ZK" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/security/prison)
+"ZN" = (
+/obj/machinery/light_construct,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "ZP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16984,6 +16937,18 @@
 "ZQ" = (
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"ZV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "ZW" = (
 /obj/random/tool,
 /turf/simulated/floor/plating,
@@ -34863,7 +34828,7 @@ de
 de
 ep
 fa
-fD
+fG
 gG
 jY
 ih
@@ -35065,7 +35030,7 @@ df
 dG
 eq
 bI
-fE
+Vi
 gG
 hD
 Dh
@@ -35267,7 +35232,7 @@ dg
 dH
 er
 bI
-fF
+Pt
 gG
 ii
 ij
@@ -35469,7 +35434,7 @@ bI
 bI
 bI
 bI
-fG
+Ws
 gH
 hC
 hE
@@ -35671,7 +35636,7 @@ aQ
 aQ
 aQ
 fb
-fH
+MF
 gG
 hE
 eC
@@ -35873,7 +35838,7 @@ hC
 hC
 hC
 hC
-fI
+KU
 gI
 hC
 eC
@@ -36075,7 +36040,7 @@ Ay
 dI
 es
 RO
-TT
+IH
 gG
 hC
 eC
@@ -36277,7 +36242,7 @@ YY
 dJ
 et
 fc
-fJ
+DU
 gG
 hC
 hE
@@ -36479,7 +36444,7 @@ BZ
 hC
 hC
 hC
-fJ
+DU
 Ps
 hF
 ik
@@ -36681,7 +36646,7 @@ BZ
 dL
 ev
 Uq
-fK
+DX
 gJ
 hG
 il
@@ -36883,7 +36848,7 @@ BZ
 dM
 ew
 hC
-fL
+Sb
 gK
 hC
 im
@@ -37085,7 +37050,7 @@ BZ
 hC
 hC
 hC
-fM
+DU
 gJ
 hH
 hH
@@ -37287,7 +37252,7 @@ cA
 cA
 cc
 cc
-fN
+Dt
 gJ
 hH
 in
@@ -37489,7 +37454,7 @@ dh
 dh
 ex
 cc
-fM
+DU
 gJ
 hH
 io
@@ -37691,8 +37656,8 @@ di
 dN
 ey
 fe
-fO
-eC
+Kr
+gJ
 hH
 io
 jl
@@ -37893,8 +37858,8 @@ dj
 dO
 ez
 ff
-fP
-gL
+EA
+DT
 hH
 io
 jk
@@ -38095,8 +38060,8 @@ dk
 dk
 eA
 cc
-fJ
-RB
+DU
+gJ
 hH
 in
 io
@@ -38297,8 +38262,8 @@ cF
 cF
 cc
 cc
-fQ
-XF
+SN
+Bx
 hH
 hH
 hH
@@ -38499,7 +38464,7 @@ cc
 cc
 cc
 cc
-fR
+Yq
 gN
 hH
 in
@@ -38701,7 +38666,7 @@ dl
 aX
 bB
 eB
-fJ
+DU
 gJ
 hH
 ip
@@ -38903,7 +38868,7 @@ Um
 aX
 aX
 fg
-fS
+HV
 gO
 hH
 iq
@@ -39098,14 +39063,14 @@ al
 Um
 Um
 Um
-Dl
-Mw
-LJ
+Rr
+HK
+XI
 Um
 dP
 aX
 fg
-fT
+Mt
 gJ
 hH
 io
@@ -39298,16 +39263,16 @@ ah
 ah
 Um
 Um
-cN
-Wo
-Ip
-LJ
-BF
+Kb
+gg
+Hg
+HK
+ZN
 Um
 aG
 aX
 fg
-fJ
+ZJ
 gJ
 hH
 in
@@ -39500,16 +39465,16 @@ ah
 ah
 Um
 Um
-cO
-Ma
-Yt
-Xv
-dr
-Bt
+Fi
+GB
+Bw
+Gr
+XY
+Um
 dQ
 Ty
 fg
-fU
+FB
 gJ
 hH
 hH
@@ -39694,25 +39659,25 @@ ah
 ah
 ah
 ah
-ap
-cj
-AX
-AX
-ck
-ck
-ck
+FO
+FO
+FO
+FO
+Qh
+Qh
+Qh
 Um
-BH
-KX
-Yl
-DE
-BP
+UP
+Zv
+Pa
+MS
+CL
 Um
 aH
 aX
 fg
-fJ
-eC
+DU
+gJ
 hH
 ir
 jk
@@ -39896,25 +39861,25 @@ ah
 ah
 ah
 ah
-ap
-ap
-ap
-bC
-bK
-ce
-cj
-Um
-Vn
+FO
+eC
+eC
+SK
+Ta
 Ok
-YN
-cJ
-cJ
+WM
+Um
+FM
+PX
+AM
+ec
+ec
 Um
 dR
 aX
 fg
-fJ
-gM
+DU
+Bx
 hH
 is
 jk
@@ -40098,25 +40063,25 @@ ah
 ah
 ah
 ah
-AX
-bE
-ap
-bD
-bL
-cf
-cf
+FO
+WW
+eC
+DM
+TS
+RM
+eC
 Um
 fp
 fp
-Gb
+Bp
 fp
 fp
 Um
 al
 eB
 fg
-fV
-gP
+KF
+gK
 hH
 hH
 hH
@@ -40300,36 +40265,36 @@ ah
 ah
 ah
 ah
-cj
-ap
-ap
-ap
-bE
-cg
-cG
-dm
-Vw
-WW
-MQ
+FO
 eC
-PM
+eC
+eC
+WW
+eC
+eC
+dm
+ii
+MM
+Su
+ii
+KZ
 Hq
 JU
 ii
 rt
-fW
+Oh
+Pd
 gQ
-gQ
-it
-jn
-gQ
+Fr
+pU
+Pd
 lh
-md
-nc
-nU
+fd
+DH
+Uk
 oN
-oN
-oN
+Fk
+Fk
 rs
 sk
 tj
@@ -40502,26 +40467,26 @@ ah
 ah
 ah
 ah
-cj
-ap
-YF
-ap
-bM
-ch
-cG
-dn
-RM
-WN
-Qk
-dT
-MW
-Jh
-Qa
-Kk
-Yb
-fX
+FO
 eC
-hI
+Fb
+eC
+Cz
+eC
+eC
+dn
+ii
+AL
+Wy
+Xr
+MW
+ZV
+VD
+nY
+Yb
+PB
+gJ
+oO
 iu
 jo
 gJ
@@ -40704,25 +40669,25 @@ ah
 ah
 ah
 ah
-ap
-bE
-ap
-bE
-Xo
-cf
-cf
+FO
+WW
+eC
+WW
+SJ
+eC
+RM
 IE
 IE
 IE
-NY
+Kh
 IE
 IE
 IE
 bs
 eD
 fi
-fY
-gR
+Ts
+LA
 hJ
 hJ
 hJ
@@ -40906,33 +40871,33 @@ ah
 ah
 ah
 ah
-ap
-ap
-ap
-ap
-ap
-ci
-cj
+FO
+eC
+eC
+eC
+eC
+Wf
+WM
 IE
-QQ
-Ls
-PA
-Ko
-UZ
+Ym
+Nn
+Bt
+Aa
+gi
 IE
 dU
 cR
 fi
-fZ
-gS
+VY
+Tm
 hJ
 iw
 jp
 ke
 lj
-ha
-BT
-Gx
+TJ
+Xm
+VS
 hJ
 iK
 iK
@@ -41108,25 +41073,25 @@ ah
 ah
 ah
 ah
-aq
-ap
-bK
-ap
-aq
-ck
-ck
+FO
+FO
+FO
+FO
+FO
+Qh
+Qh
 IE
-GR
-XI
-VO
-QW
-by
+Pu
+YH
+SH
+Hb
+WQ
 IE
 dV
 cR
 eD
-ga
-gT
+pX
+hR
 hK
 jq
 iz
@@ -41318,24 +41283,24 @@ ah
 aq
 IE
 IE
-VX
-ZI
-UQ
-UC
-Rh
+fP
+Vh
+Mo
+CJ
+Xn
 PS
 cR
 eE
 fi
-gb
-gU
+YT
+Yr
 hK
-Gn
+EL
 kg
 iz
 iz
 iz
-Xe
+iz
 iz
 hK
 iK
@@ -41529,8 +41494,8 @@ IE
 bs
 cR
 fi
+Ue
 gc
-gV
 hK
 js
 iz
@@ -41538,7 +41503,7 @@ iz
 lk
 RU
 Zh
-JB
+Oq
 hK
 pI
 qK
@@ -41731,8 +41696,8 @@ ah
 bs
 eD
 fi
-gd
-gW
+AA
+iK
 hL
 iz
 iz
@@ -41933,10 +41898,10 @@ ah
 dW
 cR
 fj
-ge
-gX
+cf
+qJ
 hK
-NN
+QP
 iz
 iz
 jq
@@ -42135,10 +42100,10 @@ ah
 dX
 cR
 fk
-ge
-gZ
+cf
+iK
 hK
-ki
+gR
 iz
 iy
 mg
@@ -42337,11 +42302,11 @@ ah
 dW
 cR
 fj
-ge
-gX
+Tl
+qJ
 hK
-iA
-ix
+OE
+iz
 iy
 Xd
 kg
@@ -42539,12 +42504,12 @@ ah
 bs
 eF
 fi
-ge
-gW
-hM
-ix
-ix
-Of
+cf
+iK
+hL
+iz
+iz
+iy
 ln
 SS
 UW
@@ -42741,12 +42706,12 @@ AE
 AE
 cR
 fi
-gf
-gY
+AI
+As
 hK
-iB
-ix
-ix
+Ox
+iz
+iz
 LC
 iz
 ng
@@ -42943,13 +42908,13 @@ KK
 AE
 Os
 Ov
-gj
-gZ
+YF
+iK
 hK
-iC
-ix
-ix
-lo
+OO
+iz
+iz
+iz
 iz
 JE
 Sh
@@ -43145,13 +43110,13 @@ Nr
 LO
 UA
 fi
-gg
-hb
+Pk
+Nc
 hK
 MI
 iz
-ki
-ki
+gR
+gR
 iz
 ni
 od
@@ -43347,13 +43312,13 @@ dp
 AE
 cR
 fi
-ge
-gZ
+cf
+iK
 hJ
 iE
-jt
-kj
-lp
+Uz
+AN
+LN
 mi
 nj
 oe
@@ -43549,8 +43514,8 @@ dq
 AE
 cR
 fi
-gh
-gV
+VV
+gc
 hN
 hN
 hN
@@ -43751,8 +43716,8 @@ Sn
 AE
 cR
 fi
-ge
-gZ
+cf
+iK
 hN
 iF
 ju
@@ -43953,8 +43918,8 @@ ds
 AE
 cR
 fi
-ge
-hc
+Tl
+AT
 hN
 iG
 jv
@@ -44155,8 +44120,8 @@ dt
 AE
 cR
 fi
-ge
-gZ
+cf
+iK
 hN
 hN
 jw
@@ -44357,8 +44322,8 @@ du
 AE
 cR
 fi
-gi
-hd
+YW
+KR
 hO
 iH
 jx
@@ -44559,8 +44524,8 @@ dv
 AE
 cR
 fi
-ge
-gZ
+cf
+iK
 hP
 iI
 jy
@@ -44761,8 +44726,8 @@ dw
 AE
 cR
 fi
-gk
-hf
+Jb
+PK
 hN
 hN
 jz
@@ -44963,8 +44928,8 @@ AE
 AE
 cR
 fi
-ge
-gZ
+cf
+iK
 hN
 iG
 jA
@@ -45165,8 +45130,8 @@ Ob
 AE
 cR
 fi
-ge
-gZ
+cf
+iK
 hN
 iF
 jB
@@ -45367,8 +45332,8 @@ dC
 AE
 cR
 fi
-fY
-gR
+Ts
+LA
 ls
 ls
 ls
@@ -45569,9 +45534,9 @@ AE
 AE
 Yp
 fi
-gg
-BE
-hQ
+GH
+iK
+oT
 iJ
 jC
 kp
@@ -45771,9 +45736,9 @@ QM
 RC
 cR
 XM
-ge
-CI
-hg
+cf
+iK
+oi
 iK
 jD
 iK
@@ -45973,18 +45938,18 @@ En
 HU
 cR
 XM
-gm
-hh
-Bh
-hR
-jE
-iL
-lu
-mn
-nr
-oj
-oU
-pU
+GY
+QZ
+HT
+Tr
+SL
+EY
+Ma
+TI
+Dd
+LH
+gf
+RL
 iK
 ru
 sq
@@ -46175,8 +46140,8 @@ bs
 bs
 cR
 fi
-gn
-gX
+Jc
+qJ
 hS
 TM
 hS
@@ -46186,7 +46151,7 @@ hS
 hS
 hS
 hS
-pW
+Ye
 qQ
 ru
 sq
@@ -46377,8 +46342,8 @@ bs
 MK
 cR
 fi
-Pg
-gZ
+YL
+iK
 Kw
 kr
 lv
@@ -46388,7 +46353,7 @@ jF
 ns
 ok
 hS
-pV
+Vd
 qU
 ru
 sq
@@ -46578,9 +46543,9 @@ dy
 eh
 HP
 eQ
-fq
-go
-hi
+UN
+WS
+GN
 hT
 Qg
 Gj
@@ -46590,9 +46555,9 @@ LF
 nt
 ol
 oV
-pX
-qV
-rD
+Wb
+Mc
+MN
 sD
 ru
 tB
@@ -46781,8 +46746,8 @@ bs
 RH
 eR
 fi
-gp
-hj
+Rf
+Ih
 hS
 iO
 jH
@@ -46792,7 +46757,7 @@ mq
 nu
 om
 hS
-pY
+HF
 qW
 ru
 sE

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -2092,10 +2092,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
-"eI" = (
-/obj/item/weapon/stool,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -3531,6 +3527,15 @@
 "gZ" = (
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
+"ha" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/structure/bookcase,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "hb" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck Port Hallway - Library";
@@ -3554,10 +3559,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
-"he" = (
-/obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "hf" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4121,12 +4122,34 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
+"ix" = (
+/turf/simulated/floor/plating,
+/area/civilian/lounge)
 "iy" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "iz" = (
 /turf/simulated/floor/wood,
+/area/civilian/lounge)
+"iA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/civilian/lounge)
+"iB" = (
+/obj/machinery/vending/games,
+/turf/simulated/floor/plating,
+/area/civilian/lounge)
+"iC" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/pen,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "iE" = (
 /obj/structure/table/woodentable,
@@ -4515,6 +4538,13 @@
 	tag = "icon-wooden_chair (WEST)"
 	},
 /turf/simulated/floor/wood,
+/area/civilian/lounge)
+"jt" = (
+/obj/machinery/papershredder,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "ju" = (
 /obj/structure/bed/chair/office/dark{
@@ -4915,6 +4945,19 @@
 "kh" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
+/area/civilian/lounge)
+"ki" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/plating,
+/area/civilian/lounge)
+"kj" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "kk" = (
 /obj/structure/undies_wardrobe,
@@ -5541,6 +5584,25 @@
 	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/wood,
+/area/civilian/lounge)
+"lo" = (
+/obj/item/stack/material/wood/ten,
+/turf/simulated/floor/plating,
+/area/civilian/lounge)
+"lp" = (
+/obj/item/modular_computer/console/preset/civilian{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Rec Room - Fore";
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "lq" = (
 /obj/structure/extinguisher_cabinet{
@@ -13369,6 +13431,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
+"Al" = (
+/obj/effect/floor_decal/corner/red/three_quarters,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/reinforced,
+/area/security/prison)
 "Aq" = (
 /obj/structure/bed/chair/couch/right/black,
 /obj/item/weapon/papercrafts/oragami/swan,
@@ -13432,43 +13509,6 @@
 /area/security/prison)
 "AE" = (
 /turf/simulated/wall/r_wall,
-/area/security/prison)
-"AF" = (
-/obj/item/modular_computer/console/preset/civilian{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Rec Room - Fore";
-	dir = 8;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"AL" = (
-/obj/machinery/papershredder,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"AM" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/item/seeds/cornseed,
-/obj/item/seeds/cornseed,
-/obj/item/seeds/tobaccoseed,
-/obj/effect/floor_decal/corner/red{
-	dir = 5;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (NORTHEAST)"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "AP" = (
 /obj/structure/cable{
@@ -13578,6 +13618,13 @@
 /obj/structure/firedoor_assembly,
 /turf/simulated/floor/wood,
 /area/logistics/auxtool)
+"BT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "BU" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -13608,19 +13655,6 @@
 "BZ" = (
 /turf/simulated/wall,
 /area/civilian/counselor)
-"Ca" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"Cc" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "Ch" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -13634,9 +13668,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"Cm" = (
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/prison)
 "Cu" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -13662,24 +13693,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/civilian/counselor)
-"CC" = (
-/obj/structure/hygiene/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/prison)
 "CG" = (
 /turf/simulated/floor/reinforced/airless,
 /area/security/prison)
@@ -13708,20 +13721,6 @@
 	tag = ""
 	},
 /turf/simulated/floor/reinforced,
-/area/security/prison)
-"CW" = (
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	icon_state = "map-scrubbers"
-	},
-/turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "Da" = (
 /obj/structure/cable{
@@ -13897,15 +13896,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"El" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/computer/arcade/orion_trail,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "En" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -13964,6 +13954,13 @@
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"EJ" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/reinforced,
+/area/security/prison)
 "EK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/old_tile,
@@ -14061,6 +14058,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"Fg" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/reinforced,
+/area/security/prison)
 "Fl" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -14205,6 +14209,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"Gx" = (
+/obj/structure/bookcase/manuals/xenoarchaeology,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Gy" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -14248,10 +14256,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"GJ" = (
-/obj/machinery/vending/games,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "GO" = (
 /obj/effect/shuttle_landmark/nerva/deck2/hadrian,
 /turf/space,
@@ -14275,6 +14279,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
+"GS" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/item/seeds/potatoseed,
+/obj/item/seeds/wheatseed,
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 8
+	},
+/obj/machinery/camera/network/prison{
+	c_tag = "Prison Hydroponics";
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/security/prison)
 "GX" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4;
@@ -14284,12 +14301,6 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"He" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14369,25 +14380,6 @@
 "HJ" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
-/area/security/prison)
-"HK" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "HP" = (
@@ -14632,6 +14624,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"JB" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "JE" = (
 /obj/item/weapon/table_parts/wood,
 /obj/structure/cable{
@@ -14943,6 +14939,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
+"LB" = (
+/obj/machinery/seed_extractor,
+/obj/effect/floor_decal/corner/red/full,
+/turf/simulated/floor/reinforced,
+/area/security/prison)
 "LC" = (
 /obj/structure/bed/chair/wood{
 	dir = 8;
@@ -15125,6 +15126,24 @@
 /obj/structure/girder,
 /turf/simulated/floor/airless,
 /area/maintenance/second_deck/afp)
+"MB" = (
+/obj/structure/hygiene/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/security/prison)
 "MD" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -15307,6 +15326,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
+"NN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/synthesized_instrument/synthesizer/piano,
+/turf/simulated/floor/plating,
+/area/civilian/lounge)
 "NO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Second Deck Substation";
@@ -15428,6 +15454,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
+"Of" = (
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/plating,
+/area/civilian/lounge)
 "Ok" = (
 /obj/random/junk,
 /obj/structure/disposalpipe/segment,
@@ -15491,16 +15521,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"OB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/prison)
 "OC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -15515,11 +15535,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/security/prison)
-"OL" = (
-/obj/machinery/seed_extractor,
-/obj/effect/floor_decal/corner/red/full,
-/turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "Pe" = (
 /obj/machinery/washing_machine,
@@ -15737,13 +15752,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
-"Qm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "Qo" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Second Deck"
@@ -15821,6 +15829,20 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark,
+/area/security/prison)
+"QK" = (
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/turf/simulated/floor/reinforced,
 /area/security/prison)
 "QM" = (
 /obj/structure/ladder,
@@ -15915,24 +15937,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
-"Rl" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/prison)
 "RB" = (
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -16061,21 +16065,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"St" = (
-/obj/effect/floor_decal/corner/red/three_quarters,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/prison)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -16162,13 +16151,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"TH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/synthesized_instrument/synthesizer/piano,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "TM" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -16216,23 +16198,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
-"TV" = (
-/obj/item/stack/material/wood/ten,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"TW" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/item/seeds/potatoseed,
-/obj/item/seeds/wheatseed,
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 8
-	},
-/obj/machinery/camera/network/prison{
-	c_tag = "Prison Hydroponics";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/prison)
 "Ub" = (
 /obj/machinery/vending/tool,
 /turf/simulated/floor/tiled,
@@ -16285,6 +16250,21 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
+/area/security/prison)
+"Uy" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/item/seeds/cornseed,
+/obj/item/seeds/cornseed,
+/obj/item/seeds/tobaccoseed,
+/obj/effect/floor_decal/corner/red{
+	dir = 5;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (NORTHEAST)"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
 /area/security/prison)
 "UA" = (
 /obj/structure/disposalpipe/segment{
@@ -16537,11 +16517,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
-"Ww" = (
-/obj/machinery/biogenerator,
-/obj/effect/floor_decal/corner/red/full,
-/turf/simulated/floor/tiled/dark,
-/area/security/prison)
 "Wz" = (
 /obj/structure/closet/firecloset,
 /obj/structure/catwalk,
@@ -16599,15 +16574,6 @@
 /obj/item/stack/tile/floor,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
-"WX" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/pen,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "WY" = (
 /obj/machinery/power/sensor{
 	name_tag = "Atmospherics Power"
@@ -16629,6 +16595,10 @@
 /area/engineering/substation/atmos)
 "Xd" = (
 /obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"Xe" = (
+/obj/item/stack/material/wood/ten,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "Xg" = (
@@ -16710,6 +16680,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"Xy" = (
+/obj/machinery/biogenerator,
+/obj/effect/floor_decal/corner/red/full,
+/turf/simulated/floor/reinforced,
+/area/security/prison)
 "XF" = (
 /obj/machinery/light,
 /obj/item/weapon/caution/cone,
@@ -16804,6 +16779,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"Yf" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/reinforced,
+/area/security/prison)
 "Yj" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -16856,13 +16849,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
-"YB" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark,
-/area/security/prison)
 "YF" = (
 /obj/random/toolbox,
 /turf/simulated/floor/airless,
@@ -16921,6 +16907,25 @@
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
+"Zi" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/reinforced,
+/area/security/prison)
 "Zm" = (
 /obj/structure/bed/nice,
 /obj/item/weapon/bedsheet/white,
@@ -16966,12 +16971,18 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/security/prison)
-"ZM" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
+"ZP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/reinforced,
+/area/security/prison)
+"ZQ" = (
+/turf/simulated/floor/reinforced,
 /area/security/prison)
 "ZW" = (
 /obj/random/tool,
@@ -40919,9 +40930,9 @@ iw
 jp
 ke
 lj
-Ca
-Qm
-he
+ha
+BT
+Gx
 hJ
 iK
 iK
@@ -41324,7 +41335,7 @@ kg
 iz
 iz
 iz
-TV
+Xe
 iz
 hK
 iK
@@ -41527,7 +41538,7 @@ iz
 lk
 RU
 Zh
-Cc
+JB
 hK
 pI
 qK
@@ -41925,7 +41936,7 @@ fj
 ge
 gX
 hK
-TH
+NN
 iz
 iz
 jq
@@ -42127,7 +42138,7 @@ fk
 ge
 gZ
 hK
-eI
+ki
 iz
 iy
 mg
@@ -42329,8 +42340,8 @@ fj
 ge
 gX
 hK
-He
-iz
+iA
+ix
 iy
 Xd
 kg
@@ -42531,9 +42542,9 @@ fi
 ge
 gW
 hM
-iz
-iz
-iy
+ix
+ix
+Of
 ln
 SS
 UW
@@ -42733,9 +42744,9 @@ fi
 gf
 gY
 hK
-GJ
-iz
-iz
+iB
+ix
+ix
 LC
 iz
 ng
@@ -42935,10 +42946,10 @@ Ov
 gj
 gZ
 hK
-WX
-iz
-iz
-TV
+iC
+ix
+ix
+lo
 iz
 JE
 Sh
@@ -43139,8 +43150,8 @@ hb
 hK
 MI
 iz
-eI
-eI
+ki
+ki
 iz
 ni
 od
@@ -43340,9 +43351,9 @@ ge
 gZ
 hJ
 iE
-AL
-El
-AF
+jt
+kj
+lp
 mi
 nj
 oe
@@ -44536,9 +44547,9 @@ ah
 ah
 ah
 AE
-TW
-YB
-St
+GS
+EJ
+Al
 EQ
 Pe
 XL
@@ -44738,9 +44749,9 @@ ah
 ah
 ah
 AE
-AM
-Cm
-HK
+Uy
+ZQ
+Zi
 HJ
 ZK
 Kz
@@ -44941,8 +44952,8 @@ ah
 ah
 KL
 CO
-OB
-Rl
+ZP
+Yf
 EQ
 EQ
 Up
@@ -45142,9 +45153,9 @@ ah
 ah
 ah
 AE
-CC
-ZM
-CW
+MB
+Fg
+QK
 Eg
 PC
 Hh
@@ -45345,8 +45356,8 @@ ah
 ah
 AE
 AE
-OL
-Ww
+LB
+Xy
 AE
 Zm
 KV

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -607,6 +607,27 @@
 	},
 /turf/simulated/floor/wood,
 /area/civilian/counselor)
+"bA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "bB" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -657,6 +678,40 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/stech)
+"bK" = (
+/obj/machinery/newscaster{
+	pixel_y = -28
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
+"bM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "bN" = (
 /obj/random/tool,
 /turf/simulated/floor/reinforced/airless,
@@ -853,27 +908,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/cryo2)
-"cj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+"ch" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "cl" = (
 /obj/item/stack/rods/ten,
 /turf/simulated/floor/reinforced/airless,
@@ -1158,6 +1197,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
+"cJ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "cK" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable{
@@ -1740,31 +1783,6 @@
 /obj/item/taperoll/engineering/applied,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"ee" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/broken{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "eh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/machinery/meter,
@@ -1926,32 +1944,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"eu" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "ev" = (
 /obj/structure/closet/walllocker/emerglocker/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2052,6 +2044,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"eM" = (
+/obj/item/stack/material/steel/ten,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -2083,6 +2079,25 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"eT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/aft/second_deck)
 "eU" = (
 /obj/structure/lattice,
 /turf/space,
@@ -2194,11 +2209,42 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"fo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "fp" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"fq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "fr" = (
 /turf/simulated/wall/r_wall,
 /area/command/captain)
@@ -2389,42 +2435,67 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
-"fF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
+"fN" = (
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Library";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
+"fO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"fX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0;
-	tag = ""
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
-"gd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/fore/second_deck)
+"ga" = (
+/obj/structure/firedoor_assembly,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"gf" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"gg" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"go" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/carpet/orange,
 /area/logistics/auxtool)
 "gq" = (
 /obj/item/weapon/soap/deluxe,
@@ -2668,43 +2739,33 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"gP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"gQ" = (
+"ha" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
-"he" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/structure/bed/chair/comfy,
-/turf/simulated/floor/carpet/orange,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Starboard Observatory Hallway";
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	icon_state = "intercom";
+	pixel_x = 28;
+	tag = "icon-intercom (WEST)"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/hallway/aft/second_deck)
+"hc" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
 /area/logistics/auxtool)
 "hk" = (
 /obj/item/weapon/storage/mirror{
@@ -2896,6 +2957,17 @@
 "hH" = (
 /turf/simulated/wall,
 /area/civilian/dorms)
+"hI" = (
+/obj/item/stack/tile/floor,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Entertainer's Room";
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
 "hJ" = (
 /turf/simulated/wall,
 /area/civilian/lounge)
@@ -2938,29 +3010,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/command/headquarters)
-"hR" = (
-/obj/machinery/door/airlock/glass{
-	name = "Auxiliary Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/auxtool)
 "hS" = (
 /turf/simulated/wall/r_wall,
 /area/command/teleporter)
@@ -3197,22 +3246,6 @@
 	icon_state = "camera"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
-"iv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "iw" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -3556,30 +3589,6 @@
 /obj/item/weapon/bedsheet/green,
 /turf/simulated/floor/wood,
 /area/civilian/dorms)
-"jn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/broken{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "jo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8;
@@ -4566,20 +4575,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/civilian/dorms)
-"lh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "li" = (
 /obj/machinery/atm{
 	pixel_x = 30
@@ -4610,6 +4605,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
+"lm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "ln" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/board,
@@ -4619,6 +4624,31 @@
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
+"lo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "lq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -4672,10 +4702,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"lu" = (
-/obj/item/stack/cable_coil,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "lv" = (
 /obj/machinery/teleport/station{
 	dir = 1
@@ -5487,20 +5513,19 @@
 /obj/item/weapon/scissors,
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
+"nc" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/pen,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "ne" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
-"nf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
 "ng" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5681,23 +5706,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/command/captain)
-"nx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "ny" = (
 /turf/simulated/wall/r_wall,
 /area/command/fobedroom)
@@ -5884,14 +5892,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
-"nU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "nV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -6015,6 +6015,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
+"on" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/landmark/costume,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "oo" = (
 /obj/machinery/alarm{
 	frequency = 1439;
@@ -6371,11 +6382,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/central)
-"oN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "oO" = (
 /obj/machinery/light{
 	dir = 4
@@ -6436,15 +6442,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"oU" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/computer/arcade/orion_trail,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "oV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -6855,11 +6852,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"pS" = (
-/obj/machinery/light_construct,
-/obj/machinery/light,
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
 "pT" = (
 /obj/machinery/light{
 	dir = 1
@@ -6872,6 +6864,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
+"pX" = (
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "pZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8116,43 +8111,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"sk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
-"sl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
 "sm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -8698,6 +8656,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
+"ta" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/structure/bed/chair/couch/right/brown,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "tb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
@@ -8756,25 +8728,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
 	pixel_y = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
-"tk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -9242,10 +9195,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
-"tS" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/tiled/dark,
-/area/civilian/personal)
 "tT" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -9619,6 +9568,23 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
+"uG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/aft/second_deck)
 "uH" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -12222,6 +12188,12 @@
 /obj/effect/shuttle_landmark/ninja/deck2,
 /turf/space,
 /area/space)
+"zX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Ac" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -12231,6 +12203,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
+"Ad" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Ah" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 9;
@@ -12239,13 +12222,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"Ai" = (
-/obj/machinery/papershredder,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "Al" = (
 /obj/effect/floor_decal/corner/red/three_quarters,
 /obj/structure/cable{
@@ -12306,14 +12282,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"Az" = (
-/obj/structure/table/woodentable,
-/obj/item/device/camera,
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
 "AB" = (
 /obj/machinery/door/airlock/glass{
 	name = "Prison Observatory"
@@ -12333,23 +12301,26 @@
 "AE" = (
 /turf/simulated/wall/r_wall,
 /area/security/prison)
-"AG" = (
+"AM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
-"AM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "AP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12372,84 +12343,129 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"AY" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
+"AW" = (
 /obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Fore";
-	dir = 1;
-	icon_state = "camera"
+	c_tag = "Auxiliary Storage";
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "Bb" = (
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Cryo";
-	dir = 1;
-	icon_state = "camera"
+/obj/structure/table/woodentable,
+/obj/item/device/camera_film,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "Bc" = (
 /obj/effect/floor_decal/chapel,
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"Bj" = (
+"Bk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
+"Bm" = (
+/obj/item/weapon/material/shard,
+/turf/simulated/floor/plating,
+/area/civilian/observatory)
+"Bn" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 22
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"Br" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/item/device/taperecorder,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
+"Bs" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Bv" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"Bm" = (
-/obj/item/weapon/material/shard,
-/turf/simulated/floor/plating,
-/area/civilian/observatory)
-"Bt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Fore Hallway - Central";
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 28
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
-"BE" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/storage/pill_bottle/dice,
+"Bw" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "BJ" = (
@@ -12464,68 +12480,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "BK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"BL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (NORTHWEST)"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"BM" = (
-/obj/effect/floor_decal/chapel{
-	dir = 4;
-	icon_state = "chapel";
-	tag = "icon-chapel (EAST)"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel)
-"BP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"BQ" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = 22
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
-"BT" = (
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12539,8 +12494,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
+/area/hallway/fore/second_deck)
+"BM" = (
+/obj/effect/floor_decal/chapel{
+	dir = 4;
+	icon_state = "chapel";
+	tag = "icon-chapel (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel)
 "BU" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -12555,15 +12521,26 @@
 /turf/simulated/floor/plating,
 /area/chapel)
 "BV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm8";
+	name = "Entertainer's Room";
+	req_access = list(46)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/entertainer)
 "BW" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/yellow{
@@ -12582,19 +12559,26 @@
 /turf/simulated/wall,
 /area/civilian/counselor)
 "Cd" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/landmark/costume,
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/hallway/aft/second_deck)
 "Cg" = (
-/obj/effect/wallframe_spawn/reinforced/hull,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "Ch" = (
@@ -12603,21 +12587,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/civilian/exercise)
 "Cj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -12630,26 +12603,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"Ct" = (
-/obj/machinery/door/firedoor,
+"Cr" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Cu" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -12675,17 +12646,27 @@
 	},
 /turf/simulated/floor/wood,
 /area/civilian/counselor)
-"CD" = (
-/obj/item/stack/tile/floor,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Entertainer's Room";
+"Cw" = (
+/obj/structure/foamedmetal,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"CC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "CG" = (
 /turf/simulated/floor/reinforced/airless,
 /area/security/prison)
@@ -12711,14 +12692,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"CU" = (
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Library";
-	dir = 1;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "Da" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12731,6 +12704,30 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Db" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Df" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12743,55 +12740,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"Dl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"Dt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+"Dk" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
+"Dr" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "Dw" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/machinery/alarm{
+	pixel_y = 25
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/obj/structure/bed/chair/couch/right/brown,
+/obj/structure/bed/chair/couch/middle/brown,
 /turf/simulated/floor/wood,
 /area/logistics/auxtool)
 "Dx" = (
@@ -12807,50 +12768,26 @@
 /obj/random/toolbox,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"DB" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "DF" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"DG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
-"DN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin,
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 5
-	},
-/obj/item/device/taperecorder,
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+/area/hallway/fore/second_deck)
 "DP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -12909,26 +12846,22 @@
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
 "DS" = (
-/obj/machinery/vending/games,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"DV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
+/obj/structure/bed/nice,
+/obj/structure/curtain/open/bed,
+/obj/item/weapon/bedsheet/clown,
+/obj/item/weapon/storage/backpack/duffel/duffel_clown,
+/obj/machinery/light/small/red,
+/obj/effect/landmark/start{
+	name = "Clown"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/floor_decal/spline/fancy/wood/corner,
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
+"DX" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/logistics/auxtool)
@@ -12979,6 +12912,28 @@
 	},
 /turf/simulated/floor/lino,
 /area/civilian/counselor)
+"Ee" = (
+/obj/item/device/flashlight/lamp/lava/pink{
+	on = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"Ef" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/structure/bookcase,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Eg" = (
 /obj/machinery/door/airlock/glass{
 	name = "Prison Dorms"
@@ -13040,6 +12995,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/civilian/counselor)
+"Es" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Eu" = (
 /obj/machinery/door/airlock{
 	name = "Prison Bathroom"
@@ -13054,29 +13024,31 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
-"Ev" = (
+"Ex" = (
+/obj/structure/ladder/updown,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/fp)
+"EA" = (
+/obj/machinery/light_construct,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
+"EI" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
-"Ex" = (
-/obj/structure/ladder/updown,
-/turf/simulated/floor/plating,
-/area/maintenance/second_deck/fp)
-"EG" = (
-/obj/machinery/newscaster{
-	pixel_y = -28
-	},
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
 "EJ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -13095,19 +13067,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"EO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
 "EP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -13188,6 +13147,14 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"Fk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (NORTHWEST)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Fl" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -13202,6 +13169,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Ft" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Fu" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/flame/candle,
@@ -13256,16 +13234,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Aft-Centre"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -13300,6 +13272,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"FS" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/fp)
+"FV" = (
+/obj/structure/bookcase/manuals/xenoarchaeology,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Gj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -13313,30 +13303,32 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
-"Gm" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+"Gq" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"Gs" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"Gr" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atm{
+	pixel_x = 30
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Gv" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1;
@@ -13348,6 +13340,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"Gx" = (
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Gy" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -13391,6 +13387,13 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"GM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "GO" = (
 /obj/effect/shuttle_landmark/nerva/deck2/hadrian,
 /turf/space,
@@ -13416,33 +13419,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"GW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "GX" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4;
@@ -13452,6 +13428,19 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"Hd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/stack/tile/floor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13474,10 +13463,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "Hk" = (
-/obj/structure/foamedmetal,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"Hn" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -13513,10 +13498,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"Hv" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
 "Hy" = (
 /obj/structure/bed/chair/urist/bench/bench1/right,
 /obj/effect/floor_decal/chapel{
@@ -13556,19 +13537,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"HH" = (
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
-"HI" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
 "HJ" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -13580,6 +13548,21 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"HR" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/fs)
 "HS" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13603,6 +13586,41 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/security/boardarmoury)
+"HX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Aft-Centre"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"HZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/newscaster{
+	hitstaken = 1;
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/fore/second_deck)
 "Id" = (
 /obj/item/stack/rods/ten,
 /turf/simulated/floor/tiled/dark,
@@ -13631,16 +13649,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/command/captain)
-"In" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
+"Ii" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/turf/simulated/floor/tiled/dark,
+/area/hallway/aft/second_deck)
 "Io" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -13650,59 +13664,48 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"Iq" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
+"Ir" = (
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"Iu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"IC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
-"Iw" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/pen,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"Iz" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
-"ID" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "IE" = (
 /turf/simulated/wall/r_wall,
 /area/civilian/entertainer)
@@ -13722,9 +13725,36 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/command/captain)
+"II" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "IJ" = (
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/second_deck/fs)
+"IL" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "IM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -13735,6 +13765,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"IO" = (
+/obj/structure/bed/nice,
+/obj/structure/curtain/open/bed,
+/obj/item/weapon/bedsheet/mime,
+/obj/effect/landmark/start{
+	name = "Mime"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
 "IP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -13751,23 +13790,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"IQ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "IT" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 1;
@@ -13775,28 +13797,6 @@
 	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
-"IV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Starboard Observatory Hallway";
-	dir = 8;
-	icon_state = "camera"
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	icon_state = "intercom";
-	pixel_x = 28;
-	tag = "icon-intercom (WEST)"
-	},
-/turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "IW" = (
 /obj/structure/bed/chair/urist/bench/bench1/left,
@@ -13806,20 +13806,45 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"IZ" = (
+"IX" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
-"Ja" = (
-/obj/machinery/vending/urist/autodrobe,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"Je" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/wood,
+/area/civilian/entertainer)
+"Jf" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
 /area/civilian/entertainer)
 "Jg" = (
 /obj/structure/cable{
@@ -13864,29 +13889,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Jo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Port Hallway - Fore-Centre"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "Jv" = (
 /obj/structure/fitness/weightlifter,
 /obj/effect/floor_decal/corner/black/border{
@@ -13899,20 +13901,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"Jw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "Jy" = (
 /obj/effect/floor_decal/chapel{
 	dir = 8;
@@ -13922,10 +13910,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"JD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
 "JE" = (
 /obj/item/weapon/table_parts/wood,
 /obj/structure/cable{
@@ -13960,6 +13944,10 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"JJ" = (
+/obj/machinery/light/broken,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "JL" = (
 /obj/effect/floor_decal/chapel{
 	dir = 8;
@@ -13967,14 +13955,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"JN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+"JP" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "JQ" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -14018,13 +14006,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
-"Kb" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/synthesized_instrument/synthesizer/piano,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "Kd" = (
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
@@ -14035,6 +14016,20 @@
 /obj/item/weapon/cell/super,
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
+"Kn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/fore/second_deck)
+"Ku" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Kw" = (
 /obj/machinery/door/blast/regular{
 	dir = 2;
@@ -14061,19 +14056,35 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"KC" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/item/device/camera/tvcamera,
+/obj/structure/closet/cabinet,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/obj/item/clothing/accessory/badge/press,
+/obj/item/clothing/suit/armor/vest/press,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "KG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"KH" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "KJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14129,10 +14140,16 @@
 "KN" = (
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"KP" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
+"KR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "KV" = (
 /obj/structure/bed/nice,
 /obj/item/weapon/bedsheet/white,
@@ -14176,24 +14193,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
-"Lh" = (
+"Li" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/structure/table/woodentable,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Lj" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck Fore Port Maintenance APC";
@@ -14219,6 +14235,30 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
+"Lm" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/fore/second_deck)
 "Lt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14279,6 +14319,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
+"LG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "LI" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
@@ -14286,16 +14338,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"LK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10;
-	icon_state = "intact-supply"
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
 "LO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -14333,36 +14375,54 @@
 	},
 /turf/simulated/floor/wood,
 /area/command/captain)
+"LS" = (
+/obj/machinery/door/airlock/glass{
+	name = "Auxiliary Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/auxtool)
+"LT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "LV" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/wall/r_wall,
 /area/chapel)
-"LX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Fore Hallway - Central";
-	dir = 8;
-	icon_state = "camera"
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "LY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -14370,21 +14430,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"Mb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"Md" = (
-/obj/item/stack/tile/floor,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
 "Mg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14425,31 +14470,10 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"Mk" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
-/obj/item/device/camera/tvcamera,
-/obj/structure/closet/cabinet,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	dir = 1
-	},
-/obj/item/clothing/accessory/badge/press,
-/obj/item/clothing/suit/armor/vest/press,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+"Ml" = (
+/obj/item/weapon/crowbar,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Mn" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/breakerbox/activated{
@@ -14472,28 +14496,11 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"Mv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
+"Mt" = (
+/obj/effect/wallframe_spawn/reinforced/hull,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/area/hallway/aft/second_deck)
 "Mx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14509,6 +14516,10 @@
 /obj/structure/girder,
 /turf/simulated/floor/airless,
 /area/maintenance/second_deck/afp)
+"MA" = (
+/obj/item/stack/rods/ten,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "MB" = (
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -14535,27 +14546,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
-"MF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm8";
-	name = "Entertainer's Room";
-	req_access = list(46)
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/civilian/entertainer)
 "MG" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8;
@@ -14582,16 +14572,29 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
+"MJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "MK" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"MO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+"MM" = (
+/obj/machinery/vending/games,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"MR" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "MV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -14606,24 +14609,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"MW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Port Observatory Hallway";
-	dir = 8;
-	icon_state = "camera"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
 "MZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14633,25 +14618,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"Nd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "Ne" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Second Deck Bypass"
@@ -14668,32 +14634,37 @@
 /turf/simulated/floor/carpet,
 /area/chapel)
 "Nj" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/fore/second_deck)
 "Nk" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/standard,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
-"Np" = (
-/obj/structure/bed/nice,
-/obj/structure/curtain/open/bed,
-/obj/item/weapon/bedsheet/mime,
-/obj/effect/landmark/start{
-	name = "Mime"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
-"Nq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	icon_state = "map-supply"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "Nr" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -14715,30 +14686,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
-"Ns" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+"Nt" = (
+/obj/machinery/papershredder,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Fore Hallway - Port"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Nu" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -14779,69 +14733,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "NG" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/item/weapon/material/shard,
 /turf/simulated/floor/plating,
-/area/maintenance/second_deck/fs)
+/area/hallway/aft/second_deck)
 "NI" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"NJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"NL" = (
-/obj/item/weapon/bikehorn,
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/lipstick/black{
-	pixel_y = 5
-	},
-/obj/item/weapon/lipstick/random,
-/obj/item/weapon/lipstick/purple{
-	pixel_y = -5
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
 "NO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Second Deck Substation";
@@ -14863,6 +14761,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
+"NS" = (
+/obj/machinery/light_construct{
+	dir = 4;
+	icon_state = "tube-construct-stage1";
+	tag = "icon-tube-construct-stage1 (EAST)"
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "NT" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/red{
@@ -14872,6 +14778,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"NU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "NV" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -14901,19 +14818,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"NW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
 "NY" = (
-/obj/machinery/papershredder,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/table/woodentable,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/orange,
 /area/logistics/auxtool)
 "Ob" = (
@@ -14946,17 +14866,39 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"Oh" = (
+"Od" = (
+/obj/structure/table/woodentable,
+/obj/item/device/camera,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
+"Of" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Ok" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15023,20 +14965,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
 "OB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/obj/item/stack/tile/floor,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/aft/second_deck)
 "OC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -15052,7 +14983,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"OQ" = (
+"OM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/fore/second_deck)
+"ON" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -15063,23 +15009,42 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	icon_state = "intact-supply"
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"OP" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"OT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/area/hallway/aft/second_deck)
 "Pe" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -15092,35 +15057,6 @@
 "Ph" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/substation/atmos)
-"Pm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"Pn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/aft/second_deck)
 "Ps" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 8;
@@ -15128,6 +15064,24 @@
 	tag = "icon-corner_white (WEST)"
 	},
 /turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"Pw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Aft Hallway - Tech Storage"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "PC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15137,23 +15091,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"PG" = (
-/obj/random/toolbox,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"PJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/stack/tile/floor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "PN" = (
 /obj/random/maintenance,
 /turf/simulated/floor/reinforced,
@@ -15221,44 +15158,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"PZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "Qd" = (
 /turf/simulated/wall/r_wall,
 /area/civilian/exercise)
-"Qe" = (
-/obj/item/weapon/material/shard{
-	icon_state = "small"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"Qf" = (
-/obj/item/stack/material/steel/ten,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "Qg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -15280,6 +15182,39 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
+"Qj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Qk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Qo" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Second Deck"
@@ -15294,33 +15229,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
-"Qp" = (
+"Qt" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"Qr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15355,9 +15280,32 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"Qx" = (
-/turf/simulated/wall/r_wall,
-/area/hallway/aft/second_deck)
+"QD" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "QF" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -15413,6 +15361,16 @@
 /obj/structure/ladder,
 /turf/simulated/floor/plating,
 /area/security/boardarmoury)
+"QT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/civilian/entertainer)
 "QV" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8;
@@ -15421,68 +15379,10 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"QW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
-"QX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "QY" = (
 /obj/machinery/vending/urist/sustenance,
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Ra" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
-	},
-/obj/structure/bed/chair/couch/left/brown,
-/obj/machinery/atm{
-	pixel_x = -28
-	},
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
-"Rh" = (
-/obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "Ri" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "stickyweb2";
@@ -15525,14 +15425,36 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
-"Rx" = (
-/obj/structure/table/woodentable,
-/obj/item/device/camera_film,
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
+"Rq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
+"Ry" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/civilian/personal)
 "RC" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -15550,12 +15472,43 @@
 /turf/simulated/floor/reinforced,
 /area/security/boardarmoury)
 "RD" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 8;
-	icon_state = "map_vclamp0";
-	tag = "icon-map_vclamp0 (WEST)"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/aft/second_deck)
+"RE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Fore-Centre"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/hallway/fore/second_deck)
 "RF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -15565,23 +15518,6 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"RI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atm{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "RK" = (
 /obj/machinery/door/airlock/glass{
 	name = "Prison Hydroponics"
@@ -15622,10 +15558,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"RP" = (
-/obj/random/maintenance,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "RR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15652,33 +15584,27 @@
 /obj/structure/bookcase,
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
-"RV" = (
-/obj/item/modular_computer/console/preset/civilian{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Rec Room - Fore";
+"Sd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
-	icon_state = "camera"
+	icon_state = "map-supply"
 	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"RX" = (
-/obj/structure/bed/nice,
-/obj/structure/curtain/open/bed,
-/obj/item/weapon/bedsheet/clown,
-/obj/item/weapon/storage/backpack/duffel/duffel_clown,
-/obj/machinery/light/small/red,
-/obj/effect/landmark/start{
-	name = "Clown"
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Se" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/spline/fancy/wood/corner,
-/turf/simulated/floor/carpet/blue,
-/area/civilian/entertainer)
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -15722,18 +15648,38 @@
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
 "SG" = (
-/obj/item/device/flashlight/lamp/lava/pink{
-	on = 1
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
+/obj/structure/synthesized_instrument/synthesizer/piano,
 /turf/simulated/floor/wood,
-/area/civilian/entertainer)
+/area/civilian/lounge)
+"SP" = (
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Cryo";
+	dir = 1;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
+"SQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (EAST)"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/fore/second_deck)
 "SS" = (
 /obj/structure/bed/chair/wood{
 	dir = 1;
@@ -15770,18 +15716,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"Tb" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
 "Tc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15800,34 +15734,60 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"Tg" = (
+"Th" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
-"Tu" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	listening = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 28
+"Tl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Tn" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/aft/second_deck)
+"Tq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
@@ -15839,16 +15799,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "Tz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -28
+/obj/item/weapon/bikehorn,
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/obj/item/weapon/lipstick/black{
+	pixel_y = 5
+	},
+/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/purple{
+	pixel_y = -5
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "TA" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1;
@@ -15856,6 +15830,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"TD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Fore Hallway - Port"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "TE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15868,21 +15866,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"TJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/newscaster{
-	hitstaken = 1;
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"TF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/aft/second_deck)
 "TM" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -15910,27 +15899,14 @@
 	opacity = 1
 	},
 /area/maintenance/second_deck/afs)
-"TR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+"TT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
+/obj/structure/bed/chair/comfy,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "Ub" = (
 /obj/machinery/vending/tool,
 /turf/simulated/floor/tiled,
@@ -15938,20 +15914,6 @@
 "Uc" = (
 /turf/simulated/wall/r_wall,
 /area/chapel)
-"Uh" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
-"Uj" = (
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Auxiliary Storage";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
 "Ul" = (
 /obj/item/ammo_magazine/c44,
 /obj/structure/closet/secure_closet/nervacap,
@@ -15998,19 +15960,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Uw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "Uy" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/cornseed,
@@ -16026,6 +15975,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"Uz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "UA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -16046,37 +16003,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"UC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"UH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "UI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16103,10 +16029,10 @@
 	icon_state = "rfalse"
 	},
 /area/maintenance/second_deck/fp)
-"UQ" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
+"UL" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "UR" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/machinery/requests_console{
@@ -16123,7 +16049,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
-"UT" = (
+"UV" = (
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16135,22 +16064,14 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
+	dir = 4
 	},
-/obj/machinery/light/broken{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
-"UV" = (
-/obj/item/weapon/stool,
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "UW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -16184,12 +16105,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
 "Vi" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/area/hallway/aft/second_deck)
 "Vl" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/polarized/full{
@@ -16197,6 +16115,38 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/counselor)
+"Vn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/fore/second_deck)
+"Vp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/aft/second_deck)
 "Vq" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -16215,21 +16165,75 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
-"Vz" = (
-/obj/item/stack/rods/ten,
+"VF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
-"VJ" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/machinery/door/window/northleft,
-/turf/simulated/floor/carpet/orange,
-/area/logistics/auxtool)
+"VH" = (
+/obj/machinery/vending/urist/autodrobe,
+/turf/simulated/floor/wood,
+/area/civilian/entertainer)
 "VN" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
+"VS" = (
+/obj/item/modular_computer/console/preset/civilian{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Rec Room - Fore";
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"VY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Wc" = (
 /obj/machinery/door/morgue{
 	name = "Confessional Booth"
@@ -16257,22 +16261,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
-"We" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "Wh" = (
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -16299,25 +16287,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Wq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"Wp" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Port Hallway - Fore";
 	dir = 1;
-	icon_state = "map-scrubbers"
+	icon_state = "camera"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Wu" = (
 /obj/effect/floor_decal/corner/red/three_quarters{
 	dir = 1
@@ -16334,17 +16315,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
-"Wy" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/civilian/lounge)
 "Wz" = (
 /obj/structure/closet/firecloset,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
+"WA" = (
+/turf/simulated/wall/r_wall,
+/area/hallway/aft/second_deck)
 "WC" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
@@ -16353,38 +16331,6 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
-"WE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"WG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "WH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
@@ -16392,6 +16338,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"WI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "WK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16423,18 +16396,22 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Aft Hallway - Tech Storage"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/area/hallway/fore/second_deck)
 "WW" = (
 /obj/item/stack/tile/floor,
 /turf/simulated/floor/plating,
@@ -16462,6 +16439,24 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
+"Xf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Port Observatory Hallway";
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/hallway/aft/second_deck)
 "Xg" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -16520,26 +16515,22 @@
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
-"Xp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
+"Xr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/dark,
+/obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+/area/hallway/fore/second_deck)
 "Xt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/cobweb{
@@ -16554,20 +16545,40 @@
 /obj/effect/floor_decal/corner/red/full,
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"XH" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"Xz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
-	tag = ""
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"XD" = (
+/obj/item/weapon/material/shard{
+	icon_state = "small"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/second_deck/fp)
+/area/hallway/aft/second_deck)
+"XH" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
+/obj/structure/bed/chair/couch/left/brown,
+/obj/machinery/atm{
+	pixel_x = -28
+	},
+/turf/simulated/floor/wood,
+/area/logistics/auxtool)
 "XJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -16615,10 +16626,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
-"XO" = (
-/obj/structure/firedoor_assembly,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
+"XS" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/pill_bottle/dice,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "XT" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -16631,13 +16643,11 @@
 /turf/simulated/floor/plating,
 /area/civilian/counselor)
 "XY" = (
-/obj/machinery/light_construct{
-	dir = 4;
-	icon_state = "tube-construct-stage1";
-	tag = "icon-tube-construct-stage1 (EAST)"
-	},
-/turf/simulated/floor/wood,
-/area/civilian/entertainer)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Ya" = (
 /obj/machinery/power/sensor{
 	name_tag = "Second Deck Power"
@@ -16709,19 +16719,7 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"Yv" = (
-/obj/item/weapon/material/shard,
-/turf/simulated/floor/plating,
-/area/hallway/aft/second_deck)
-"Yw" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
-"YD" = (
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
+"Yq" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16733,21 +16731,68 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (EAST)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/broken{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
-"YE" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/light{
-	dir = 4
-	},
+"Ys" = (
+/obj/random/maintenance,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
+"Yu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"Yv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/aft/second_deck)
+"Yx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"YB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "YO" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16757,13 +16802,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"YQ" = (
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/obj/structure/bed/chair/couch/middle/brown,
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
+"YT" = (
+/obj/item/stack/cable_coil,
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "YY" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -16784,10 +16826,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"Zf" = (
-/obj/machinery/light/broken,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
 "Zh" = (
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor/plating,
@@ -16811,6 +16849,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"Zl" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/door/window/northleft,
+/turf/simulated/floor/carpet/orange,
+/area/logistics/auxtool)
 "Zm" = (
 /obj/structure/bed/nice,
 /obj/item/weapon/bedsheet/white,
@@ -16824,23 +16869,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"Zr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
 "Zu" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 2;
@@ -16848,24 +16876,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"Zy" = (
+"Zx" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/second_deck)
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/aft/second_deck)
 "ZA" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-21";
@@ -16877,9 +16905,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"ZI" = (
-/obj/item/weapon/crowbar,
-/turf/simulated/floor/plating,
+"ZJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/aft/second_deck)
 "ZK" = (
 /obj/structure/table/standard,
@@ -16887,7 +16922,7 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/security/prison)
-"ZN" = (
+"ZM" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16898,20 +16933,15 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/fore/second_deck)
-"ZO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/logistics/auxtool)
+/area/hallway/aft/second_deck)
 "ZP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16925,27 +16955,18 @@
 "ZQ" = (
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"ZT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/aft/second_deck)
 "ZW" = (
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"ZY" = (
+/obj/machinery/atmospherics/valve/shutoff{
+	dir = 8;
+	icon_state = "map_vclamp0";
+	tag = "icon-map_vclamp0 (WEST)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 
 (1,1,1) = {"
 aa
@@ -34821,7 +34842,7 @@ de
 de
 ep
 fa
-Oh
+Cr
 gG
 jY
 ih
@@ -35023,7 +35044,7 @@ df
 dG
 eq
 bI
-Qp
+OT
 gG
 hD
 Dh
@@ -35225,7 +35246,7 @@ dg
 dH
 er
 bI
-Gs
+Zx
 gG
 ii
 ij
@@ -35427,7 +35448,7 @@ bI
 bI
 bI
 bI
-WS
+Pw
 gH
 hC
 hE
@@ -35629,7 +35650,7 @@ aQ
 aQ
 aQ
 fb
-BP
+Tq
 gG
 hE
 eC
@@ -35831,7 +35852,7 @@ hC
 hC
 hC
 hC
-Wq
+Ok
 gI
 hC
 eC
@@ -36033,7 +36054,7 @@ Ay
 dI
 es
 RO
-QW
+eT
 gG
 hC
 eC
@@ -36235,7 +36256,7 @@ YY
 dJ
 et
 fc
-WE
+Li
 gG
 hC
 hE
@@ -36437,7 +36458,7 @@ BZ
 hC
 hC
 hC
-WE
+Li
 Ps
 hF
 ik
@@ -36639,7 +36660,7 @@ BZ
 dL
 ev
 Uq
-iv
+EI
 gJ
 hG
 il
@@ -36841,7 +36862,7 @@ BZ
 dM
 ew
 hC
-IQ
+Ir
 gK
 hC
 im
@@ -37043,7 +37064,7 @@ BZ
 hC
 hC
 hC
-WE
+Li
 gJ
 hH
 hH
@@ -37245,7 +37266,7 @@ cA
 cA
 cc
 cc
-Cj
+II
 gJ
 hH
 in
@@ -37447,7 +37468,7 @@ dh
 dh
 ex
 cc
-WE
+Li
 gJ
 hH
 io
@@ -37463,10 +37484,10 @@ qw
 Lg
 sd
 tb
-tS
-tS
-tS
-tS
+Ry
+Ry
+Ry
+Ry
 wH
 xk
 rn
@@ -37649,7 +37670,7 @@ di
 dN
 ey
 fe
-UH
+Tn
 gJ
 hH
 io
@@ -37665,10 +37686,10 @@ qv
 uF
 sd
 sd
-tS
-tS
-tS
-tS
+Ry
+Ry
+Ry
+Ry
 wH
 xl
 rn
@@ -37851,8 +37872,8 @@ dj
 dO
 ez
 ff
-Ev
-Bb
+Of
+SP
 hH
 io
 jk
@@ -38053,7 +38074,7 @@ dk
 dk
 eA
 cc
-WE
+Li
 gJ
 hH
 in
@@ -38255,8 +38276,8 @@ cF
 cF
 cc
 cc
-Tu
-UQ
+Db
+Vi
 hH
 hH
 hH
@@ -38457,7 +38478,7 @@ cc
 cc
 cc
 cc
-ZT
+uG
 gN
 hH
 in
@@ -38659,7 +38680,7 @@ dl
 aX
 bB
 eB
-WE
+Li
 gJ
 hH
 ip
@@ -38861,7 +38882,7 @@ Um
 aX
 aX
 fg
-DF
+Qk
 gO
 hH
 iq
@@ -39056,14 +39077,14 @@ al
 Um
 Um
 Um
-Mk
-HH
-NY
+KC
+pX
+go
 Um
 dP
 aX
 fg
-NJ
+ZM
 gJ
 hH
 io
@@ -39256,16 +39277,16 @@ ah
 ah
 Um
 Um
-Ra
-Uj
-VJ
-HH
-pS
+XH
+AW
+Zl
+pX
+EA
 Um
 aG
 aX
 fg
-BT
+RD
 gJ
 hH
 in
@@ -39458,16 +39479,16 @@ ah
 ah
 Um
 Um
-YQ
-JD
-Lh
-he
-EG
+Dw
+Dr
+NY
+TT
+bK
 Um
 dQ
 Ty
 fg
-FH
+HX
 gJ
 hH
 hH
@@ -39652,24 +39673,24 @@ ah
 ah
 ah
 ah
-Cg
-Cg
-Cg
-Cg
-Qx
-Qx
-Qx
+Mt
+Mt
+Mt
+Mt
+WA
+WA
+WA
 Um
-Dw
-ZO
-DN
-Rx
-Az
+ta
+DX
+Br
+Bb
+Od
 Um
 aH
 aX
 fg
-WE
+Li
 gJ
 hH
 ir
@@ -39854,25 +39875,25 @@ ah
 ah
 ah
 ah
-Cg
+Mt
 eC
 eC
-ZI
-XO
-lu
-Hk
+Ml
+ga
+YT
+Cw
 Um
-gg
-Nj
-DV
-Iz
-Iz
+JP
+DB
+Bk
+hc
+hc
 Um
 dR
 aX
 fg
-WE
-UQ
+Li
+Vi
 hH
 is
 jk
@@ -40056,24 +40077,24 @@ ah
 ah
 ah
 ah
-Cg
+Mt
 WW
 eC
-Vz
-Yv
+MA
+NG
 RM
 eC
 Um
 fp
 fp
-hR
+LS
 fp
 fp
 Um
 al
 eB
 fg
-nx
+ON
 gK
 hH
 hH
@@ -40258,7 +40279,7 @@ ah
 ah
 ah
 ah
-Cg
+Mt
 eC
 eC
 eC
@@ -40267,29 +40288,29 @@ eC
 eC
 dm
 ii
-Md
-Xp
+OB
+LT
 ii
-MO
+Ii
 Hq
 JU
 ii
 rt
-cj
-ID
-gQ
-Mb
-Tb
-ID
-lh
-Tg
-Tz
-Nq
-oN
-AM
-AM
+Bs
+GM
+TF
+Ft
+LG
+GM
+Vp
+Cj
+Ad
+Sd
+Yv
+XY
+XY
 rs
-sk
+FH
 tj
 OC
 IM
@@ -40460,24 +40481,24 @@ ah
 ah
 ah
 ah
-Cg
+Mt
 eC
-PG
+Gx
 eC
-Qe
+XD
 eC
 eC
 dn
-ii
-YE
-GW
-PJ
-MW
-gd
-Jw
-UC
+Cd
+IL
+WI
+Hd
+Xf
+Tl
+Qj
+Se
 Yb
-BK
+Yx
 gJ
 oO
 iu
@@ -40491,14 +40512,14 @@ oO
 gJ
 gJ
 rt
-sl
-tk
-IV
-EO
-NW
-IZ
-Pn
-Pn
+VF
+Cg
+ha
+Xz
+Th
+Yu
+ZJ
+fo
 tX
 uL
 vz
@@ -40662,24 +40683,24 @@ ah
 ah
 ah
 ah
-Cg
+Mt
 WW
 eC
 WW
-RP
+Ys
 eC
 RM
 IE
 IE
 IE
-MF
+BV
 IE
 IE
 IE
 bs
 eD
 fi
-Ct
+BK
 LA
 hJ
 hJ
@@ -40864,33 +40885,33 @@ ah
 ah
 ah
 ah
-Cg
+Mt
 eC
 eC
 eC
 eC
-Qf
-Hk
+eM
+Cw
 IE
-NL
-SG
-fF
-CD
-Np
+Tz
+Ee
+Je
+hI
+IO
 IE
 dU
 cR
 fi
-gP
-nU
+Qt
+Uz
 hJ
 iw
 jp
 ke
 lj
-KH
-Uh
-Rh
+Ef
+YB
+FV
 hJ
 iK
 iK
@@ -41066,25 +41087,25 @@ ah
 ah
 ah
 ah
-Cg
-Cg
-Cg
-Cg
-Cg
-Qx
-Qx
+Mt
+Mt
+Mt
+Mt
+Mt
+WA
+WA
 IE
-Cd
-DG
-LK
-HI
-RX
+on
+cJ
+lm
+QT
+DS
 IE
 dV
 cR
 eD
-ZN
-RD
+CC
+ZY
 hK
 jq
 iz
@@ -41276,19 +41297,19 @@ ah
 aq
 IE
 IE
-Ja
-BQ
-XY
-nf
-Hv
+VH
+Bn
+NS
+Jf
+Dk
 PS
 cR
 eE
 fi
-OQ
-BL
+bM
+Fk
 hK
-BE
+XS
 kg
 iz
 iz
@@ -41487,8 +41508,8 @@ IE
 bs
 cR
 fi
-Jo
-Vi
+RE
+MR
 hK
 js
 iz
@@ -41496,7 +41517,7 @@ iz
 lk
 RU
 Zh
-KP
+Ku
 hK
 pI
 qK
@@ -41689,7 +41710,7 @@ ah
 bs
 eD
 fi
-YD
+UV
 iK
 hL
 iz
@@ -41891,10 +41912,10 @@ ah
 dW
 cR
 fj
-Hn
+Hk
 qJ
 hK
-Kb
+SG
 iz
 iz
 jq
@@ -42093,10 +42114,10 @@ ah
 dX
 cR
 fk
-Hn
+Hk
 iK
 hK
-UV
+UL
 iz
 iy
 mg
@@ -42295,10 +42316,10 @@ ah
 dW
 cR
 fj
-Nd
+fX
 qJ
 hK
-Wy
+Bw
 iz
 iy
 Xd
@@ -42497,7 +42518,7 @@ ah
 bs
 eF
 fi
-Hn
+Hk
 iK
 hL
 iz
@@ -42699,10 +42720,10 @@ AE
 AE
 cR
 fi
-Qr
-Gm
+fq
+zX
 hK
-DS
+MM
 iz
 iz
 LC
@@ -42901,10 +42922,10 @@ KK
 AE
 Os
 Ov
-Bt
+AM
 iK
 hK
-Iw
+nc
 iz
 iz
 iz
@@ -43103,13 +43124,13 @@ Nr
 LO
 UA
 fi
-jn
-CU
+Lm
+fN
 hK
 MI
 iz
-UV
-UV
+UL
+UL
 iz
 ni
 od
@@ -43305,13 +43326,13 @@ dp
 AE
 cR
 fi
-Hn
+Hk
 iK
 hJ
 iE
-Ai
-oU
-RV
+Nt
+Gq
+VS
 mi
 nj
 oe
@@ -43507,8 +43528,8 @@ dq
 AE
 cR
 fi
-QX
-Vi
+VY
+MR
 hN
 hN
 hN
@@ -43709,7 +43730,7 @@ Sn
 AE
 cR
 fi
-Hn
+Hk
 iK
 hN
 iF
@@ -43911,8 +43932,8 @@ ds
 AE
 cR
 fi
-Nd
-Zf
+fX
+JJ
 hN
 iG
 jv
@@ -44113,7 +44134,7 @@ dt
 AE
 cR
 fi
-Hn
+Hk
 iK
 hN
 hN
@@ -44315,8 +44336,8 @@ du
 AE
 cR
 fi
-PZ
-Dt
+IC
+KR
 hO
 iH
 jx
@@ -44517,7 +44538,7 @@ dv
 AE
 cR
 fi
-Hn
+Hk
 iK
 hP
 iI
@@ -44719,8 +44740,8 @@ dw
 AE
 cR
 fi
-Zy
-AY
+Vn
+Wp
 hN
 hN
 jz
@@ -44921,7 +44942,7 @@ AE
 AE
 cR
 fi
-Hn
+Hk
 iK
 hN
 iG
@@ -45123,7 +45144,7 @@ Ob
 AE
 cR
 fi
-Hn
+Hk
 iK
 hN
 iF
@@ -45325,7 +45346,7 @@ dC
 AE
 cR
 fi
-Ct
+BK
 LA
 ls
 ls
@@ -45527,7 +45548,7 @@ AE
 AE
 Yp
 fi
-ee
+lo
 iK
 oT
 iJ
@@ -45729,7 +45750,7 @@ QM
 RC
 cR
 XM
-Hn
+Hk
 iK
 oi
 iK
@@ -45931,18 +45952,18 @@ En
 HU
 cR
 XM
-eu
-BV
-Uw
-AG
-Zr
-OB
-LX
-Iq
-We
-TJ
-RI
-Iu
+QD
+Kn
+IX
+NU
+gf
+OM
+Bv
+OP
+DF
+HZ
+Gr
+Xr
 iK
 ru
 sq
@@ -46133,7 +46154,7 @@ bs
 bs
 cR
 fi
-Dl
+Nj
 qJ
 hS
 TM
@@ -46144,7 +46165,7 @@ hS
 hS
 hS
 hS
-UT
+Yq
 qQ
 ru
 sq
@@ -46335,7 +46356,7 @@ bs
 MK
 cR
 fi
-Ns
+TD
 iK
 Kw
 kr
@@ -46346,7 +46367,7 @@ jF
 ns
 ok
 hS
-Pm
+SQ
 qU
 ru
 sq
@@ -46536,9 +46557,9 @@ dy
 eh
 HP
 eQ
-XH
-TR
-In
+FS
+bA
+fO
 hT
 Qg
 Gj
@@ -46548,9 +46569,9 @@ LF
 nt
 ol
 oV
-Bj
-WG
-NG
+Rq
+Es
+HR
 sD
 ru
 tB
@@ -46739,8 +46760,8 @@ bs
 RH
 eR
 fi
-Yw
-JN
+ch
+MJ
 hS
 iO
 jH
@@ -46750,7 +46771,7 @@ mq
 nu
 om
 hS
-Mv
+WS
 qW
 ru
 sE

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -34,8 +34,8 @@
 "ai" = (
 /obj/structure/catwalk,
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/second_deck/afp)
@@ -80,14 +80,14 @@
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "solar_tool_pump";
-	tag_exterior_door = "solar_tool_outer";
 	frequency = 1379;
 	id_tag = "solar_tool_airlock";
-	tag_interior_door = "solar_tool_inner";
 	pixel_x = 25;
 	req_access = list(13);
-	tag_chamber_sensor = "solar_tool_sensor"
+	tag_airpump = "solar_tool_pump";
+	tag_chamber_sensor = "solar_tool_sensor";
+	tag_exterior_door = "solar_tool_outer";
+	tag_interior_door = "solar_tool_inner"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
@@ -151,8 +151,8 @@
 /area/maintenance/second_deck/afp)
 "av" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -162,42 +162,42 @@
 /area/maintenance/second_deck/afp)
 "aw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "ax" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "ay" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
@@ -292,9 +292,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
@@ -321,35 +321,35 @@
 /area/maintenance/second_deck/afp)
 "aR" = (
 /obj/item/pipe{
-	tag = "icon-simple (EAST)";
+	dir = 4;
 	icon_state = "simple";
-	dir = 4
+	tag = "icon-simple (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "aS" = (
 /obj/item/pipe{
-	tag = "icon-simple (EAST)";
+	dir = 4;
 	icon_state = "simple";
-	dir = 4
+	tag = "icon-simple (EAST)"
 	},
 /obj/item/remains/robot,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "aT" = (
 /obj/item/pipe{
-	tag = "icon-simple (EAST)";
+	dir = 4;
 	icon_state = "simple";
-	dir = 4
+	tag = "icon-simple (EAST)"
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "aU" = (
 /obj/item/pipe{
-	tag = "icon-simple (EAST)";
+	dir = 4;
 	icon_state = "simple";
-	dir = 4
+	tag = "icon-simple (EAST)"
 	},
 /obj/item/stack/rods/ten,
 /turf/simulated/floor/plating,
@@ -493,13 +493,13 @@
 /area/maintenance/second_deck/fp)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -520,25 +520,25 @@
 "bu" = (
 /turf/simulated/open,
 /obj/machinery/atmospherics/pipe/zpipe/down/fuel{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/lattice,
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (WEST)";
+	dir = 8;
 	icon_state = "down-supply";
-	dir = 8
+	tag = "icon-down-supply (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "down-scrubbers";
-	dir = 8
+	tag = "icon-down-scrubbers (WEST)"
 	},
 /turf/simulated/open{
 	initial_gas = null
@@ -558,8 +558,8 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/item/weapon/circuitboard/borgupload,
 /turf/simulated/floor/plating,
@@ -571,12 +571,12 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -586,8 +586,8 @@
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/item/weapon/circuitboard/helm,
 /turf/simulated/floor/plating,
@@ -701,14 +701,14 @@
 "bO" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/corner/red/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -719,9 +719,9 @@
 /area/security/prison)
 "bP" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -737,8 +737,8 @@
 /area/engineering/fuelbay)
 "bS" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -784,8 +784,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -798,12 +798,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -817,9 +817,9 @@
 "bY" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -828,17 +828,17 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/techstorage)
 "bZ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -852,9 +852,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/techstorage)
@@ -870,9 +870,9 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/techstorage)
@@ -976,8 +976,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -989,9 +989,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1006,9 +1006,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1017,8 +1017,8 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/fuelbay)
@@ -1033,9 +1033,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1069,8 +1069,8 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -1119,9 +1119,9 @@
 /area/engineering/techstorage)
 "cA" = (
 /obj/structure/cryofeed{
-	tag = "icon-cryo_rear (EAST)";
+	dir = 4;
 	icon_state = "cryo_rear";
-	dir = 4
+	tag = "icon-cryo_rear (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1134,9 +1134,9 @@
 	dir = 1
 	},
 /obj/machinery/cryopod{
-	tag = "icon-body_scanner_0 (EAST)";
+	dir = 4;
 	icon_state = "body_scanner_0";
-	dir = 4
+	tag = "icon-body_scanner_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1149,15 +1149,15 @@
 	name = "JoinLateCryo2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
 "cD" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1230,8 +1230,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -1249,8 +1249,8 @@
 /area/security/prison)
 "cL" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1262,8 +1262,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
@@ -1275,8 +1275,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -1330,9 +1330,9 @@
 "cT" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
@@ -1350,9 +1350,9 @@
 /area/maintenance/second_deck/fp)
 "cW" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	tag = "icon-air_map (WEST)";
+	dir = 8;
 	icon_state = "air_map";
-	dir = 8
+	tag = "icon-air_map (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
@@ -1380,8 +1380,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/button/ignition{
 	id = "engines";
@@ -1431,9 +1431,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -1477,17 +1477,17 @@
 /area/engineering/techstorage)
 "dh" = (
 /obj/machinery/cryopod{
-	tag = "icon-body_scanner_0 (EAST)";
+	dir = 4;
 	icon_state = "body_scanner_0";
-	dir = 4
+	tag = "icon-body_scanner_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
 "di" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1497,8 +1497,8 @@
 	name = "JoinLateCryo2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1539,8 +1539,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -1639,20 +1639,20 @@
 /area/maintenance/second_deck/fp)
 "dC" = (
 /obj/structure/hygiene/toilet{
-	icon_state = "toilet00";
-	dir = 8
+	dir = 8;
+	icon_state = "toilet00"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
 "dD" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
@@ -1704,8 +1704,8 @@
 "dI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1717,8 +1717,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -1730,9 +1730,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -1760,8 +1760,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1769,8 +1769,8 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1858,8 +1858,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1875,8 +1875,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1890,14 +1890,14 @@
 /area/maintenance/second_deck/afp)
 "en" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1995,9 +1995,9 @@
 "ev" = (
 /obj/structure/closet/walllocker/emerglocker/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -2023,8 +2023,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -2036,16 +2036,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
 "ez" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -2092,6 +2092,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"eI" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "eQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
@@ -2142,9 +2146,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
@@ -2270,8 +2274,8 @@
 /area/command/captain)
 "ft" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -2297,12 +2301,12 @@
 /area/maintenance/second_deck/afp)
 "fv" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-22";
-	icon_state = "plant-22"
+	icon_state = "plant-22";
+	tag = "icon-plant-22"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -2311,9 +2315,9 @@
 /obj/item/weapon/storage/backpack/duffel/duffel_eng,
 /obj/item/clothing/glasses/welding/superior,
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -2339,14 +2343,14 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -2361,8 +2365,8 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -2373,9 +2377,9 @@
 /area/command/ce)
 "fA" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2400,9 +2404,9 @@
 /area/engineering/break_room)
 "fB" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -2421,9 +2425,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -2431,13 +2435,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2538,8 +2542,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2557,9 +2561,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2591,9 +2595,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2607,9 +2611,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2624,9 +2628,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/light{
@@ -2650,9 +2654,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
@@ -2685,9 +2689,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2702,13 +2706,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
@@ -2720,8 +2724,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2739,9 +2743,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2759,9 +2763,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2779,9 +2783,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2797,12 +2801,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -2827,8 +2831,8 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
@@ -2841,9 +2845,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2861,9 +2865,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/firealarm{
 	dir = 2;
@@ -2885,9 +2889,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2902,9 +2906,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -2914,8 +2918,8 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2930,9 +2934,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck Port Hallway - Fore-Centre"
@@ -2941,8 +2945,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -2957,9 +2961,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2977,9 +2981,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2997,8 +3001,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3016,9 +3020,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3027,9 +3031,9 @@
 	dir = 4
 	},
 /obj/machinery/light/broken{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -3041,13 +3045,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3067,12 +3071,12 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3094,8 +3098,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -3113,8 +3117,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -3126,12 +3130,12 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -3147,9 +3151,9 @@
 "gn" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3178,8 +3182,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3266,8 +3270,8 @@
 /area/command/captain)
 "gw" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -3305,8 +3309,8 @@
 /obj/item/weapon/rig/ce/equipped,
 /obj/item/clothing/mask/breath,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -3327,8 +3331,8 @@
 	name = "Chief Engineer"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -3355,34 +3359,34 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "gG" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "gH" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -3396,9 +3400,9 @@
 /area/hallway/aft/second_deck)
 "gI" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -3481,25 +3485,25 @@
 /area/hallway/fore/second_deck)
 "gS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "gT" = (
 /obj/machinery/atmospherics/valve/shutoff{
-	tag = "icon-map_vclamp0 (WEST)";
+	dir = 8;
 	icon_state = "map_vclamp0";
-	dir = 8
+	tag = "icon-map_vclamp0 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "gU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -3550,6 +3554,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
+"he" = (
+/obj/structure/bookcase/manuals/xenoarchaeology,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "hf" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -3584,15 +3592,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "hj" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -3603,8 +3611,8 @@
 	pixel_y = 0
 	},
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -3633,16 +3641,16 @@
 /area/command/captain)
 "hq" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /turf/simulated/floor/carpet,
 /area/command/captain)
 "hr" = (
 /obj/machinery/atmospherics/unary/engine{
-	tag = "icon-nozzle (EAST)";
+	dir = 4;
 	icon_state = "nozzle";
-	dir = 4
+	tag = "icon-nozzle (EAST)"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/fdengine)
@@ -3657,16 +3665,16 @@
 /area/engineering/fdengine)
 "ht" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -3704,8 +3712,8 @@
 	pixel_y = -8
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Chief Engineer's Office";
@@ -3732,8 +3740,8 @@
 "hz" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled/dark,
@@ -3770,9 +3778,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -3915,8 +3923,8 @@
 /area/engineering/fdengine)
 "hZ" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -3941,16 +3949,16 @@
 "ic" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -3983,12 +3991,12 @@
 /area/command/ce)
 "if" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -4010,9 +4018,9 @@
 "ih" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -4030,22 +4038,22 @@
 /area/hallway/aft/second_deck)
 "ik" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "il" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva3 (NORTH)";
+	dir = 1;
 	icon_state = "nerva3";
-	dir = 1
+	tag = "icon-nerva3 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -4113,34 +4121,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
-"ix" = (
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "iy" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "iz" = (
 /turf/simulated/floor/wood,
-/area/civilian/lounge)
-"iA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
-"iB" = (
-/obj/machinery/vending/games,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
-"iC" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/pen,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "iE" = (
 /obj/structure/table/woodentable,
@@ -4180,9 +4166,9 @@
 /area/command/headquarters)
 "iJ" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -4228,8 +4214,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
@@ -4245,8 +4231,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
@@ -4259,8 +4245,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/carpet,
 /area/command/captain)
@@ -4270,12 +4256,12 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/carpet,
 /area/command/captain)
@@ -4284,8 +4270,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -4299,8 +4285,8 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/carpet,
 /area/command/captain)
@@ -4310,8 +4296,8 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Captain's Bedroom";
@@ -4357,9 +4343,9 @@
 "iZ" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -4455,22 +4441,22 @@
 /area/hallway/aft/second_deck)
 "jh" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2 (NORTH)";
+	dir = 1;
 	icon_state = "nerva2";
-	dir = 1
+	tag = "icon-nerva2 (NORTH)"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "ji" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -4479,8 +4465,8 @@
 /area/civilian/dorms)
 "jl" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood_broken3";
-	icon_state = "wood_broken3"
+	icon_state = "wood_broken3";
+	tag = "icon-wood_broken3"
 	},
 /area/civilian/dorms)
 "jm" = (
@@ -4502,8 +4488,8 @@
 /area/hallway/aft/second_deck)
 "jo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -4516,26 +4502,19 @@
 /area/civilian/lounge)
 "jq" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair";
-	dir = 4
+	tag = "icon-wooden_chair (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "js" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /turf/simulated/floor/wood,
-/area/civilian/lounge)
-"jt" = (
-/obj/machinery/papershredder,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "ju" = (
 /obj/structure/bed/chair/office/dark{
@@ -4554,8 +4533,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -4611,9 +4590,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -4625,16 +4604,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
 "jC" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/open,
@@ -4658,8 +4637,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -4683,8 +4662,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
@@ -4702,15 +4681,15 @@
 "jJ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "jK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -4727,9 +4706,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -4768,9 +4747,9 @@
 /area/engineering/break_room)
 "jQ" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -4812,9 +4791,9 @@
 /area/engineering/break_room)
 "jT" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4822,16 +4801,16 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "jU" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4844,8 +4823,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -4921,34 +4900,21 @@
 /area/civilian/lounge)
 "kf" = (
 /turf/simulated/floor/wood{
-	tag = "icon-wood_broken1";
-	icon_state = "wood_broken1"
+	icon_state = "wood_broken1";
+	tag = "icon-wood_broken1"
 	},
 /area/civilian/lounge)
 "kg" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair_preview (NORTH)";
+	dir = 1;
 	icon_state = "wooden_chair_preview";
-	dir = 1
+	tag = "icon-wooden_chair_preview (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "kh" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
-/area/civilian/lounge)
-"ki" = (
-/obj/item/weapon/stool,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
-"kj" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/computer/arcade/orion_trail,
-/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "kk" = (
 /obj/structure/undies_wardrobe,
@@ -4980,8 +4946,8 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -4992,8 +4958,8 @@
 /area/command/headquarters)
 "kp" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -5006,9 +4972,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHWEST)";
+	dir = 9;
 	icon_state = "warning";
-	dir = 9
+	tag = "icon-warning (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
@@ -5043,8 +5009,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/item/modular_computer/telescreen/preset/generic{
 	pixel_y = 26
@@ -5105,8 +5071,8 @@
 "kF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -5118,8 +5084,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -5144,9 +5110,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5163,13 +5129,13 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5196,9 +5162,9 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5213,9 +5179,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
@@ -5264,8 +5230,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -5284,8 +5250,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5305,8 +5271,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5329,8 +5295,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5343,13 +5309,13 @@
 	tag = "icon-direction_eng (WEST)"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -5360,8 +5326,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5382,13 +5348,13 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -5400,12 +5366,12 @@
 /area/civilian/dorms)
 "kZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -5428,15 +5394,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood_broken6";
-	icon_state = "wood_broken6"
+	icon_state = "wood_broken6";
+	tag = "icon-wood_broken6"
 	},
 /area/civilian/dorms)
 "lb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5448,9 +5414,9 @@
 /area/civilian/dorms)
 "lc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5464,9 +5430,9 @@
 /area/civilian/dorms)
 "ld" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -5477,9 +5443,9 @@
 "le" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5488,14 +5454,14 @@
 /area/civilian/dorms)
 "lf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5509,14 +5475,14 @@
 	name = "Dorms"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5528,12 +5494,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -5561,9 +5527,9 @@
 /area/civilian/lounge)
 "ll" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
@@ -5571,29 +5537,10 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/board,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/wood,
-/area/civilian/lounge)
-"lo" = (
-/obj/item/stack/material/wood/ten,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
-"lp" = (
-/obj/item/modular_computer/console/preset/civilian{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Rec Room - Fore";
-	dir = 8;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/plating,
 /area/civilian/lounge)
 "lq" = (
 /obj/structure/extinguisher_cabinet{
@@ -5643,8 +5590,8 @@
 	pixel_x = -25
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -5678,9 +5625,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "TeleporterHub";
@@ -5745,25 +5692,25 @@
 /area/command/captain)
 "lE" = (
 /obj/item/modular_computer/console/preset/nervacommand{
-	tag = "icon-console (WEST)";
+	dir = 8;
 	icon_state = "console";
-	dir = 8
+	tag = "icon-console (WEST)"
 	},
 /obj/item/weapon/card/id/captains_spare,
 /turf/simulated/floor/wood,
 /area/command/captain)
 "lF" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "lG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5803,8 +5750,8 @@
 /area/engineering/fdengine)
 "lK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -5854,9 +5801,9 @@
 /area/engineering/break_room)
 "lQ" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5904,18 +5851,18 @@
 	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "lW" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -5924,9 +5871,9 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/hallway/aft/second_deck)
@@ -5953,8 +5900,8 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
@@ -5981,15 +5928,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"me" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/structure/bookcase,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "mg" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/deck/cards,
@@ -5997,8 +5935,8 @@
 /area/civilian/lounge)
 "mi" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-18";
-	icon_state = "plant-18"
+	icon_state = "plant-18";
+	tag = "icon-plant-18"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -6006,9 +5944,9 @@
 	pixel_x = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
@@ -6031,8 +5969,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -6096,13 +6034,13 @@
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /turf/simulated/floor/wood,
 /area/command/captain)
@@ -6117,8 +6055,8 @@
 /area/command/captain)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/wood,
 /area/command/captain)
@@ -6321,9 +6259,9 @@
 /area/maintenance/second_deck/afp)
 "mJ" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/engineering/break_room)
@@ -6397,9 +6335,9 @@
 	icon_state = "camera"
 	},
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /obj/structure/sign/deck/second{
 	dir = 4;
@@ -6408,17 +6346,17 @@
 	tag = "icon-deck-2 (EAST)"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "mS" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/sign/directions/medical{
 	pixel_x = 32
@@ -6439,27 +6377,27 @@
 "mV" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (EAST)";
+	dir = 4;
 	icon_state = "down-supply";
-	dir = 4
+	tag = "icon-down-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "down-scrubbers";
-	dir = 4
+	tag = "icon-down-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
 /area/maintenance/second_deck/central)
 "mW" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6473,20 +6411,20 @@
 /area/maintenance/second_deck/central)
 "mX" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	tag = "icon-up-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "up-scrubbers";
-	dir = 8
+	tag = "icon-up-scrubbers (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	tag = "icon-up-supply (WEST)";
+	dir = 8;
 	icon_state = "up-supply";
-	dir = 8
+	tag = "icon-up-supply (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/central)
@@ -6496,8 +6434,8 @@
 /area/maintenance/second_deck/central)
 "mZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/lapvend,
 /turf/simulated/floor/carpet/blue2,
@@ -6526,13 +6464,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"nd" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "ne" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -6552,8 +6483,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood{
-	tag = "icon-wood_broken3";
-	icon_state = "wood_broken3"
+	icon_state = "wood_broken3";
+	tag = "icon-wood_broken3"
 	},
 /area/civilian/lounge)
 "nj" = (
@@ -6619,9 +6550,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -6631,21 +6562,21 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
 "nq" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/hallway/fore/second_deck)
@@ -6689,8 +6620,8 @@
 /area/command/teleporter)
 "nt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -6738,8 +6669,8 @@
 /area/command/fobedroom)
 "nz" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/reinforced,
@@ -6816,9 +6747,9 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -6878,9 +6809,9 @@
 /area/civilian/dorms)
 "nP" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair";
-	dir = 4
+	tag = "icon-wooden_chair (EAST)"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
@@ -6897,9 +6828,9 @@
 /area/civilian/dorms)
 "nR" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
@@ -6922,8 +6853,8 @@
 "nU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -6943,10 +6874,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"nW" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "nZ" = (
 /obj/machinery/light,
 /turf/simulated/floor/wood,
@@ -6968,8 +6895,8 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
@@ -7117,9 +7044,9 @@
 /area/command/fobedroom)
 "ot" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light/small,
@@ -7128,54 +7055,54 @@
 /area/engineering/fdengine)
 "ou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "ov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Maintenance";
@@ -7184,44 +7111,44 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
 "ox" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
 "oy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/meter,
@@ -7229,9 +7156,9 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
@@ -7241,23 +7168,23 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
 "oA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -7268,14 +7195,14 @@
 /area/engineering/atmospherics)
 "oB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/camera/network/engineering{
@@ -7293,14 +7220,14 @@
 "oD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -7313,32 +7240,32 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "oF" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
@@ -7348,9 +7275,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -7361,9 +7288,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7379,9 +7306,9 @@
 /area/engineering/break_room)
 "oJ" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7408,9 +7335,9 @@
 	pixel_y = 0
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -7503,8 +7430,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -7541,33 +7468,33 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "oY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "oZ" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-22";
-	icon_state = "plant-22"
+	icon_state = "plant-22";
+	tag = "icon-plant-22"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -7630,8 +7557,8 @@
 /area/engineering/atmospherics)
 "pj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7690,8 +7617,8 @@
 /area/engineering/break_room)
 "pq" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7704,9 +7631,9 @@
 /area/engineering/break_room)
 "ps" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7717,34 +7644,34 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "pu" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "pv" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7755,9 +7682,9 @@
 /area/hallway/aft/second_deck)
 "pw" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -7766,18 +7693,18 @@
 /area/hallway/aft/second_deck)
 "px" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "py" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck Aft Hallway - Bathrooms"
@@ -7786,9 +7713,9 @@
 /area/hallway/aft/second_deck)
 "pz" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/device/radio/intercom{
@@ -7858,8 +7785,8 @@
 /area/hallway/fore/second_deck)
 "pJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -7906,12 +7833,12 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -7954,14 +7881,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -7973,19 +7900,19 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/light/broken{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -8010,8 +7937,8 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -8023,14 +7950,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8042,8 +7969,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8090,8 +8017,8 @@
 /area/command/bridge)
 "qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8104,8 +8031,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -8124,15 +8051,15 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "qd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8161,8 +8088,8 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -8176,8 +8103,8 @@
 /area/command/fobedroom)
 "qf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8186,8 +8113,8 @@
 /area/command/fobedroom)
 "qg" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet/purple,
 /area/command/fobedroom)
@@ -8205,17 +8132,17 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmospherics)
 "qk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -8257,18 +8184,18 @@
 "qo" = (
 /obj/machinery/vending/cola,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "qp" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -8276,9 +8203,9 @@
 "qq" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -8288,9 +8215,9 @@
 /area/engineering/break_room)
 "qr" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/industrial/outline/orange,
@@ -8298,9 +8225,9 @@
 /area/engineering/break_room)
 "qs" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -8311,9 +8238,9 @@
 /area/engineering/break_room)
 "qt" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -8367,9 +8294,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8434,25 +8361,25 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "qE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "qF" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8491,16 +8418,16 @@
 /area/hallway/fore/second_deck)
 "qL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
 "qM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8519,15 +8446,15 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
 "qO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8552,8 +8479,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -8584,8 +8511,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -8607,9 +8534,9 @@
 /area/command/bridge)
 "qY" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Captain's Office Staircase";
@@ -8617,26 +8544,26 @@
 	icon_state = "camera"
 	},
 /obj/machinery/door/blast/regular/open{
-	tag = "icon-pdoor0 (WEST)";
-	name = "Bridge Lockdown";
-	icon_state = "pdoor0";
 	dir = 8;
-	id = "bridgelock"
+	icon_state = "pdoor0";
+	id = "bridgelock";
+	name = "Bridge Lockdown";
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/open,
 /area/command/bridge)
 "qZ" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/door/blast/regular/open{
-	tag = "icon-pdoor0 (WEST)";
-	name = "Bridge Lockdown";
-	icon_state = "pdoor0";
 	dir = 8;
-	id = "bridgelock"
+	icon_state = "pdoor0";
+	id = "bridgelock";
+	name = "Bridge Lockdown";
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/open,
 /area/command/bridge)
@@ -8652,8 +8579,8 @@
 	dir = 8
 	},
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /turf/simulated/floor/carpet/purple,
 /area/command/fobedroom)
@@ -8672,8 +8599,8 @@
 /area/command/fobedroom)
 "rd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -8685,8 +8612,8 @@
 /area/engineering/atmospherics)
 "re" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -8696,8 +8623,8 @@
 /area/engineering/atmospherics)
 "rf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8711,21 +8638,21 @@
 /area/engineering/atmospherics)
 "rg" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmospherics)
@@ -8745,9 +8672,9 @@
 	req_one_access = list(11,24)
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
@@ -8760,9 +8687,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -8770,14 +8697,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -8786,9 +8713,9 @@
 	sortType = "Atmospherics"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -8990,8 +8917,8 @@
 /area/engineering/atmospherics)
 "rJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -9010,12 +8937,12 @@
 /area/maintenance/second_deck/afs)
 "rM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
@@ -9034,23 +8961,23 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Second Deck Telecommunications Relay"
@@ -9060,24 +8987,24 @@
 "rO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "down-scrubbers";
-	dir = 8
+	tag = "icon-down-scrubbers (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/fuel{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (WEST)";
+	dir = 8;
 	icon_state = "down-supply";
-	dir = 8
+	tag = "icon-down-supply (WEST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "32-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "32-8"
 	},
 /turf/simulated/open,
 /area/maintenance/second_deck/afs)
@@ -9130,8 +9057,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/bath)
@@ -9148,9 +9075,9 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9202,8 +9129,8 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 28;
@@ -9228,8 +9155,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9245,14 +9172,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9267,20 +9194,20 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9297,14 +9224,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9332,12 +9259,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -9359,14 +9286,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9381,9 +9308,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9401,9 +9328,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9418,18 +9345,18 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9448,14 +9375,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9470,14 +9397,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9603,8 +9530,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -9623,14 +9550,14 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -9640,8 +9567,8 @@
 	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -9664,9 +9591,9 @@
 	tag = ""
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -9744,9 +9671,9 @@
 /area/maintenance/second_deck/afs)
 "sP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9756,17 +9683,17 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "sQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9777,17 +9704,17 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "sR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9804,9 +9731,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -9816,27 +9743,27 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "sT" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -9867,8 +9794,8 @@
 /area/civilian/bath)
 "sW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -9882,8 +9809,8 @@
 "sY" = (
 /obj/machinery/vending/urist/coatdispenser,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -9939,9 +9866,9 @@
 /area/maintenance/second_deck/afs)
 "ti" = (
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb1 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb1";
-	dir = 1
+	tag = "icon-cobweb1 (NORTH)"
 	},
 /obj/structure/table/rack,
 /obj/random/maintenance,
@@ -9967,8 +9894,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -9979,24 +9906,24 @@
 /area/hallway/aft/second_deck)
 "tl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "tm" = (
 /obj/machinery/atmospherics/valve/shutoff{
-	tag = "icon-map_vclamp0 (WEST)";
+	dir = 8;
 	icon_state = "map_vclamp0";
-	dir = 8
+	tag = "icon-map_vclamp0 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "tn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10041,8 +9968,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -10056,18 +9983,18 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/primtool)
@@ -10078,14 +10005,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10100,14 +10027,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10128,14 +10055,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10173,17 +10100,17 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/landmark/start{
 	name = "Assistant"
@@ -10197,9 +10124,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10225,9 +10152,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10250,9 +10177,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10270,19 +10197,19 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -10357,9 +10284,9 @@
 /area/engineering/atmospherics)
 "tK" = (
 /obj/structure/cable/yellow{
-	icon_state = "16-0";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "16-0"
 	},
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/cable/yellow{
@@ -10367,19 +10294,19 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	tag = "icon-up-supply (WEST)";
+	dir = 8;
 	icon_state = "up-supply";
-	dir = 8
+	tag = "icon-up-supply (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	tag = "icon-up-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "up-scrubbers";
-	dir = 8
+	tag = "icon-up-scrubbers (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -10392,8 +10319,8 @@
 "tM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/bath)
@@ -10402,8 +10329,8 @@
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -10518,9 +10445,9 @@
 /area/logistics/primtool)
 "ud" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -10533,8 +10460,8 @@
 /area/logistics/primtool)
 "uf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -10578,8 +10505,8 @@
 /area/engineering/atmospherics)
 "um" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/meter,
 /obj/structure/disposalpipe/segment{
@@ -10640,8 +10567,8 @@
 "uq" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
@@ -10686,25 +10613,25 @@
 /area/engineering/atmospherics)
 "uw" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
-	name = "Carbon Dioxide Supply Control";
-	icon_state = "computer";
 	dir = 8;
 	frequency = 1441;
-	sensors = list("co2_sensor" = "Tank");
+	icon_state = "computer";
 	input_tag = "co2_in";
-	output_tag = "co2_out"
+	name = "Carbon Dioxide Supply Control";
+	output_tag = "co2_out";
+	sensors = list("co2_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -10712,8 +10639,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/plating,
@@ -10738,8 +10665,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Bathrooms";
@@ -10754,9 +10681,9 @@
 /area/civilian/bath)
 "uB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10777,9 +10704,9 @@
 	name = "Unisex Restrooms"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10791,9 +10718,9 @@
 /area/civilian/personal)
 "uD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10809,8 +10736,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -10850,8 +10777,8 @@
 "uJ" = (
 /obj/structure/bed/chair/couch/right/black,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/observatory)
@@ -10877,8 +10804,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/observatory)
@@ -11001,8 +10928,8 @@
 /area/maintenance/second_deck/afs)
 "vc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Atmospherics - Entry";
@@ -11017,8 +10944,8 @@
 /area/engineering/atmospherics)
 "vd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11031,15 +10958,15 @@
 /area/engineering/atmospherics)
 "vf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "vg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled,
@@ -11052,8 +10979,8 @@
 /area/engineering/atmospherics)
 "vi" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11082,12 +11009,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11176,8 +11103,8 @@
 	icon_state = "camera"
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -11212,22 +11139,22 @@
 /area/civilian/observatory)
 "vy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/observatory)
 "vz" = (
 /obj/item/stack/tile/floor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/observatory)
@@ -11239,13 +11166,13 @@
 /area/civilian/observatory)
 "vB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/escape_pod1/station)
@@ -11254,9 +11181,9 @@
 /area/shuttle/escape_pod1/station)
 "vD" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (WEST)";
+	dir = 8;
 	icon_state = "shuttlechair";
-	dir = 8
+	tag = "icon-shuttlechair (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/escape_pod1/station)
@@ -11279,8 +11206,8 @@
 /area/maintenance/second_deck/fs)
 "vI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
@@ -11334,16 +11261,16 @@
 "vQ" = (
 /obj/effect/floor_decal/corner/orange,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11435,9 +11362,9 @@
 /area/civilian/observatory)
 "wc" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/escape_pod1/station)
@@ -11472,8 +11399,8 @@
 /area/maintenance/second_deck/fs)
 "wj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -11483,8 +11410,8 @@
 /area/maintenance/second_deck/afs)
 "wk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11537,8 +11464,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -11549,16 +11476,16 @@
 /area/engineering/atmospherics)
 "wo" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "wp" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled,
@@ -11586,8 +11513,8 @@
 "wt" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11604,16 +11531,16 @@
 /area/engineering/atmospherics)
 "wv" = (
 /obj/effect/floor_decal/corner/orange{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
@@ -11648,8 +11575,8 @@
 /area/civilian/bath)
 "wy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -11671,9 +11598,9 @@
 	name = "Showers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11691,18 +11618,18 @@
 /area/civilian/bath)
 "wA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11776,9 +11703,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -11820,9 +11747,9 @@
 /obj/structure/closet,
 /obj/random/maintenance/clean,
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb2 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb2";
-	dir = 1
+	tag = "icon-cobweb2 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -11883,13 +11810,13 @@
 /area/engineering/atmospherics)
 "wW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /obj/machinery/meter,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -11911,8 +11838,8 @@
 /area/engineering/atmospherics)
 "wZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11935,12 +11862,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11968,8 +11895,8 @@
 /area/engineering/atmospherics)
 "xe" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12067,12 +11994,12 @@
 /area/engineering/atmospherics)
 "xr" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = 28
@@ -12089,8 +12016,8 @@
 /area/engineering/atmospherics)
 "xs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12102,8 +12029,8 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -12128,31 +12055,31 @@
 "xv" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "xw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "xx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "xy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled,
@@ -12172,17 +12099,17 @@
 /area/engineering/atmospherics)
 "xB" = (
 /obj/effect/floor_decal/corner/orange{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12226,8 +12153,8 @@
 /area/civilian/personal)
 "xF" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper_0";
-	dir = 4
+	dir = 4;
+	icon_state = "sleeper_0"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/escape_pod1/station)
@@ -12290,8 +12217,8 @@
 /area/engineering/atmospherics)
 "xK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/meter,
@@ -12303,8 +12230,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12358,8 +12285,8 @@
 /area/engineering/atmospherics)
 "xS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12390,16 +12317,16 @@
 /area/engineering/atmospherics)
 "xY" = (
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
@@ -12449,8 +12376,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -12469,14 +12396,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -12513,17 +12440,17 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -12548,8 +12475,8 @@
 /area/maintenance/second_deck/fs)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/structure/sign/warning/compressed_gas,
 /turf/simulated/wall/r_wall/prepainted,
@@ -12559,8 +12486,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12573,8 +12500,8 @@
 /area/engineering/atmospherics)
 "yl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12613,8 +12540,8 @@
 "yq" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12642,12 +12569,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12699,9 +12626,9 @@
 /area/maintenance/second_deck/afs)
 "yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12720,9 +12647,9 @@
 /area/maintenance/second_deck/afs)
 "yy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12766,14 +12693,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -12789,19 +12716,19 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -12830,27 +12757,27 @@
 "yG" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/second_deck/fs)
 "yH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "yI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12912,8 +12839,8 @@
 /area/engineering/atmospherics)
 "yM" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12935,8 +12862,8 @@
 "yN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12951,8 +12878,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13024,8 +12951,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -13037,19 +12964,19 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "yX" = (
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -13093,8 +13020,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/vehicle_part/random,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-stickyweb2";
-	icon_state = "stickyweb2"
+	icon_state = "stickyweb2";
+	tag = "icon-stickyweb2"
 	},
 /obj/random/drinkbottle,
 /obj/random/smokes,
@@ -13130,8 +13057,8 @@
 /area/engineering/atmospherics)
 "zi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -13166,8 +13093,8 @@
 /area/engineering/atmospherics)
 "zl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -13207,9 +13134,9 @@
 /area/engineering/atmospherics)
 "zr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -13258,9 +13185,9 @@
 /area/maintenance/second_deck/afs)
 "zA" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -13392,9 +13319,9 @@
 "zR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
@@ -13415,9 +13342,9 @@
 "zU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/comfy/brown{
-	tag = "icon-comfychair_preview (WEST)";
+	dir = 8;
 	icon_state = "comfychair_preview";
-	dir = 8
+	tag = "icon-comfychair_preview (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -13429,34 +13356,19 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
 "Ah" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"Al" = (
-/obj/effect/floor_decal/corner/red/three_quarters,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "Aq" = (
 /obj/structure/bed/chair/couch/right/black,
 /obj/item/weapon/papercrafts/oragami/swan,
@@ -13468,9 +13380,9 @@
 	req_one_access = list(11,24)
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
@@ -13497,8 +13409,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -13520,6 +13432,43 @@
 /area/security/prison)
 "AE" = (
 /turf/simulated/wall/r_wall,
+/area/security/prison)
+"AF" = (
+/obj/item/modular_computer/console/preset/civilian{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Rec Room - Fore";
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"AL" = (
+/obj/machinery/papershredder,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"AM" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/item/seeds/cornseed,
+/obj/item/seeds/cornseed,
+/obj/item/seeds/tobaccoseed,
+/obj/effect/floor_decal/corner/red{
+	dir = 5;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (NORTHEAST)"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "AP" = (
 /obj/structure/cable{
@@ -13619,9 +13568,9 @@
 /area/security/prison)
 "BM" = (
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
+	dir = 4;
 	icon_state = "chapel";
-	dir = 4
+	tag = "icon-chapel (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -13645,24 +13594,33 @@
 "BW" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
-"BX" = (
-/obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "BZ" = (
 /turf/simulated/wall,
 /area/civilian/counselor)
+"Ca" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/structure/bookcase,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"Cc" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Ch" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -13671,11 +13629,14 @@
 "Cl" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"Cm" = (
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/prison)
 "Cu" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -13692,15 +13653,33 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/counselor)
+"CC" = (
+/obj/structure/hygiene/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/prison)
 "CG" = (
 /turf/simulated/floor/reinforced/airless,
 /area/security/prison)
@@ -13717,9 +13696,9 @@
 /obj/item/seeds/tomatoseed,
 /obj/item/device/analyzer/plant_analyzer,
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -13729,6 +13708,20 @@
 	tag = ""
 	},
 /turf/simulated/floor/reinforced,
+/area/security/prison)
+"CW" = (
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "Da" = (
 /obj/structure/cable{
@@ -13781,14 +13774,14 @@
 /area/logistics/auxtool)
 "DP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -13818,9 +13811,9 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
@@ -13853,8 +13846,8 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/flame/candle,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -13865,9 +13858,9 @@
 /area/chapel)
 "Ed" = (
 /obj/structure/window/reinforced/tinted{
-	tag = "icon-window (EAST)";
+	dir = 4;
 	icon_state = "window";
-	dir = 4
+	tag = "icon-window (EAST)"
 	},
 /obj/item/weapon/stool/padded,
 /obj/item/device/radio/intercom{
@@ -13904,6 +13897,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"El" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "En" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -13953,8 +13955,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
@@ -13962,13 +13964,6 @@
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"EJ" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "EK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/old_tile,
@@ -14017,8 +14012,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -14030,8 +14025,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
@@ -14040,9 +14035,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Chapel"
@@ -14059,26 +14054,19 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
-"Fg" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "Fl" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -14107,12 +14095,12 @@
 /area/maintenance/second_deck/afp)
 "Fz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
@@ -14120,9 +14108,9 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/cable,
 /obj/machinery/door/blast/regular{
@@ -14146,9 +14134,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -14170,8 +14158,8 @@
 	name = "Auxiliary Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14195,9 +14183,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
@@ -14208,8 +14196,8 @@
 /area/civilian/lounge)
 "Gv" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /obj/item/weapon/stool,
 /obj/machinery/light{
@@ -14219,14 +14207,14 @@
 /area/chapel)
 "Gy" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -14243,9 +14231,9 @@
 /area/hallway/fore/second_deck)
 "GF" = (
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -14254,12 +14242,16 @@
 	pixel_x = 28
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"GJ" = (
+/obj/machinery/vending/games,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "GO" = (
 /obj/effect/shuttle_landmark/nerva/deck2/hadrian,
 /turf/space,
@@ -14283,34 +14275,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
-"GS" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/item/seeds/potatoseed,
-/obj/item/seeds/wheatseed,
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 8
-	},
-/obj/machinery/camera/network/prison{
-	c_tag = "Prison Hydroponics";
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "GX" = (
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
+	dir = 4;
 	icon_state = "chapel";
-	dir = 4
+	tag = "icon-chapel (EAST)"
 	},
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"He" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/camera/network/prison{
 	c_tag = "Prison Dorms";
@@ -14320,8 +14305,8 @@
 /area/security/prison)
 "Hi" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 8
+	dir = 8;
+	icon_state = "chapel"
 	},
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
@@ -14345,17 +14330,17 @@
 "Hy" = (
 /obj/structure/bed/chair/urist/bench/bench1/right,
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
+	dir = 4;
 	icon_state = "chapel";
-	dir = 4
+	tag = "icon-chapel (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "HA" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -14371,9 +14356,9 @@
 /area/engineering/substation/atmos)
 "HB" = (
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
+	dir = 4;
 	icon_state = "chapel";
-	dir = 4
+	tag = "icon-chapel (EAST)"
 	},
 /obj/item/weapon/stool,
 /obj/machinery/camera/network/second_deck{
@@ -14384,6 +14369,25 @@
 "HJ" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/security/prison)
+"HK" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "HP" = (
@@ -14408,9 +14412,9 @@
 	name = "Boarding Armoury Access"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
@@ -14490,8 +14494,8 @@
 /area/hallway/aft/second_deck)
 "IP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14506,9 +14510,9 @@
 /area/maintenance/second_deck/afs)
 "IT" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -14537,8 +14541,8 @@
 "IW" = (
 /obj/structure/bed/chair/urist/bench/bench1/left,
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -14560,14 +14564,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -14602,17 +14606,17 @@
 /area/security/prison)
 "Jm" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "Jv" = (
 /obj/structure/fitness/weightlifter,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -14621,8 +14625,8 @@
 /area/civilian/exercise)
 "Jy" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 8
+	dir = 8;
+	icon_state = "chapel"
 	},
 /obj/item/weapon/stool,
 /obj/machinery/light,
@@ -14641,14 +14645,14 @@
 "JG" = (
 /obj/structure/fitness/weightlifter,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -14664,8 +14668,8 @@
 /area/civilian/exercise)
 "JL" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 8
+	dir = 8;
+	icon_state = "chapel"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -14702,8 +14706,8 @@
 "Ka" = (
 /obj/machinery/power/terminal,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -14751,9 +14755,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
@@ -14762,8 +14766,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
@@ -14788,8 +14792,8 @@
 /obj/effect/floor_decal/corner/red/three_quarters,
 /obj/machinery/light,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -14804,9 +14808,9 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/space,
 /area/security/prison)
@@ -14860,14 +14864,14 @@
 /area/maintenance/second_deck/afs)
 "Lf" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/maintenance/second_deck/fs)
@@ -14897,9 +14901,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
@@ -14939,20 +14943,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
-"LB" = (
-/obj/machinery/seed_extractor,
-/obj/effect/floor_decal/corner/red/full,
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "LC" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
@@ -15033,8 +15032,8 @@
 /area/chapel)
 "LY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -15057,12 +15056,12 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
@@ -15073,9 +15072,9 @@
 "Mi" = (
 /obj/machinery/vending/fitness,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /obj/effect/floor_decal/corner/black/border,
 /obj/machinery/alarm{
@@ -15101,8 +15100,8 @@
 /area/civilian/exercise)
 "Mq" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
@@ -15126,24 +15125,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/airless,
 /area/maintenance/second_deck/afp)
-"MB" = (
-/obj/structure/hygiene/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "MD" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -15154,17 +15135,17 @@
 /area/chapel)
 "MG" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
@@ -15184,8 +15165,8 @@
 /area/maintenance/second_deck/fp)
 "MQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15203,8 +15184,8 @@
 /area/hallway/aft/second_deck)
 "MV" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15285,9 +15266,9 @@
 /area/security/prison)
 "Nu" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/security/prison)
@@ -15306,9 +15287,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -15326,22 +15307,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"NN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/synthesized_instrument/synthesizer/piano,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "NO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Second Deck Substation";
 	req_access = list(10)
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -15357,9 +15331,9 @@
 "NT" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -15376,12 +15350,12 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -15405,8 +15379,8 @@
 /area/hallway/aft/second_deck)
 "NY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15426,8 +15400,8 @@
 /area/civilian/entertainer)
 "Ob" = (
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -15454,10 +15428,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"Of" = (
-/obj/structure/bed/chair/wood,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "Ok" = (
 /obj/random/junk,
 /obj/structure/disposalpipe/segment,
@@ -15465,12 +15435,12 @@
 /area/logistics/auxtool)
 "Op" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -15521,6 +15491,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"OB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/prison)
 "OC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -15536,6 +15516,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"OL" = (
+/obj/machinery/seed_extractor,
+/obj/effect/floor_decal/corner/red/full,
+/turf/simulated/floor/tiled/dark,
+/area/security/prison)
 "Pe" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -15548,9 +15533,9 @@
 "Pg" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15585,16 +15570,16 @@
 /area/hallway/aft/second_deck)
 "Ps" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "PA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15611,8 +15596,8 @@
 "PC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
@@ -15631,17 +15616,17 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
 "PP" = (
 /obj/structure/window/reinforced/tinted{
-	tag = "icon-window (WEST)";
+	dir = 8;
 	icon_state = "window";
-	dir = 8
+	tag = "icon-window (WEST)"
 	},
 /obj/item/weapon/stool/padded,
 /obj/item/device/radio/intercom{
@@ -15665,9 +15650,9 @@
 /area/civilian/entertainer)
 "PT" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -15710,8 +15695,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
@@ -15720,9 +15705,9 @@
 	sortType = "Captain"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
@@ -15731,8 +15716,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -15752,6 +15737,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
+"Qm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "Qo" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Second Deck"
@@ -15768,22 +15760,22 @@
 /area/engineering/substation/second_deck)
 "Qv" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 8
+	dir = 8;
+	icon_state = "chapel"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "Qw" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
+	dir = 4;
 	icon_state = "bordercolor";
-	dir = 4
+	tag = "icon-bordercolor (EAST)"
 	},
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
+	dir = 1;
 	icon_state = "bordercolor";
-	dir = 1
+	tag = "icon-bordercolor (NORTH)"
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -15797,9 +15789,9 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -15829,20 +15821,6 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/prison)
-"QK" = (
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
 /area/security/prison)
 "QM" = (
 /obj/structure/ladder,
@@ -15875,9 +15853,9 @@
 /area/civilian/entertainer)
 "QV" = (
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
@@ -15897,8 +15875,8 @@
 /area/civilian/entertainer)
 "Ri" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-stickyweb2";
-	icon_state = "stickyweb2"
+	icon_state = "stickyweb2";
+	tag = "icon-stickyweb2"
 	},
 /obj/structure/closet/crate,
 /obj/random/maintenance,
@@ -15914,8 +15892,8 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/wood,
@@ -15937,15 +15915,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
+"Rl" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/prison)
 "RB" = (
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/hallway/aft/second_deck)
 "RC" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/blast/regular{
@@ -15981,8 +15977,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
@@ -16010,16 +16006,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "RT" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -16033,9 +16029,9 @@
 /area/civilian/lounge)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16050,20 +16046,35 @@
 /area/hallway/fore/second_deck)
 "Sh" = (
 /obj/item/modular_computer/console/preset/library{
-	icon_state = "console";
-	dir = 1
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "Sn" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
+/area/security/prison)
+"St" = (
+/obj/effect/floor_decal/corner/red/three_quarters,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16075,23 +16086,23 @@
 /area/maintenance/second_deck/fp)
 "SS" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair_preview (NORTH)";
+	dir = 1;
 	icon_state = "wooden_chair_preview";
-	dir = 1
+	tag = "icon-wooden_chair_preview (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/civilian/lounge)
 "ST" = (
 /obj/structure/hygiene/shower{
-	icon_state = "shower";
 	dir = 8;
+	icon_state = "shower";
 	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
@@ -16099,9 +16110,9 @@
 /obj/structure/fitness/punchingbag,
 /obj/effect/floor_decal/corner/black/border,
 /obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
+	dir = 8;
 	icon_state = "bordercolor";
-	dir = 8
+	tag = "icon-bordercolor (WEST)"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -16117,13 +16128,13 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -16134,8 +16145,8 @@
 /area/maintenance/second_deck/afp)
 "TA" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -16151,6 +16162,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"TH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/synthesized_instrument/synthesizer/piano,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "TM" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -16160,14 +16178,14 @@
 	name = "Teleporter Blast Door Control"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
@@ -16198,6 +16216,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
+"TV" = (
+/obj/item/stack/material/wood/ten,
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
+"TW" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/item/seeds/potatoseed,
+/obj/item/seeds/wheatseed,
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 8
+	},
+/obj/machinery/camera/network/prison{
+	c_tag = "Prison Hydroponics";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/prison)
 "Ub" = (
 /obj/machinery/vending/tool,
 /turf/simulated/floor/tiled,
@@ -16223,8 +16258,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
@@ -16251,25 +16286,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Uy" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/item/seeds/cornseed,
-/obj/item/seeds/cornseed,
-/obj/item/seeds/tobaccoseed,
-/obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (NORTHEAST)";
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "UA" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -16281,8 +16301,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
@@ -16321,9 +16341,9 @@
 /area/maintenance/second_deck/fp)
 "UQ" = (
 /obj/machinery/light_construct{
-	tag = "icon-tube-construct-stage1 (EAST)";
+	dir = 4;
 	icon_state = "tube-construct-stage1";
-	dir = 4
+	tag = "icon-tube-construct-stage1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
@@ -16378,9 +16398,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
@@ -16395,8 +16415,8 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light_construct{
-	icon_state = "tube-construct-stage1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube-construct-stage1"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
@@ -16404,17 +16424,17 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
@@ -16431,8 +16451,8 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
@@ -16448,8 +16468,8 @@
 /area/civilian/counselor)
 "Wd" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -16458,12 +16478,12 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
@@ -16517,6 +16537,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
+"Ww" = (
+/obj/machinery/biogenerator,
+/obj/effect/floor_decal/corner/red/full,
+/turf/simulated/floor/tiled/dark,
+/area/security/prison)
 "Wz" = (
 /obj/structure/closet/firecloset,
 /obj/structure/catwalk,
@@ -16551,9 +16576,9 @@
 /area/civilian/counselor)
 "WN" = (
 /obj/machinery/light_construct{
-	tag = "icon-tube-construct-stage1 (EAST)";
+	dir = 4;
 	icon_state = "tube-construct-stage1";
-	dir = 4
+	tag = "icon-tube-construct-stage1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
@@ -16574,6 +16599,15 @@
 /obj/item/stack/tile/floor,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
+"WX" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/pen,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood,
+/area/civilian/lounge)
 "WY" = (
 /obj/machinery/power/sensor{
 	name_tag = "Atmospherics Power"
@@ -16583,8 +16617,8 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -16607,13 +16641,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
@@ -16646,9 +16680,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -16662,9 +16696,9 @@
 "Xt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -16676,11 +16710,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
-"Xy" = (
-/obj/machinery/biogenerator,
-/obj/effect/floor_decal/corner/red/full,
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "XF" = (
 /obj/machinery/light,
 /obj/item/weapon/caution/cone,
@@ -16692,8 +16721,8 @@
 /area/civilian/entertainer)
 "XJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16718,9 +16747,9 @@
 "XM" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/machinery/door/blast/regular{
 	dir = 2;
@@ -16775,24 +16804,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"Yf" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "Yj" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -16805,8 +16816,8 @@
 "Yl" = (
 /obj/random/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16837,14 +16848,21 @@
 /area/maintenance/second_deck/fp)
 "Yt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"YB" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/security/prison)
 "YF" = (
 /obj/random/toolbox,
 /turf/simulated/floor/airless,
@@ -16852,8 +16870,8 @@
 "YN" = (
 /obj/item/weapon/caution/cone,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16872,9 +16890,9 @@
 /area/logistics/auxtool)
 "YO" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -16884,8 +16902,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/newscaster{
 	hitstaken = 1;
@@ -16893,9 +16911,9 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -16903,32 +16921,13 @@
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
-"Zi" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/security/prison)
 "Zm" = (
 /obj/structure/bed/nice,
 /obj/item/weapon/bedsheet/white,
 /obj/item/weapon/broken_bottle,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -16944,12 +16943,12 @@
 /area/maintenance/second_deck/fs)
 "ZA" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -16967,18 +16966,12 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/security/prison)
-"ZP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+"ZM" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
-/turf/simulated/floor/reinforced,
-/area/security/prison)
-"ZQ" = (
-/turf/simulated/floor/reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "ZW" = (
 /obj/random/tool,
@@ -40926,9 +40919,9 @@ iw
 jp
 ke
 lj
-me
-nd
-BX
+Ca
+Qm
+he
 hJ
 iK
 iK
@@ -41127,10 +41120,10 @@ hK
 jq
 iz
 kf
-ix
-ix
-ix
-ix
+iz
+iz
+iz
+iz
 hK
 iK
 iK
@@ -41330,9 +41323,9 @@ Gn
 kg
 iz
 iz
-ix
-lo
-ix
+iz
+TV
+iz
 hK
 iK
 qJ
@@ -41534,7 +41527,7 @@ iz
 lk
 RU
 Zh
-nW
+Cc
 hK
 pI
 qK
@@ -41932,7 +41925,7 @@ fj
 ge
 gX
 hK
-NN
+TH
 iz
 iz
 jq
@@ -42134,7 +42127,7 @@ fk
 ge
 gZ
 hK
-ki
+eI
 iz
 iy
 mg
@@ -42336,8 +42329,8 @@ fj
 ge
 gX
 hK
-iA
-ix
+He
+iz
 iy
 Xd
 kg
@@ -42538,9 +42531,9 @@ fi
 ge
 gW
 hM
-ix
-ix
-Of
+iz
+iz
+iy
 ln
 SS
 UW
@@ -42740,9 +42733,9 @@ fi
 gf
 gY
 hK
-iB
-ix
-ix
+GJ
+iz
+iz
 LC
 iz
 ng
@@ -42942,10 +42935,10 @@ Ov
 gj
 gZ
 hK
-iC
-ix
-ix
-lo
+WX
+iz
+iz
+TV
 iz
 JE
 Sh
@@ -43146,8 +43139,8 @@ hb
 hK
 MI
 iz
-ki
-ki
+eI
+eI
 iz
 ni
 od
@@ -43347,9 +43340,9 @@ ge
 gZ
 hJ
 iE
-jt
-kj
-lp
+AL
+El
+AF
 mi
 nj
 oe
@@ -44543,9 +44536,9 @@ ah
 ah
 ah
 AE
-GS
-EJ
-Al
+TW
+YB
+St
 EQ
 Pe
 XL
@@ -44745,9 +44738,9 @@ ah
 ah
 ah
 AE
-Uy
-ZQ
-Zi
+AM
+Cm
+HK
 HJ
 ZK
 Kz
@@ -44948,8 +44941,8 @@ ah
 ah
 KL
 CO
-ZP
-Yf
+OB
+Rl
 EQ
 EQ
 Up
@@ -45149,9 +45142,9 @@ ah
 ah
 ah
 AE
-MB
-Fg
-QK
+CC
+ZM
+CW
 Eg
 PC
 Hh
@@ -45352,8 +45345,8 @@ ah
 ah
 AE
 AE
-LB
-Xy
+OL
+Ww
 AE
 Zm
 KV

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -56,8 +56,8 @@
 /area/hallway/centralfirst)
 "ak" = (
 /obj/structure/sign/warning/docking_area{
-	icon_state = "securearea";
-	dir = 1
+	dir = 1;
+	icon_state = "securearea"
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/centralfirst)
@@ -106,8 +106,8 @@
 	req_access = list(13)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -140,8 +140,8 @@
 /area/hallway/centralfirst)
 "at" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -160,8 +160,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -177,24 +177,24 @@
 /area/hallway/centralfirst)
 "ax" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/centralfirst)
 "ay" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "az" = (
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 4
+	dir = 4;
+	icon_state = "handrail"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -252,9 +252,9 @@
 	req_access = list(13)
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -288,9 +288,9 @@
 	id_tag = "security_pump3"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHWEST)";
+	dir = 9;
 	icon_state = "warning";
-	dir = 9
+	tag = "icon-warning (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -301,9 +301,9 @@
 	id_tag = "security_pump3"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -327,9 +327,9 @@
 /area/maintenance/first_deck/afp)
 "aO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -338,31 +338,31 @@
 /area/hallway/centralfirst)
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "aQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -373,13 +373,13 @@
 /area/hallway/centralfirst)
 "aR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -390,13 +390,13 @@
 /area/hallway/centralfirst)
 "aS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Port Hallway - Docking";
@@ -412,9 +412,9 @@
 "aT" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -447,17 +447,17 @@
 /area/hallway/centralfirst)
 "aW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "aX" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -475,8 +475,8 @@
 	req_access = list(13)
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -493,9 +493,9 @@
 	id_tag = "security_pump3"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHWEST)";
+	dir = 10;
 	icon_state = "warning";
-	dir = 10
+	tag = "icon-warning (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -506,9 +506,9 @@
 	id_tag = "security_pump3"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -569,8 +569,8 @@
 /area/hallway/centralfirst)
 "bk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/centralfirst)
@@ -644,9 +644,9 @@
 	icon_state = "intact"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/item/trash/cigbutt/rand,
 /turf/simulated/floor/plating,
@@ -661,8 +661,8 @@
 /area/maintenance/first_deck/central)
 "bx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -681,9 +681,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afp)
@@ -783,9 +783,9 @@
 /area/maintenance/first_deck/afp)
 "bR" = (
 /obj/structure/bed/chair/office/dark{
-	tag = "icon-officechair_preview (WEST)";
+	dir = 8;
 	icon_state = "officechair_preview";
-	dir = 8
+	tag = "icon-officechair_preview (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afp)
@@ -822,9 +822,9 @@
 /area/maintenance/first_deck/central)
 "bX" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -1089,8 +1089,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
@@ -1178,8 +1178,8 @@
 	pixel_y = 25
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/dockingcheckpoint)
@@ -1188,8 +1188,8 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1264,9 +1264,9 @@
 /obj/random/soap,
 /obj/structure/scrap,
 /obj/machinery/light_construct{
-	tag = "icon-tube-construct-stage1 (EAST)";
+	dir = 4;
 	icon_state = "tube-construct-stage1";
-	dir = 4
+	tag = "icon-tube-construct-stage1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/abandonedwarehouse)
@@ -1355,9 +1355,9 @@
 /area/security/dockingcheckpoint)
 "db" = (
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -1381,8 +1381,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated,
 /obj/structure/cable{
@@ -1444,8 +1444,8 @@
 /area/civilian/abandonedwarehouse)
 "dh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -1476,9 +1476,9 @@
 "dm" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/orange{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/solar/main)
@@ -1560,15 +1560,15 @@
 /area/maintenance/first_deck/fp)
 "ds" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "security_pump";
-	tag_exterior_door = "security_outer";
 	frequency = 1379;
 	id_tag = "security_airlock";
-	tag_interior_door = "security_inner";
 	pixel_x = 0;
 	pixel_y = 25;
 	req_access = list(13);
-	tag_chamber_sensor = "security_sensor"
+	tag_airpump = "security_pump";
+	tag_chamber_sensor = "security_sensor";
+	tag_exterior_door = "security_outer";
+	tag_interior_door = "security_inner"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -1597,8 +1597,8 @@
 /area/maintenance/first_deck/fp)
 "du" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -1629,9 +1629,9 @@
 "dw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fp)
@@ -1667,9 +1667,9 @@
 /area/security/dockingcheckpoint)
 "dB" = (
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -1705,8 +1705,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -1807,9 +1807,9 @@
 "dR" = (
 /obj/structure/ladder,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fp)
@@ -1836,8 +1836,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/first_emergency_storage)
@@ -1889,9 +1889,9 @@
 /area/security/dockingcheckpoint)
 "dY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -1900,13 +1900,13 @@
 /area/security/dockingcheckpoint)
 "dZ" = (
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1919,8 +1919,8 @@
 	req_access = list(1)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1936,8 +1936,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -2028,8 +2028,8 @@
 "en" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -2045,9 +2045,9 @@
 /area/civilian/first_emergency_storage)
 "ep" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -2161,8 +2161,8 @@
 /area/command/aicore)
 "eC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fp)
@@ -2210,17 +2210,17 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
 "eG" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -2239,8 +2239,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afp)
@@ -2283,15 +2283,15 @@
 /area/hallway/centralfirst)
 "eM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -2307,9 +2307,9 @@
 /area/maintenance/mainsolar)
 "eR" = (
 /obj/structure/cable/orange{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/orange{
@@ -2373,8 +2373,8 @@
 	pixel_y = 23
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -2385,9 +2385,9 @@
 	id_tag = "nuke_shuttle_dock_pump"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -2497,8 +2497,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2508,8 +2508,8 @@
 /area/hallway/centralfirst)
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2522,8 +2522,8 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2533,8 +2533,8 @@
 "fk" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2544,17 +2544,17 @@
 "fl" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -2577,9 +2577,9 @@
 /area/maintenance/first_deck/central)
 "fp" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -2593,8 +2593,8 @@
 /area/maintenance/first_deck/central)
 "fr" = (
 /obj/structure/sign/warning/airlock{
-	icon_state = "doors";
-	dir = 8
+	dir = 8;
+	icon_state = "doors"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/mainsolar)
@@ -2605,10 +2605,10 @@
 	pixel_y = 0
 	},
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Solar - Main";
 	capacity = 1e+007;
 	charge = 0;
-	cur_coils = 4;
-	RCon_tag = "Solar - Main"
+	cur_coils = 4
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = 23
@@ -2640,14 +2640,14 @@
 /area/maintenance/mainsolar)
 "fv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-supply";
-	dir = 6
+	tag = "icon-intact-supply (SOUTHEAST)"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -2687,12 +2687,12 @@
 /area/command/aicore)
 "fA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -2718,9 +2718,9 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -2734,17 +2734,17 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
 "fF" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHWEST)";
+	dir = 10;
 	icon_state = "warning";
-	dir = 10
+	tag = "icon-warning (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -2755,9 +2755,9 @@
 	id_tag = "nuke_shuttle_dock_pump"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -2800,8 +2800,8 @@
 /area/hallway/centralfirst)
 "fK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
@@ -2830,8 +2830,8 @@
 /area/hallway/centralfirst)
 "fM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
@@ -2921,8 +2921,8 @@
 "fV" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -2935,8 +2935,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -2947,17 +2947,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "fY" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2994,13 +2994,13 @@
 "gc" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -3014,9 +3014,9 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -3127,8 +3127,8 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/mainsolar)
@@ -3175,9 +3175,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/orange{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/solar/main)
@@ -3229,9 +3229,9 @@
 /area/security/topgun)
 "gu" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -3259,8 +3259,8 @@
 "gw" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -3384,8 +3384,8 @@
 /area/maintenance/first_deck/central)
 "gO" = (
 /obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 8
+	dir = 8;
+	icon_state = "shock"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/mainsolar)
@@ -3483,9 +3483,9 @@
 "ha" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/first_deck_lobby)
@@ -3529,9 +3529,9 @@
 /area/hallway/centralfirst)
 "hg" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3546,9 +3546,9 @@
 /area/hallway/centralfirst)
 "hh" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva3 (NORTH)";
+	dir = 1;
 	icon_state = "nerva3";
-	dir = 1
+	tag = "icon-nerva3 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -3557,9 +3557,9 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/hallway/centralfirst)
@@ -3629,8 +3629,8 @@
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -3664,25 +3664,25 @@
 /area/command/aicore)
 "hu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
 "hv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -3724,8 +3724,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3744,9 +3744,9 @@
 /area/civilian/first_deck_lobby)
 "hB" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2 (NORTH)";
+	dir = 1;
 	icon_state = "nerva2";
-	dir = 1
+	tag = "icon-nerva2 (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3761,17 +3761,17 @@
 /area/hallway/centralfirst)
 "hC" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "hD" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing/mapped,
 /obj/structure/sign/directions/evac{
@@ -3793,9 +3793,9 @@
 /obj/structure/closet/walllocker/emerglocker/west,
 /obj/structure/closet/firecloset,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/first_deck_atmos)
@@ -3830,9 +3830,9 @@
 /area/maintenance/first_deck/central)
 "hJ" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3840,13 +3840,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -3972,9 +3972,9 @@
 /area/maintenance/first_deck/central)
 "hQ" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/reinforced/airless,
@@ -4042,9 +4042,9 @@
 /area/command/aicore)
 "hW" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/status_display{
@@ -4069,16 +4069,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
 "hZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -4091,12 +4091,12 @@
 /area/security/topgun)
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/topgun)
@@ -4116,8 +4116,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Lobby";
@@ -4170,8 +4170,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated,
@@ -4212,9 +4212,9 @@
 /area/maintenance/first_deck/central)
 "im" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4271,8 +4271,8 @@
 /area/engineering/first_deck_atmos)
 "ir" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
@@ -4297,8 +4297,8 @@
 /area/maintenance/first_deck/central)
 "iu" = (
 /obj/structure/sign/warning/airlock{
-	icon_state = "doors";
-	dir = 8
+	dir = 8;
+	icon_state = "doors"
 	},
 /turf/simulated/wall,
 /area/maintenance/first_deck/central)
@@ -4313,9 +4313,9 @@
 /area/maintenance/first_deck/central)
 "iw" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/camera/network/command{
@@ -4326,9 +4326,9 @@
 /area/maintenance/first_deck/fs)
 "ix" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/aicore)
@@ -4338,25 +4338,25 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
 "iz" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Aft";
@@ -4377,12 +4377,12 @@
 "iB" = (
 /obj/machinery/ai_slipper,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -4473,17 +4473,17 @@
 "iH" = (
 /obj/machinery/status_display,
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/aicore)
 "iI" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/porta_turret{
 	dir = 8
@@ -4498,13 +4498,13 @@
 "iJ" = (
 /obj/machinery/ai_slipper,
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -4540,13 +4540,13 @@
 /area/command/aicore)
 "iM" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/aicore)
@@ -4577,8 +4577,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -4628,8 +4628,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/first_deck_lobby)
@@ -4710,8 +4710,8 @@
 	pixel_y = 1
 	},
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 1
+	dir = 1;
+	icon_state = "map_connector"
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -4728,26 +4728,26 @@
 /area/maintenance/first_deck/central)
 "jg" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "jh" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/item/trash/cigbutt/rand,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "ji" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -4790,8 +4790,8 @@
 /area/command/aicore)
 "jn" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/table/steel_reinforced,
 /obj/structure/cable/yellow{
@@ -4823,9 +4823,9 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -4870,9 +4870,9 @@
 /area/civilian/first_deck_lobby)
 "ju" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4889,16 +4889,16 @@
 "jv" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/first_deck_lobby)
 "jw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -4972,9 +4972,9 @@
 /area/command/aicore)
 "jF" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4991,9 +4991,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -5047,9 +5047,9 @@
 /area/maintenance/first_deck/afs)
 "jL" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5082,8 +5082,8 @@
 "jN" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5099,13 +5099,13 @@
 "jO" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Central Maintenance APC"
@@ -5115,23 +5115,23 @@
 "jP" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "down-scrubbers";
-	dir = 8
+	tag = "icon-down-scrubbers (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (WEST)";
+	dir = 8;
 	icon_state = "down-supply";
-	dir = 8
+	tag = "icon-down-supply (WEST)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/central)
 "jQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5153,9 +5153,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-supply";
-	dir = 6
+	tag = "icon-intact-supply (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5171,9 +5171,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5190,9 +5190,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5209,9 +5209,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5224,16 +5224,16 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5253,9 +5253,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5267,17 +5267,17 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5290,8 +5290,8 @@
 "ka" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/modular_computer/console/preset/civilian{
-	icon_state = "console";
-	dir = 1
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/aicore)
@@ -5305,8 +5305,8 @@
 "kc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/modular_computer/console/preset/research{
-	icon_state = "console";
-	dir = 1
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/aicore)
@@ -5362,8 +5362,8 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/topgun)
@@ -5386,8 +5386,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -5409,9 +5409,9 @@
 /area/maintenance/first_deck/afs)
 "km" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2 (NORTH)";
+	dir = 1;
 	icon_state = "nerva2";
-	dir = 1
+	tag = "icon-nerva2 (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5429,9 +5429,9 @@
 /area/hallway/centralfirst)
 "kn" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5671,9 +5671,9 @@
 /area/maintenance/first_deck/fs)
 "kL" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/reinforced/airless,
@@ -5685,21 +5685,21 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
 "kN" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5711,13 +5711,13 @@
 /area/command/aicore)
 "kO" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5726,13 +5726,13 @@
 /area/command/aicore)
 "kP" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5745,9 +5745,9 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5764,13 +5764,13 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -5787,8 +5787,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -5805,8 +5805,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -5887,8 +5887,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5903,13 +5903,13 @@
 /area/hallway/centralfirst)
 "lb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5925,13 +5925,13 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5944,13 +5944,13 @@
 "ld" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5963,13 +5963,13 @@
 "le" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5978,8 +5978,8 @@
 	tag = ""
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6014,8 +6014,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6032,8 +6032,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6047,13 +6047,13 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6148,9 +6148,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -6252,14 +6252,14 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6280,9 +6280,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6299,9 +6299,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -6317,9 +6317,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -6335,9 +6335,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
@@ -6350,13 +6350,13 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -6389,13 +6389,13 @@
 	},
 /obj/machinery/light/small/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -6429,12 +6429,12 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -6456,12 +6456,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -6475,8 +6475,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6501,8 +6501,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6530,8 +6530,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/first_deck_storage)
@@ -6570,8 +6570,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6590,8 +6590,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6619,8 +6619,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -6676,9 +6676,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6823,9 +6823,9 @@
 /area/maintenance/first_deck/central)
 "my" = (
 /obj/structure/bed/chair/office/comfy/black{
-	tag = "icon-comfyofficechair_preview (EAST)";
+	dir = 4;
 	icon_state = "comfyofficechair_preview";
-	dir = 4
+	tag = "icon-comfyofficechair_preview (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6903,9 +6903,9 @@
 /area/maintenance/first_deck/central)
 "mJ" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/closet,
 /obj/random/junk,
@@ -6924,9 +6924,9 @@
 "mM" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -6944,9 +6944,9 @@
 /area/maintenance/first_deck/fs)
 "mP" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	tag = "icon-air_map (WEST)";
+	dir = 8;
 	icon_state = "air_map";
-	dir = 8
+	tag = "icon-air_map (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -7060,54 +7060,54 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
 "mW" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "down-scrubbers";
-	dir = 4
+	tag = "icon-down-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (EAST)";
+	dir = 4;
 	icon_state = "down-supply";
-	dir = 4
+	tag = "icon-down-supply (EAST)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "32-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "32-4"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/afs)
 "mX" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -7225,9 +7225,9 @@
 /area/maintenance/first_deck/central)
 "nh" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -7237,9 +7237,9 @@
 "ni" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -7249,9 +7249,9 @@
 /area/maintenance/first_deck/central)
 "nj" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -7261,9 +7261,9 @@
 /area/maintenance/first_deck/central)
 "nk" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -7274,9 +7274,9 @@
 /area/maintenance/first_deck/central)
 "nl" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -7287,9 +7287,9 @@
 /area/maintenance/first_deck/central)
 "nm" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -7299,17 +7299,17 @@
 "nn" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "no" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -7327,13 +7327,13 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -7349,9 +7349,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -7368,9 +7368,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/random/tool,
 /turf/simulated/floor/plating,
@@ -7453,12 +7453,12 @@
 	dir = 4
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -7571,9 +7571,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/orange{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/solar/auxaft)
@@ -7585,8 +7585,8 @@
 	},
 /obj/item/device/radio,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
@@ -7620,8 +7620,8 @@
 /area/engineering/substation/first_deck)
 "nR" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -7707,8 +7707,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -7769,9 +7769,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -7797,8 +7797,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -7810,9 +7810,9 @@
 /area/security/abandonedcheckpoint)
 "oj" = (
 /obj/structure/bed/chair/office/dark{
-	tag = "icon-officechair_preview (WEST)";
+	dir = 8;
 	icon_state = "officechair_preview";
-	dir = 8
+	tag = "icon-officechair_preview (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/security/abandonedcheckpoint)
@@ -7846,9 +7846,9 @@
 /area/maintenance/first_deck/fs)
 "on" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /obj/structure/closet/crate,
 /obj/random/bomb_supply,
@@ -7919,14 +7919,14 @@
 /area/security/abandonedcheckpoint)
 "ox" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -7955,9 +7955,9 @@
 /area/maintenance/first_deck/central)
 "oB" = (
 /obj/structure/bed/chair/office/comfy/black{
-	tag = "icon-comfyofficechair_preview (EAST)";
+	dir = 4;
 	icon_state = "comfyofficechair_preview";
-	dir = 4
+	tag = "icon-comfyofficechair_preview (EAST)"
 	},
 /obj/effect/landmark/start{
 	name = "Stowaway"
@@ -7989,9 +7989,9 @@
 /area/space)
 "oG" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -8012,8 +8012,8 @@
 /area/maintenance/first_deck/afs)
 "oJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -8022,13 +8022,13 @@
 /area/hallway/centralfirst)
 "oK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -8039,25 +8039,25 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/security/abandonedcheckpoint)
 "oM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Abandoned Checkpoint";
@@ -8067,13 +8067,13 @@
 /area/security/abandonedcheckpoint)
 "oN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -8212,9 +8212,9 @@
 "pg" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/central)
@@ -8224,9 +8224,9 @@
 /area/maintenance/first_deck/central)
 "pi" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/open,
@@ -8348,16 +8348,16 @@
 	id_tag = "robotics_solar_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "robotics_solar_pump";
-	tag_exterior_door = "robotics_solar_outer";
 	frequency = 1379;
 	id_tag = "robotics_solar_airlock";
-	tag_interior_door = "robotics_solar_inner";
 	layer = 3.3;
 	pixel_x = 0;
 	pixel_y = -25;
 	req_access = list(13);
-	tag_chamber_sensor = "robotics_solar_sensor"
+	tag_airpump = "robotics_solar_pump";
+	tag_chamber_sensor = "robotics_solar_sensor";
+	tag_exterior_door = "robotics_solar_outer";
+	tag_interior_door = "robotics_solar_inner"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
@@ -8373,8 +8373,8 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aftsolar)
@@ -8414,9 +8414,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/orange{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/catwalk,
@@ -8424,9 +8424,9 @@
 /area/maintenance/aftsolar)
 "pv" = (
 /obj/structure/cable/orange{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
@@ -8462,18 +8462,18 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aftsolar)
 "py" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8493,45 +8493,45 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
 "pA" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/afs)
 "pB" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/afs)
 "pC" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/afs)
@@ -8545,9 +8545,9 @@
 /area/hallway/centralfirst)
 "pE" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -8566,8 +8566,8 @@
 /area/maintenance/first_deck/central)
 "pG" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -8583,9 +8583,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/orange{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -8650,18 +8650,18 @@
 /area/maintenance/first_deck/afs)
 "pN" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
 "pO" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /obj/random/junk,
@@ -8669,18 +8669,18 @@
 /area/maintenance/first_deck/afs)
 "pP" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
 "pQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated,
@@ -8693,8 +8693,8 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -8706,9 +8706,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -8729,9 +8729,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -8783,18 +8783,18 @@
 	req_access = list(12)
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
 "qc" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -8803,9 +8803,9 @@
 /area/hallway/centralfirst)
 "qd" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -8818,9 +8818,9 @@
 	req_access = list(12)
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -8871,9 +8871,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -8909,16 +8909,16 @@
 	req_access = list(13)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "qp" = (
 /obj/structure/cable/orange{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/orange{
 	d1 = 1;


### PR DESCRIPTION
##About the Pull Request.

Large picture - Adds in various new stuff and life to the Nerva map. Last big change was the Brig back in 2019?/2020.

- Adds in a finished version of the library because we have an actual librarian now! Wooo!

- Accidentaly removed the reinforced plating above the armory before adding a new commit that FIXES THAT WOOPS

- Replaces Aux Storage with a journalists office. Currently has no access requirement (until I get a response from Glloyd on journalist access)

- Makes the other observatory that was previously breached and held together by two inflatables and duct tape sealed. On a further note, thefts via Vox Raiders have gone down by 100%.

- Gives the Clown and Mime rooms an actual floor and carpet.