### PR TITLE
Nerva Map Tweaking - Chaplain, Saferoom, Bugfixing.

### DIFF
--- a/maps/nerva/datums/nerva_access_datums.dm
+++ b/maps/nerva/datums/nerva_access_datums.dm
@@ -39,3 +39,9 @@
 	id = access_seniornt
 	desc = "Senior Researcher"
 	region = ACCESS_REGION_COMMAND
+
+/var/const/access_chaplainarea = "ACCESS_CHAPELAREA" //77
+/datum/access/chaplainarea
+	id = access_chaplainarea
+	desc = "Chaplain"
+	region = ACCESS_REGION_GENERAL

--- a/maps/nerva/datums/nerva_jobs.dm
+++ b/maps/nerva/datums/nerva_jobs.dm
@@ -344,8 +344,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the second officer and the chief medical officer"
-	access = list(access_medical, access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels, access_psychiatrist)
-	minimal_access = list(access_medical, access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels, access_psychiatrist)
+	access = list(access_medical, access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels, access_psychiatrist, access_chaplainarea)
+	minimal_access = list(access_medical, access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels, access_psychiatrist, access_chaplainarea)
 	alt_titles = list(
 	"Counselor" = /decl/hierarchy/outfit/job/medical/psychiatrist/nerva,
 	"Morale Officer" = /decl/hierarchy/outfit/job/chaplain,

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -12730,6 +12730,9 @@
 	pixel_x = 0;
 	tag = ""
 	},
+/obj/item/weapon/gun/projectile/shotgun/pump/combat{
+	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "vZ" = (
@@ -14783,6 +14786,25 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"zu" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	icon_state = "rwindow"
+	},
+/obj/structure/table/rack,
+/obj/item/weapon/storage/box/ammo/beanbags,
+/obj/item/weapon/storage/box/ammo/beanbags,
+/obj/item/weapon/gun/projectile/shotgun/pump/combat{
+	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/combat{
+	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/space)
 "zv" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -15205,13 +15227,6 @@
 "Am" = (
 /obj/structure/closet,
 /obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fs)
-"An" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Firefighting equipment";
-	req_access = list("ACCESS_MAINT")
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Ao" = (
@@ -19160,6 +19175,13 @@
 /obj/effect/shuttle_landmark/skipjack/deck4,
 /turf/space,
 /area/space)
+"Hu" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/command/safe_room)
 "Hw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9;
@@ -19230,16 +19252,7 @@
 /turf/simulated/wall/titanium,
 /area/hadrian/storage)
 "HE" = (
-/obj/structure/closet/medical_wall/filled{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/random/firstaid,
-/obj/random/firstaid,
-/obj/item/bodybag/cryobag,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
-/obj/machinery/light,
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -20312,9 +20325,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "Kh" = (
-/obj/structure/curtain/open/bed,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/steel,
+/obj/item/bodybag/cryobag,
 /obj/effect/floor_decal/techfloor{
-	dir = 1;
+	dir = 8;
 	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -22391,6 +22408,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
+"Uv" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/command/safe_room)
 "Ux" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -22682,6 +22702,20 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"VV" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1;
+	icon_state = "corner_techfloor_grid"
+	},
+/turf/space,
+/area/space)
+"VW" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/command/safe_room)
 "VX" = (
 /obj/structure/table/rack{
 	dir = 1
@@ -22735,6 +22769,10 @@
 /obj/structure/bed/nice,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
+"Wd" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
+/area/command/safe_room)
 "Wj" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22817,21 +22855,16 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1;
-	icon_state = "corner_techfloor_grid"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1;
-	icon_state = "techfloor_corners"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0;
 	tag = ""
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
@@ -22954,7 +22987,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -22962,6 +22994,7 @@
 	pixel_x = 0;
 	tag = ""
 	},
+/obj/effect/floor_decal/corner_techfloor_grid,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "Xv" = (
@@ -22979,14 +23012,6 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1;
 	icon_state = "techfloor_edges"
-	},
-/obj/machinery/button/remote/airlock{
-	id = "bridgesafedoor";
-	name = "safe room door-control";
-	pixel_x = 0;
-	pixel_y = 32;
-	req_access = newlist();
-	specialfunctions = 4
 	},
 /obj/structure/bed/chair/padded/blue,
 /turf/simulated/floor/tiled/techmaint,
@@ -23046,6 +23071,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"XK" = (
+/turf/space,
+/area/maintenance/fourth_deck/fs)
 "XN" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -23432,7 +23460,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Zy" = (
-/obj/structure/bed/nice,
+/obj/structure/closet/medical_wall/filled{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/table/steel,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/effect/floor_decal/techfloor{
+	dir = 10;
+	icon_state = "techfloor_edges"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "ZA" = (
@@ -51748,7 +51786,7 @@ yC
 tM
 TR
 Ag
-rI
+BH
 sj
 BF
 Ch
@@ -52554,7 +52592,7 @@ oI
 zv
 sj
 sj
-An
+sj
 sj
 td
 sj
@@ -52755,9 +52793,9 @@ rO
 oI
 zt
 sj
-BH
+AX
+AY
 rI
-sj
 rI
 tO
 uQ
@@ -52957,9 +52995,9 @@ rO
 oI
 zv
 sj
-AX
-AY
-td
+AZ
+BI
+sj
 ZM
 tP
 Zw
@@ -53158,10 +53196,10 @@ wN
 rO
 oI
 zv
-sj
-AZ
-BI
-sj
+oI
+oI
+oI
+oI
 tR
 tQ
 uT
@@ -53359,9 +53397,9 @@ vX
 rO
 rO
 oI
-zv
-oI
-oI
+zw
+uX
+Ao
 oI
 oI
 oI
@@ -53561,11 +53599,11 @@ Wv
 Kh
 Zy
 oI
+oI
+oI
 zv
 oI
 BK
-oI
-oI
 oI
 oI
 Sh
@@ -53760,12 +53798,12 @@ oJ
 Kf
 dL
 HE
-rO
-rO
+Uv
+Wd
+oI
+oI
 oI
 zv
-oI
-oI
 oI
 oI
 oI
@@ -53962,13 +54000,13 @@ KC
 Oa
 TS
 Xt
-Kh
-Zy
+VW
+Hu
+oI
+oI
 oI
 zw
 Ao
-oI
-oI
 oI
 oI
 aa
@@ -54168,9 +54206,9 @@ ZD
 rO
 oI
 zx
+XK
+XK
 Ap
-oI
-oI
 oI
 aa
 aa
@@ -55979,11 +56017,11 @@ aa
 aa
 aa
 aa
+VV
 aa
 aa
 aa
-aa
-aa
+zu
 aa
 aa
 aa

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -8595,7 +8595,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/conveyor_switch/oneway{
-	id = "torpedo"
+	id = "torpedo2"
 	},
 /obj/item/device/radio/intercom{
 	dir = 2;
@@ -9745,7 +9745,7 @@
 "qO" = (
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "torpedo"
+	id = "torpedo2"
 	},
 /obj/structure/shipammo/torpedo/loaded,
 /obj/effect/floor_decal/industrial/warning{
@@ -9756,7 +9756,7 @@
 "qP" = (
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "torpedo"
+	id = "torpedo2"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 6;
@@ -10439,7 +10439,7 @@
 	},
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "torpedo"
+	id = "torpedo2"
 	},
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -10751,7 +10751,7 @@
 	},
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "torpedo"
+	id = "torpedo2"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -11285,7 +11285,7 @@
 	},
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "torpedo"
+	id = "torpedo2"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -14786,25 +14786,6 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
-"zu" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/structure/table/rack,
-/obj/item/weapon/storage/box/ammo/beanbags,
-/obj/item/weapon/storage/box/ammo/beanbags,
-/obj/item/weapon/gun/projectile/shotgun/pump/combat{
-	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
-	},
-/obj/item/weapon/gun/projectile/shotgun/pump/combat{
-	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/space)
 "zv" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -15237,14 +15218,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
-"Ap" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small/red,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fs)
 "Aq" = (
 /obj/structure/catwalk,
 /obj/machinery/door/blast/regular/open{
@@ -15626,13 +15599,6 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fs)
-"AZ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/weapon/stool/padded,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Ba" = (
@@ -19180,6 +19146,7 @@
 	dir = 6;
 	icon_state = "techfloor_edges"
 	},
+/obj/structure/bed/nice,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "Hw" = (
@@ -20322,6 +20289,10 @@
 	dir = 4;
 	icon_state = "chair_preview"
 	},
+/obj/machinery/light_switch{
+	pixel_x = -32;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "Kh" = (
@@ -20334,6 +20305,8 @@
 	dir = 8;
 	icon_state = "techfloor_edges"
 	},
+/obj/item/weapon/reagent_containers/ivbag/blood/OMinus,
+/obj/item/weapon/reagent_containers/ivbag/nanoblood,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "Ki" = (
@@ -21108,6 +21081,11 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fourth_deck/fs)
+"Ov" = (
+/obj/item/trash/cigbutt/rand,
+/obj/machinery/light/small/red,
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fs)
 "Ox" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/fadeblue{
@@ -21151,10 +21129,6 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 1;
 	icon_state = "techfloor_corners"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -32;
-	pixel_y = 24
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -22702,18 +22676,12 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
-"VV" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1;
-	icon_state = "corner_techfloor_grid"
-	},
-/turf/space,
-/area/space)
 "VW" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4;
 	icon_state = "techfloor_edges"
 	},
+/obj/structure/iv_drip,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "VX" = (
@@ -23014,6 +22982,15 @@
 	icon_state = "techfloor_edges"
 	},
 /obj/structure/bed/chair/padded/blue,
+/obj/machinery/button/remote/airlock{
+	desiredstate = 1;
+	id = "bridgesafedoor";
+	name = "safe room door-control";
+	pixel_x = -6;
+	pixel_y = 22;
+	req_access = list("ACCESS_BRIDGE");
+	specialfunctions = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "XC" = (
@@ -23071,9 +23048,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
-"XK" = (
-/turf/space,
-/area/maintenance/fourth_deck/fs)
 "XN" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -23140,6 +23114,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"Yk" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fs)
 "Ym" = (
 /obj/structure/closet/crate,
 /obj/random/powercell,
@@ -23147,6 +23127,7 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/walllocker/emerglocker/west,
+/obj/item/weapon/airlock_brace,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/safe_room)
 "Yp" = (
@@ -23293,6 +23274,9 @@
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
 	dir = 4;
 	icon_state = "corner_white_three_quarters"
+	},
+/obj/structure/sign/warning/secure_area{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -52795,7 +52779,7 @@ zt
 sj
 AX
 AY
-rI
+Yk
 rI
 tO
 uQ
@@ -52995,7 +52979,7 @@ rO
 oI
 zv
 sj
-AZ
+sj
 BI
 sj
 ZM
@@ -53195,13 +53179,13 @@ vW
 wN
 rO
 oI
-zv
-oI
+zw
+Ao
 oI
 oI
 oI
 tR
-tQ
+rI
 uT
 oI
 oI
@@ -53396,10 +53380,10 @@ rO
 vX
 rO
 rO
+rO
 oI
-zw
-uX
-Ao
+zv
+oI
 oI
 oI
 oI
@@ -53598,10 +53582,10 @@ IY
 Wv
 Kh
 Zy
-oI
-oI
+rO
 oI
 zv
+Ov
 oI
 BK
 oI
@@ -53800,10 +53784,10 @@ dL
 HE
 Uv
 Wd
-oI
-oI
+rO
 oI
 zv
+rI
 oI
 oI
 oI
@@ -54002,11 +53986,11 @@ TS
 Xt
 VW
 Hu
+rO
+oI
+zv
 oI
 oI
-oI
-zw
-Ao
 oI
 oI
 aa
@@ -54204,11 +54188,11 @@ ZT
 vY
 ZD
 rO
-oI
+rO
 zx
-XK
-XK
-Ap
+zv
+oI
+oI
 oI
 aa
 aa
@@ -54406,7 +54390,7 @@ rO
 rO
 rO
 rO
-oI
+rO
 oI
 Aq
 oI
@@ -56017,11 +56001,11 @@ aa
 aa
 aa
 aa
-VV
 aa
 aa
 aa
-zu
+aa
+aa
 aa
 aa
 aa

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -30107,28 +30107,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
-"sfT" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/stamp/captain,
-/obj/machinery/button/remote/blast_door{
-	id = "capofficeview";
-	name = "Office Blast Door Control";
-	pixel_x = 6;
-	pixel_y = 22;
-	req_access = list("ACCESS_CAPTAIN")
-	},
-/obj/machinery/button/remote/airlock{
-	desiredstate = 1;
-	id = "bridgesafedoor";
-	name = "safe room door-control";
-	pixel_x = -6;
-	pixel_y = 22;
-	req_access = list("ACCESS_BRIDGE");
-	specialfunctions = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/space)
 "smN" = (
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4;
@@ -63342,7 +63320,7 @@ aaa
 aaa
 aaa
 aaa
-sfT
+aaa
 aaa
 aaa
 aaa

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -14517,7 +14517,7 @@
 /area/civilian/kitchen)
 "ayy" = (
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Bar";
+	c_tag = "Bar Counter";
 	dir = 4
 	},
 /obj/structure/hygiene/sink{
@@ -29942,7 +29942,7 @@
 /area/security/portgun)
 "qiD" = (
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Chapel Mourge";
+	c_tag = "Bar";
 	dir = 8;
 	icon_state = "camera"
 	},

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -14003,7 +14003,7 @@
 /obj/machinery/button/remote/blast_door{
 	id = "bridgeoutlock";
 	name = "Bridge Outer Lockdown";
-	pixel_x = 0;
+	pixel_x = -5;
 	pixel_y = 5;
 	req_access = list("ACCESS_BRIDGE")
 	},

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -1369,6 +1369,7 @@
 /area/medical/morgue)
 "adi" = (
 /obj/machinery/button/crematorium{
+	id = 2;
 	pixel_x = 21;
 	pixel_y = 0
 	},
@@ -9769,6 +9770,15 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
+/obj/machinery/button/remote/airlock{
+	desiredstate = 1;
+	id = "bridgesafedoor";
+	name = "safe room door-control";
+	pixel_x = -6;
+	pixel_y = 22;
+	req_access = list("ACCESS_BRIDGE");
+	specialfunctions = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "aro" = (
@@ -28599,10 +28609,12 @@
 /area/security/portgun)
 "dvF" = (
 /obj/machinery/door/window/brigdoor/southright{
-	id = "Cell 3"
+	id = "Cell 3";
+	req_access = list("ACCESS_SECURITY")
 	},
 /obj/machinery/door/window/brigdoor/northleft{
-	id = "Cell 3"
+	id = "Cell 3";
+	req_access = list("ACCESS_SECURITY")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29072,10 +29084,12 @@
 /area/rnd/office)
 "grS" = (
 /obj/machinery/door/window/brigdoor/southright{
-	id = "Cell 2"
+	id = "Cell 2";
+	req_access = list("ACCESS_SECURITY")
 	},
 /obj/machinery/door/window/brigdoor/northleft{
-	id = "Cell 2"
+	id = "Cell 2";
+	req_access = list("ACCESS_SECURITY")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29928,7 +29942,7 @@
 /area/security/portgun)
 "qiD" = (
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Bar Main";
+	c_tag = "Chapel Mourge";
 	dir = 8;
 	icon_state = "camera"
 	},
@@ -30093,6 +30107,28 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
+"sfT" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/stamp/captain,
+/obj/machinery/button/remote/blast_door{
+	id = "capofficeview";
+	name = "Office Blast Door Control";
+	pixel_x = 6;
+	pixel_y = 22;
+	req_access = list("ACCESS_CAPTAIN")
+	},
+/obj/machinery/button/remote/airlock{
+	desiredstate = 1;
+	id = "bridgesafedoor";
+	name = "safe room door-control";
+	pixel_x = -6;
+	pixel_y = 22;
+	req_access = list("ACCESS_BRIDGE");
+	specialfunctions = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/space)
 "smN" = (
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4;
@@ -30138,10 +30174,12 @@
 /area/maintenance/third_deck/cents)
 "sCk" = (
 /obj/machinery/door/window/brigdoor/southright{
-	id = "Cell 1"
+	id = "Cell 1";
+	req_access = list("ACCESS_SECURITY")
 	},
 /obj/machinery/door/window/brigdoor/northleft{
-	id = "Cell 1"
+	id = "Cell 1";
+	req_access = list("ACCESS_SECURITY")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -63304,7 +63342,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sfT
 aaa
 aaa
 aaa

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -2245,20 +2245,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"fo" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "fp" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -5089,29 +5075,6 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
-"ky" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/machinery/button/windowtint{
-	dir = 4;
-	icon_state = "light0";
-	pixel_x = 24;
-	range = 5;
-	tag = "icon-light0 (EAST)"
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-18";
-	tag = "icon-plant-18"
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "kz" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/pinpointer,
@@ -13640,48 +13603,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
-"Bl" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4;
-	icon_state = "map_scrubber_on"
-	},
-/mob/living/simple_animal/cat/fluff/Runtime,
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Bm" = (
 /obj/item/weapon/material/shard,
 /turf/simulated/floor/plating,
 /area/civilian/observatory)
-"Bp" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/structure/closet/secure_closet/CMO,
-/obj/item/device/megaphone,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/suit/storage/hooded/wintercoat/medical,
-/obj/item/device/radio/medical,
-/obj/item/clothing/suit/storage/toggle/labcoat/cmo/alt,
-/obj/item/clothing/accessory/storage/white_vest,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/item/clothing/accessory/armband/bluegoldcom,
-/obj/item/clothing/accessory/armband/medblue,
-/obj/item/weapon/folder/white,
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Bt" = (
 /turf/simulated/wall/false{
 	density = 1;
@@ -13689,10 +13614,6 @@
 	opacity = 1
 	},
 /area/logistics/auxtool)
-"Bz" = (
-/obj/effect/paint_stripe/blue,
-/turf/simulated/wall/r_wall/prepainted,
-/area/space)
 "BC" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -13743,24 +13664,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"BL" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/folder/white{
-	pixel_y = 0
-	},
-/obj/item/weapon/pen,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Morgue";
-	dir = 4
-	},
-/obj/item/weapon/hand_labeler,
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "BM" = (
 /obj/effect/floor_decal/chapel{
 	tag = "icon-chapel (EAST)";
@@ -13875,20 +13778,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"Cp" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	icon_state = "intercom";
-	pixel_x = -28;
-	tag = "icon-intercom (EAST)"
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Cu" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -14068,17 +13957,6 @@
 /obj/random/toolbox,
 /turf/simulated/floor/wood/walnut,
 /area/logistics/auxtool)
-"DI" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "DN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -14279,18 +14157,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"EI" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "EJ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -14333,20 +14199,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/prison)
-"ES" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer";
-	name = "Chief Medical Officer RC";
-	pixel_y = -30
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "EW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14437,23 +14289,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"Fr" = (
-/obj/machinery/door/airlock/medical{
-	name = "Chief Medical Officer";
-	req_access = list("ACCESS_CHIEF_MEDICAL_OFFICER")
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/space)
 "Fu" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/flame/candle,
@@ -14508,13 +14343,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"FK" = (
-/obj/structure/morgue,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "FN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14539,15 +14367,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"FV" = (
-/obj/structure/table/glass,
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Medical Officer's Office";
-	dir = 8
-	},
-/obj/item/toy/desk/newtoncradle,
-/turf/simulated/floor/tiled/white,
-/area/space)
 "FX" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15241,12 +15060,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"JM" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/white,
-/area/space)
 "JQ" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -15518,9 +15331,7 @@
 /turf/simulated/floor/carpet,
 /area/chapel)
 "Lq" = (
-/obj/structure/closet,
-/obj/random/maintenance,
-/turf/simulated/floor/plating,
+/turf/space,
 /area/maintenance/third_deck/fp)
 "Ls" = (
 /obj/item/device/flashlight/lamp/lava/pink{
@@ -15903,17 +15714,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
-"Nf" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Ng" = (
 /obj/structure/table/rack{
 	desc = "A simple wooden altar covered in cloth.";
@@ -16249,17 +16049,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"OK" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Pb" = (
 /obj/structure/closet/coffin,
 /obj/structure/window/reinforced,
@@ -16312,25 +16101,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"Pp" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/machinery/disposal,
-/obj/machinery/light_switch{
-	dir = 4;
-	on = 1;
-	pixel_x = 25
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposalpipe/trunk{
-	dir = 1;
-	icon_state = "pipe-t"
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Ps" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	tag = "icon-corner_white (WEST)";
@@ -16441,13 +16211,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"PX" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bridge Maintenance";
-	req_access = list("ACCESS_BRIDGE")
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "Qa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -16779,28 +16542,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"RP" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/item/weapon/rig/medical/equipped,
-/obj/structure/table/rack,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/item/weapon/storage/belt/medical,
-/obj/item/weapon/storage/fancy/vials,
-/obj/item/weapon/storage/fancy/vials,
-/turf/simulated/floor/tiled/white,
-/area/space)
 "RR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16831,10 +16572,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"Sb" = (
-/obj/item/modular_computer/console/preset/medical,
-/turf/simulated/floor/tiled/white,
-/area/space)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	tag = "icon-intact-scrubbers (EAST)";
@@ -17819,23 +17556,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
-"Yv" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/machinery/keycard_auth{
-	pixel_y = -26
-	},
-/obj/effect/landmark/start{
-	name = "Chief Medical Officer"
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
 "YC" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -17851,43 +17571,6 @@
 "YF" = (
 /obj/random/toolbox,
 /turf/simulated/floor/airless,
-/area/space)
-"YG" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/structure/bed/chair,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (NORTHWEST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/space)
-"YM" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
 /area/space)
 "YN" = (
 /obj/item/weapon/caution/cone,
@@ -18053,11 +17736,6 @@
 "ZQ" = (
 /turf/simulated/floor/reinforced,
 /area/security/prison)
-"ZT" = (
-/obj/effect/wallframe_spawn/reinforced/polarized/full,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/space)
 "ZW" = (
 /obj/random/tool,
 /turf/simulated/floor/plating,
@@ -38803,8 +38481,8 @@ ah
 aa
 aa
 aa
-FK
-BL
+aa
+aa
 aa
 aa
 aa
@@ -39807,12 +39485,12 @@ Sl
 Sl
 ah
 ah
-Bz
-ck
-ck
-ck
-ck
-ck
+ah
+ah
+ah
+ah
+aa
+aa
 aa
 aa
 aa
@@ -40009,12 +39687,12 @@ Sl
 ah
 ah
 ah
-ZT
-RP
-EI
-Cp
-Nf
-PX
+ah
+ah
+ah
+ah
+aa
+aa
 aa
 aa
 aa
@@ -40211,12 +39889,12 @@ Sl
 ah
 ah
 ah
-ZT
-fo
-Bl
-Sb
-ES
-ck
+ah
+ah
+ah
+ah
+aa
+aa
 aa
 aa
 aa
@@ -40413,12 +40091,12 @@ Sl
 ah
 ah
 ah
-Fr
-YM
-YG
-JM
-Yv
-ck
+ah
+ah
+ah
+ah
+aa
+aa
 aa
 aa
 aa
@@ -40615,12 +40293,12 @@ ah
 ah
 ah
 ah
-ZT
-OK
-DI
-FV
-ky
-ck
+ah
+ah
+ah
+ah
+aa
+aa
 aa
 aa
 aa
@@ -40817,12 +40495,12 @@ vv
 vv
 ah
 ah
-ZT
-Bp
-Pp
-ck
-ck
-ck
+ah
+ah
+ah
+ah
+aa
+aa
 aa
 aa
 aa
@@ -41019,12 +40697,12 @@ Id
 vv
 ah
 ah
-Bz
-ck
-ck
-ck
-cG
-cG
+ah
+ah
+ah
+ah
+aa
+aa
 aa
 aa
 aa

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -485,6 +485,21 @@
 /obj/item/trash/cigbutt/rand,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
+"br" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "bs" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/second_deck/fp)
@@ -2230,6 +2245,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"fo" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "fp" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -3523,6 +3552,10 @@
 "gZ" = (
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
+"ha" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "hb" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck Port Hallway - Library";
@@ -5056,6 +5089,29 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
+"ky" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/machinery/button/windowtint{
+	dir = 4;
+	icon_state = "light0";
+	pixel_x = 24;
+	range = 5;
+	tag = "icon-light0 (EAST)"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-18";
+	tag = "icon-plant-18"
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "kz" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/pinpointer,
@@ -5067,6 +5123,27 @@
 /obj/item/weapon/storage/lockbox/station_account,
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
+"kA" = (
+/obj/structure/crematorium{
+	id = 2
+	},
+/obj/machinery/button/crematorium{
+	id = 2;
+	pixel_x = 21;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/black/border{
+	tag = "icon-bordercolor (NORTH)";
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "kB" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -7047,6 +7124,22 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
+"on" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "oo" = (
 /obj/machinery/alarm{
 	frequency = 1439;
@@ -10900,6 +10993,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
+"uW" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small/red{
+	dir = 8;
+	icon_state = "firelight1"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "uX" = (
 /obj/structure/table/standard,
 /obj/item/device/camera,
@@ -13017,24 +13126,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"zd" = (
-/obj/structure/largecrate,
-/obj/random/smokes,
-/obj/random/smokes,
-/obj/random/smokes,
-/obj/random/smokes,
-/obj/random/smokes,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/vehicle_part/random,
-/obj/effect/decal/cleanable/cobweb{
-	tag = "icon-stickyweb2";
-	icon_state = "stickyweb2"
-	},
-/obj/random/drinkbottle,
-/obj/random/smokes,
-/obj/item/ammo_casing/musket/flintlock,
-/turf/simulated/floor/plating,
-/area/maintenance/second_deck/afs)
 "ze" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
@@ -13278,13 +13369,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
-"zK" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/second_deck/afs)
 "zL" = (
 /obj/machinery/computer/arcade{
 	dir = 2
@@ -13368,6 +13452,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
+"Ag" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/high;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/corner/black/border{
+	tag = "icon-bordercolor (NORTH)";
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "Ah" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	tag = "icon-corner_white (NORTHWEST)";
@@ -13454,6 +13556,19 @@
 "AE" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/prison)
+"AI" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list("ACCESS_MAINT")
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "AP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13470,6 +13585,33 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
+"AR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	tag = "icon-intact-scrubbers (EAST)";
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	tag = "icon-intact-supply (EAST)";
+	icon_state = "intact-supply";
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small/red{
+	tag = "icon-firelight1 (NORTH)";
+	icon_state = "firelight1";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "AS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -13498,10 +13640,48 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
+"Bl" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4;
+	icon_state = "map_scrubber_on"
+	},
+/mob/living/simple_animal/cat/fluff/Runtime,
+/turf/simulated/floor/tiled/white,
+/area/space)
 "Bm" = (
 /obj/item/weapon/material/shard,
 /turf/simulated/floor/plating,
 /area/civilian/observatory)
+"Bp" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/structure/closet/secure_closet/CMO,
+/obj/item/device/megaphone,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/suit/storage/hooded/wintercoat/medical,
+/obj/item/device/radio/medical,
+/obj/item/clothing/suit/storage/toggle/labcoat/cmo/alt,
+/obj/item/clothing/accessory/storage/white_vest,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/item/clothing/accessory/armband/bluegoldcom,
+/obj/item/clothing/accessory/armband/medblue,
+/obj/item/weapon/folder/white,
+/turf/simulated/floor/tiled/white,
+/area/space)
 "Bt" = (
 /turf/simulated/wall/false{
 	density = 1;
@@ -13509,6 +13689,10 @@
 	opacity = 1
 	},
 /area/logistics/auxtool)
+"Bz" = (
+/obj/effect/paint_stripe/blue,
+/turf/simulated/wall/r_wall/prepainted,
+/area/space)
 "BC" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -13559,6 +13743,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
+"BL" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/folder/white{
+	pixel_y = 0
+	},
+/obj/item/weapon/pen,
+/obj/machinery/camera/network/medbay{
+	c_tag = "Morgue";
+	dir = 4
+	},
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/tiled/dark,
+/area/space)
 "BM" = (
 /obj/effect/floor_decal/chapel{
 	tag = "icon-chapel (EAST)";
@@ -13605,11 +13807,66 @@
 "BZ" = (
 /turf/simulated/wall/prepainted,
 /area/civilian/counselor)
+"Ca" = (
+/obj/structure/flora/pottedplant/unusual,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/chaplainarea)
+"Cc" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/black/border{
+	tag = "icon-bordercolor (WEST)";
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border,
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "Ch" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/civilian/exercise)
+"Cj" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
+"Ck" = (
+/obj/effect/wallframe_spawn/reinforced/polarized/full,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/civilian/chaplainarea)
 "Cl" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -13618,6 +13875,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"Cp" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	icon_state = "intercom";
+	pixel_x = -28;
+	tag = "icon-intercom (EAST)"
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "Cu" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -13683,6 +13954,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"CV" = (
+/obj/structure/closet/coffin,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/remains,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "Da" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13701,6 +13980,21 @@
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
+"Dg" = (
+/obj/structure/morgue,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/floor_decal/corner/black/border{
+	tag = "icon-bordercolor (NORTH)";
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	tag = "icon-bordercolor (WEST)";
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "Dh" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -13715,6 +14009,19 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"Dm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/carpet,
+/area/civilian/chaplainarea)
 "Dw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13761,6 +14068,17 @@
 /obj/random/toolbox,
 /turf/simulated/floor/wood/walnut,
 /area/logistics/auxtool)
+"DI" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "DN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13961,6 +14279,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"EI" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "EJ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -14003,6 +14333,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/prison)
+"ES" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer";
+	name = "Chief Medical Officer RC";
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "EW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14072,6 +14416,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"Fi" = (
+/obj/structure/closet/coffin,
+/obj/machinery/door/window/southleft{
+	name = "Coffin Storage"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "Fl" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -14086,6 +14437,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Fr" = (
+/obj/machinery/door/airlock/medical{
+	name = "Chief Medical Officer";
+	req_access = list("ACCESS_CHIEF_MEDICAL_OFFICER")
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/space)
 "Fu" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/flame/candle,
@@ -14140,6 +14508,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"FK" = (
+/obj/structure/morgue,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/space)
 "FN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14164,6 +14539,39 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"FV" = (
+/obj/structure/table/glass,
+/obj/machinery/camera/network/command{
+	c_tag = "Chief Medical Officer's Office";
+	dir = 8
+	},
+/obj/item/toy/desk/newtoncradle,
+/turf/simulated/floor/tiled/white,
+/area/space)
+"FX" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
+"FY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	icon_state = "map_vent_out";
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/civilian/chaplainarea)
 "Gb" = (
 /obj/machinery/door/airlock/glass{
 	name = "Auxiliary Storage"
@@ -14200,11 +14608,58 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
+"Gm" = (
+/obj/structure/largecrate,
+/obj/random/smokes,
+/obj/random/smokes,
+/obj/random/smokes,
+/obj/random/smokes,
+/obj/random/smokes,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/vehicle_part/random,
+/obj/effect/decal/cleanable/cobweb{
+	tag = "icon-stickyweb2";
+	icon_state = "stickyweb2"
+	},
+/obj/random/drinkbottle,
+/obj/random/smokes,
+/obj/item/ammo_casing/musket/flintlock,
+/turf/simulated/floor/plating,
+/area/space)
 "Gn" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/storage/pill_bottle/dice,
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
+"Gq" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/hand_labeler,
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Chapel Mourge";
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/corner/black/border,
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
+"Gs" = (
+/obj/structure/morgue,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	tag = "icon-bordercolor (WEST)";
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "Gv" = (
 /obj/effect/floor_decal/chapel{
 	icon_state = "chapel";
@@ -14278,6 +14733,26 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/civilian/exercise)
+"GH" = (
+/obj/machinery/door/airlock{
+	name = "Chapel Mourge";
+	req_access = list("ACCESS_CHAPELAREA")
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "GO" = (
 /obj/effect/shuttle_landmark/nerva/deck2/hadrian,
 /turf/space,
@@ -14323,6 +14798,32 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"Ha" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/button/windowtint{
+	dir = 4;
+	icon_state = "light0";
+	pixel_x = 24;
+	range = 5;
+	tag = "icon-light0 (EAST)"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/effect/landmark/start{
+	name = "Chaplain"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/chaplainarea)
+"Hb" = (
+/turf/simulated/floor/wood/walnut,
+/area/civilian/chaplainarea)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14376,10 +14877,7 @@
 	icon_state = "chapel";
 	dir = 4
 	},
-/obj/structure/bed/chair/urist/bench/bench1/right{
-	icon_state = "benchright";
-	dir = 1
-	},
+/obj/structure/flora/pottedplant/small,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "HA" = (
@@ -14423,6 +14921,10 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"HR" = (
+/obj/structure/closet/wardrobe/chaplain_black,
+/turf/simulated/floor/carpet,
+/area/civilian/chaplainarea)
 "HS" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14487,6 +14989,23 @@
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"It" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/simulated/floor/carpet,
+/area/civilian/chaplainarea)
 "Iw" = (
 /turf/simulated/wall/r_wall/false{
 	icon_state = "rdebug"
@@ -14567,17 +15086,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
-"IW" = (
-/obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
-	},
-/obj/structure/bed/chair/urist/bench/bench1/left{
-	icon_state = "benchleft";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel)
 "IZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14589,6 +15097,34 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"Ja" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	tag = "icon-intact-scrubbers (EAST)";
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	tag = "icon-intact-supply (EAST)";
+	icon_state = "intact-supply";
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "Jg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -14705,6 +15241,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"JM" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/white,
+/area/space)
 "JQ" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -14809,6 +15351,26 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
+"Ky" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "Kz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14823,6 +15385,18 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"KH" = (
+/obj/machinery/light/small,
+/obj/item/stack/tile/floor,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 1;
+	icon_state = "cobweb1";
+	tag = "icon-cobweb1 (NORTH)"
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "KJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14943,6 +15517,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
+"Lq" = (
+/obj/structure/closet,
+/obj/random/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fp)
 "Ls" = (
 /obj/item/device/flashlight/lamp/lava/pink{
 	on = 1
@@ -14969,6 +15548,28 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
+"Lx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (SOUTHEAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "LA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
@@ -15028,6 +15629,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"LL" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "LO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -15057,19 +15664,16 @@
 	req_access = list("ACCESS_CAPTAIN")
 	},
 /obj/machinery/button/remote/airlock{
+	desiredstate = 1;
 	id = "bridgesafedoor";
 	name = "safe room door-control";
 	pixel_x = -6;
 	pixel_y = 22;
+	req_access = list("ACCESS_BRIDGE");
 	specialfunctions = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
-"LV" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/wall/r_wall/prepainted,
-/area/chapel)
 "LW" = (
 /obj/structure/table/rack{
 	dir = 1
@@ -15299,6 +15903,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
+"Nf" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "Ng" = (
 /obj/structure/table/rack{
 	desc = "A simple wooden altar covered in cloth.";
@@ -15363,6 +15978,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"NA" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	icon_state = "map_vent_out";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "NE" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -15529,6 +16161,26 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
+"Oq" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Maintenance";
+	req_access = list("ACCESS_CHAPELAREA")
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "Os" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -15597,6 +16249,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"OK" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
+"Pb" = (
+/obj/structure/closet/coffin,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "Pe" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -15644,6 +16312,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"Pp" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/machinery/disposal,
+/obj/machinery/light_switch{
+	dir = 4;
+	on = 1;
+	pixel_x = 25
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 1;
+	icon_state = "pipe-t"
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "Ps" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	tag = "icon-corner_white (WEST)";
@@ -15677,6 +16364,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
+"PE" = (
+/obj/structure/closet,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "PM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -15750,6 +16441,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"PX" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Bridge Maintenance";
+	req_access = list("ACCESS_BRIDGE")
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "Qa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -15827,6 +16525,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
+"Qq" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "Qv" = (
 /obj/effect/floor_decal/chapel{
 	icon_state = "chapel";
@@ -15941,6 +16644,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
+"QS" = (
+/turf/simulated/floor/carpet,
+/area/civilian/chaplainarea)
 "QV" = (
 /obj/effect/floor_decal/corner/black/border{
 	tag = "icon-bordercolor (WEST)";
@@ -16073,6 +16779,28 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"RP" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/item/weapon/rig/medical/equipped,
+/obj/structure/table/rack,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/fancy/vials,
+/obj/item/weapon/storage/fancy/vials,
+/turf/simulated/floor/tiled/white,
+/area/space)
 "RR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16103,6 +16831,10 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"Sb" = (
+/obj/item/modular_computer/console/preset/medical,
+/turf/simulated/floor/tiled/white,
+/area/space)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	tag = "icon-intact-scrubbers (EAST)";
@@ -16127,6 +16859,16 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
+"Si" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
+"Sl" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/civilian/chaplainarea)
 "Sn" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -16145,6 +16887,12 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
+"SN" = (
+/obj/structure/closet/coffin,
+/obj/structure/window/reinforced,
+/obj/random/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "SS" = (
 /obj/structure/bed/chair/wood/walnut{
 	icon_state = "wooden_chair_preview";
@@ -16190,6 +16938,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"SZ" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/storage/candle_box,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	luminosity = 3
+	},
+/obj/effect/floor_decal/corner/black/border,
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
 "Tc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16208,6 +16970,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
+"Tq" = (
+/obj/machinery/door/airlock/glass{
+	name = "Chapel Office";
+	req_access = list("ACCESS_CHAPELAREA")
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/civilian/chaplainarea)
+"Tx" = (
+/obj/structure/closet/coffin,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/random/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
 "Ty" = (
 /obj/random/junk,
 /obj/machinery/light/small/red,
@@ -16514,6 +17292,41 @@
 /obj/structure/inflatable/door,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
+"Vx" = (
+/obj/structure/closet/wardrobe/chaplain_black{
+	name = "chapel closet"
+	},
+/turf/simulated/floor/carpet,
+/area/civilian/chaplainarea)
+"VB" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (NORTHEAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afs)
+"VF" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet,
+/area/civilian/chaplainarea)
 "VN" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/reinforced,
@@ -16767,6 +17580,15 @@
 /obj/random/maintenance,
 /turf/simulated/floor/airless,
 /area/space)
+"Xq" = (
+/obj/structure/table/woodentable/walnut,
+/obj/structure/flora/pottedplant/smallcactus,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/chaplainarea)
 "Xt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/cobweb{
@@ -16784,6 +17606,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"Xx" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/toy/desk/newtoncradle,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/chaplainarea)
 "Xy" = (
 /obj/machinery/biogenerator,
 /obj/effect/floor_decal/corner/red/full,
@@ -16964,6 +17796,19 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"Yr" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	icon_state = "intercom";
+	pixel_x = -23;
+	tag = "icon-intercom (EAST)"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Chapel Office"
+	},
+/turf/simulated/floor/carpet,
+/area/civilian/chaplainarea)
 "Yt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -16974,6 +17819,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"Yv" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = -26
+	},
+/obj/effect/landmark/start{
+	name = "Chief Medical Officer"
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "YC" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -16989,6 +17851,43 @@
 "YF" = (
 /obj/random/toolbox,
 /turf/simulated/floor/airless,
+/area/space)
+"YG" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (NORTHWEST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
+"YM" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal";
+	tag = "icon-corner_white_diagonal (EAST)"
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
 /area/space)
 "YN" = (
 /obj/item/weapon/caution/cone,
@@ -17049,6 +17948,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
+"Zd" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/high;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/chaplainarea)
 "Zh" = (
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor/plating,
@@ -17098,13 +18010,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "ZA" = (
-/obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
-	},
 /obj/effect/floor_decal/chapel{
 	icon_state = "chapel";
 	dir = 1
+	},
+/obj/structure/flora/pottedplant{
+	tag = "icon-plant-18";
+	icon_state = "plant-18"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -17141,6 +18053,11 @@
 "ZQ" = (
 /turf/simulated/floor/reinforced,
 /area/security/prison)
+"ZT" = (
+/obj/effect/wallframe_spawn/reinforced/polarized/full,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/space)
 "ZW" = (
 /obj/random/tool,
 /turf/simulated/floor/plating,
@@ -36263,8 +37180,8 @@ Xj
 Xj
 zx
 pe
-ah
-ah
+ck
+ck
 ah
 ah
 aa
@@ -36460,13 +37377,13 @@ rn
 yA
 pe
 pe
+zu
 zc
+zb
 za
 za
-za
-pe
-ah
-ah
+Gm
+ck
 ah
 ah
 aa
@@ -36661,14 +37578,14 @@ xh
 rn
 sh
 pe
-yZ
+zL
+Si
 za
-zK
 pe
-pe
-pe
-ah
-ah
+zy
+yZ
+ck
+ck
 ah
 ah
 aa
@@ -36863,13 +37780,13 @@ xg
 rn
 sh
 pe
-za
-zu
-zL
 pe
 pe
-ah
-ah
+TP
+pe
+pe
+ck
+ck
 ah
 ah
 ah
@@ -37063,13 +37980,13 @@ rn
 rn
 rn
 rn
-sh
-pe
-za
-za
-zy
-pe
-ah
+Ja
+AI
+uW
+Cj
+VB
+PE
+ck
 ah
 ah
 ah
@@ -37266,12 +38183,12 @@ wF
 xi
 rn
 sh
+rr
+rr
+rr
+on
 pe
-zb
-za
-pe
-pe
-ah
+ck
 ah
 ah
 ah
@@ -37468,12 +38385,12 @@ wG
 xj
 rn
 yd
-pe
-za
-za
-pe
-pe
-ah
+Qq
+Tx
+Pb
+on
+ha
+ck
 ah
 ah
 ah
@@ -37669,13 +38586,13 @@ tS
 wH
 xk
 rn
-sh
-pe
-zc
-za
-pe
-pe
-ah
+AR
+LL
+CV
+Fi
+FX
+rU
+ck
 ah
 ah
 ah
@@ -37872,12 +38789,12 @@ wH
 xl
 rn
 sh
-pe
-za
-za
-pe
-pe
-ah
+rU
+Tx
+SN
+on
+KH
+ck
 ah
 ah
 ah
@@ -37886,8 +38803,8 @@ ah
 aa
 aa
 aa
-aa
-aa
+FK
+BL
 aa
 aa
 aa
@@ -38074,12 +38991,12 @@ wI
 xm
 xE
 ye
-pe
-za
-za
-pe
-pe
-ah
+Sl
+Sl
+Sl
+Oq
+Sl
+Sl
 ah
 ah
 ah
@@ -38276,12 +39193,12 @@ wJ
 xn
 rn
 sh
-pe
-za
-pe
-pe
-pe
-ah
+Sl
+Dg
+Gs
+Cc
+Sl
+Sl
 ah
 ah
 ah
@@ -38289,7 +39206,7 @@ ah
 ah
 aa
 aa
-aa
+Lq
 aa
 aa
 aa
@@ -38478,12 +39395,12 @@ rn
 rn
 rn
 sh
-pe
-za
-pe
-pe
-ah
-ah
+Sl
+Ag
+Lx
+br
+SZ
+Sl
 ah
 ah
 ah
@@ -38680,12 +39597,12 @@ te
 te
 te
 yf
-TP
-za
-pe
-pe
-ah
-ah
+Sl
+kA
+Ky
+NA
+Gq
+Sl
 ah
 ah
 ah
@@ -38881,21 +39798,21 @@ Uc
 Uc
 Uc
 Uc
-Uc
-pe
-zd
-pe
-pe
+Sl
+Sl
+Sl
+GH
+Sl
+Sl
+Sl
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-aa
-aa
+Bz
+ck
+ck
+ck
+ck
+ck
 aa
 aa
 aa
@@ -39083,21 +40000,21 @@ JZ
 MD
 Fu
 ZA
-Uc
-pe
-pe
-pe
-pe
+Ck
+Yr
+Dm
+It
+Vx
+Sl
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-aa
-aa
+ZT
+RP
+EI
+Cp
+Nf
+PX
 aa
 aa
 aa
@@ -39285,21 +40202,21 @@ Ng
 QG
 QG
 BM
-Uc
-pe
-pe
-pe
+Tq
+QS
+VF
+FY
+HR
+Sl
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-aa
-aa
+ZT
+fo
+Bl
+Sb
+ES
+ck
 aa
 aa
 aa
@@ -39486,22 +40403,22 @@ Qv
 PO
 RT
 JL
-IW
-LV
+TA
+Ck
+Hb
+Xx
+Xq
+Sl
+Sl
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-aa
-aa
+Fr
+YM
+YG
+JM
+Yv
+ck
 aa
 aa
 aa
@@ -39689,21 +40606,21 @@ Ll
 GX
 Bc
 Hy
-XT
+Sl
+Zd
+Ha
+Ca
+Sl
 ah
 ah
 ah
 ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-ah
-aa
-aa
+ZT
+OK
+DI
+FV
+ky
+ck
 aa
 aa
 aa
@@ -39891,21 +40808,21 @@ Ll
 Mq
 Jy
 tV
-tV
-vv
-vv
-vv
-vv
+Sl
+Sl
+Sl
+Sl
+Sl
 vv
 vv
 ah
 ah
-ah
-ah
-ah
-ah
-aa
-aa
+ZT
+Bp
+Pp
+ck
+ck
+ck
 aa
 aa
 aa
@@ -40102,12 +41019,12 @@ Id
 vv
 ah
 ah
-ah
-ah
-ah
-ah
-aa
-aa
+Bz
+ck
+ck
+ck
+cG
+cG
 aa
 aa
 aa

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -498,6 +498,10 @@
 	pixel_x = 0;
 	tag = ""
 	},
+/obj/structure/disposalpipe/segment{
+	icon_state = "pipe-c";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/chaplainarea)
 "bs" = (
@@ -7101,6 +7105,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "oo" = (
@@ -10970,6 +10977,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/generic,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "uX" = (
@@ -13530,6 +13538,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "AP" = (
@@ -13568,9 +13577,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
-	icon_state = "firelight1";
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -13747,6 +13754,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/chaplainarea)
 "Ch" = (
@@ -13763,6 +13773,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "Ck" = (
@@ -13881,6 +13892,9 @@
 	tag = "icon-bordercolor (WEST)";
 	icon_state = "bordercolor";
 	dir = 8
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Chaplain's Morgue"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/chaplainarea)
@@ -14382,6 +14396,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/generic,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "FY" = (
@@ -14444,7 +14461,7 @@
 /obj/random/smokes,
 /obj/item/ammo_casing/musket/flintlock,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/second_deck/afs)
 "Gn" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/storage/pill_bottle/dice,
@@ -14454,7 +14471,7 @@
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/hand_labeler,
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Chapel Mourge";
+	c_tag = "Bar";
 	dir = 8;
 	icon_state = "camera"
 	},
@@ -14554,7 +14571,7 @@
 /area/civilian/exercise)
 "GH" = (
 /obj/machinery/door/airlock{
-	name = "Chapel Mourge";
+	name = "Chapel Morgue";
 	req_access = list("ACCESS_CHAPELAREA")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14570,6 +14587,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/chaplainarea)
 "GO" = (
@@ -14641,6 +14661,9 @@
 /turf/simulated/floor/wood/walnut,
 /area/civilian/chaplainarea)
 "Hb" = (
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Chaplain's Office"
+	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/chaplainarea)
 "Hh" = (
@@ -14740,10 +14763,6 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
-"HR" = (
-/obj/structure/closet/wardrobe/chaplain_black,
-/turf/simulated/floor/carpet,
-/area/civilian/chaplainarea)
 "HS" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14822,6 +14841,10 @@
 	icon_state = "1-8";
 	pixel_x = 0;
 	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/chaplainarea)
@@ -14922,25 +14945,24 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
-	icon_state = "intact-supply";
-	dir = 4
-	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4";
 	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	icon_state = "map-supply";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Chapel";
+	sortType = "Bodyguard"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -15182,6 +15204,9 @@
 	icon_state = "bordercolor";
 	tag = "icon-bordercolor (EAST)"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/chaplainarea)
 "Kz" = (
@@ -15330,9 +15355,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
-"Lq" = (
-/turf/space,
-/area/maintenance/third_deck/fp)
 "Ls" = (
 /obj/item/device/flashlight/lamp/lava/pink{
 	on = 1
@@ -15378,6 +15400,10 @@
 	d2 = 4;
 	icon_state = "2-4";
 	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/chaplainarea)
@@ -15979,6 +16005,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/chaplainarea)
 "Os" = (
@@ -16049,6 +16078,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"OQ" = (
+/obj/machinery/light_switch{
+	on = 1;
+	pixel_x = 10;
+	pixel_y = -25
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	icon_state = "pipe-t";
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/civilian/chaplainarea)
 "Pb" = (
 /obj/structure/closet/coffin,
 /obj/structure/window/reinforced,
@@ -17051,6 +17093,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "VF" = (
@@ -17541,9 +17587,6 @@
 	tag = "icon-intercom (EAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Chapel Office"
-	},
 /turf/simulated/floor/carpet,
 /area/civilian/chaplainarea)
 "Yt" = (
@@ -17641,6 +17684,9 @@
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/chaplainarea)
@@ -36858,8 +36904,8 @@ Xj
 Xj
 zx
 pe
-ck
-ck
+pe
+pe
 ah
 ah
 aa
@@ -37061,7 +37107,7 @@ zb
 za
 za
 Gm
-ck
+pe
 ah
 ah
 aa
@@ -37262,8 +37308,8 @@ za
 pe
 zy
 yZ
-ck
-ck
+pe
+pe
 ah
 ah
 aa
@@ -37463,8 +37509,8 @@ pe
 TP
 pe
 pe
-ck
-ck
+pe
+pe
 ah
 ah
 ah
@@ -37664,7 +37710,7 @@ uW
 Cj
 VB
 PE
-ck
+pe
 ah
 ah
 ah
@@ -37866,7 +37912,7 @@ rr
 rr
 on
 pe
-ck
+pe
 ah
 ah
 ah
@@ -38068,7 +38114,7 @@ Tx
 Pb
 on
 ha
-ck
+pe
 ah
 ah
 ah
@@ -38270,7 +38316,7 @@ CV
 Fi
 FX
 rU
-ck
+pe
 ah
 ah
 ah
@@ -38472,7 +38518,7 @@ Tx
 SN
 on
 KH
-ck
+pe
 ah
 ah
 ah
@@ -38884,7 +38930,7 @@ ah
 ah
 aa
 aa
-Lq
+aa
 aa
 aa
 aa
@@ -39081,7 +39127,7 @@ SZ
 Sl
 ah
 ah
-ah
+aa
 ah
 ah
 aa
@@ -39682,7 +39728,7 @@ Ck
 Yr
 Dm
 It
-Vx
+OQ
 Sl
 ah
 ah
@@ -39884,7 +39930,7 @@ Tq
 QS
 VF
 FY
-HR
+Vx
 Sl
 ah
 ah

--- a/maps/nerva/nerva.dm
+++ b/maps/nerva/nerva.dm
@@ -1,4 +1,4 @@
-#if !defined(USING_MAP_DATUM)
+.#if !defined(USING_MAP_DATUM)
 
 	#include "nerva_announcements.dm"
 	#include "nerva_areas.dm"

--- a/maps/nerva/nerva_areas.dm
+++ b/maps/nerva/nerva_areas.dm
@@ -195,6 +195,15 @@
 	name = "\improper Exercise Room"
 	sound_env = SMALL_ENCLOSED
 
+/area/civilian/chaplainarea
+	name = "\improper Chapel Office"
+	icon_state = "blueold"
+	req_access = list(access_chaplainarea)
+
+/area/civillian/chaplainmourge
+	name = "\improper Chapel Mourge"
+	icon_state = "blue_new"
+
 //////////////////////////////////////
 //			SECURITY				//
 //////////////////////////////////////


### PR DESCRIPTION
### Changelogs:

### Chapel:

- Chaplain now has an office with a morgue and crematorium.
- Additional coffin storage outside, with some loot that randomly spawns in them.
- Tintable windows.


**Images:**
![chapoffice](https://user-images.githubusercontent.com/53942081/123723259-ed62fb80-d881-11eb-8cd6-114c927d0346.PNG)


### Saferoom:

- Button has been tweaked, access has been added to the doors, and expanded slightly, with a single shotgun, additional items and a small medical area. (No table/surgery capability.)

**Images:**
![pew](https://user-images.githubusercontent.com/53942081/123723193-ce646980-d881-11eb-8829-cff20fdef382.PNG)


### Security Brig:
- Windoors Access changed so that cells are finally secure again.

### Torpedo Bay:
- Changes Cargo and Torpedo Deck Levers to be independant.


\\ If people are against a additional cremator, I can remove it. //