### PR TITLE
Bugfix - Fixed mined rocks not generating resources on new turf

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -336,6 +336,15 @@ var/list/mining_floors = list()
 	if(istype(N))
 		N.overlay_detail = "asteroid[rand(0,9)]"
 		N.updateMineralOverlays(1)
+		if(!N.has_resources || length(resources))
+			return
+		for(var/i in random_maps)
+			var/datum/random_map/noise/ore/orenoise = random_maps[i]
+			if(!istype(orenoise))
+				continue
+			if(orenoise.origin_z == N.z)
+				orenoise.generate_tile(N)
+				break
 
 /turf/simulated/mineral/proc/excavate_find(var/prob_clean = 0, var/datum/find/F)
 

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -54,40 +54,47 @@
 				continue
 			if(!priority_process)
 				CHECK_TICK
-			T.resources = list()
-			T.resources[MATERIAL_SAND] = rand(3,5)
-			T.resources[MATERIAL_GRAPHENE] = rand(3,5)
-
 			var/tmp_cell
 			TRANSLATE_AND_VERIFY_COORD(x, y)
+			generate_tile(T, tmp_cell)
 
-			if(tmp_cell < rare_val)      // Surface metals.
-				T.resources[MATERIAL_IRON] =     rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
-				T.resources[MATERIAL_GOLD] =     rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_SILVER] =   rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_DIAMOND] =  0
-				T.resources[MATERIAL_PHORON] =   0
-				T.resources[MATERIAL_OSMIUM] =   0
-				T.resources[MATERIAL_HYDROGEN] = 0
-			else if(tmp_cell < deep_val) // Rare metals.
-				T.resources[MATERIAL_GOLD] =     rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_SILVER] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_PHORON] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_OSMIUM] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_HYDROGEN] = 0
-				T.resources[MATERIAL_DIAMOND] =  0
-				T.resources[MATERIAL_IRON] =     0
-			else                             // Deep metals.
-				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_DIAMOND] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_PHORON] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
-				T.resources[MATERIAL_OSMIUM] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
-				T.resources[MATERIAL_HYDROGEN] = rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_IRON] =     0
-				T.resources[MATERIAL_GOLD] =     0
-				T.resources[MATERIAL_SILVER] =   0
+/datum/random_map/noise/ore/proc/generate_tile(var/turf/simulated/T, var/tmp_cell = null)
+	if(!istype(T) || !T.has_resources)
+		return
+	T.resources = list()
+	T.resources[MATERIAL_SAND] = rand(3,5)
+	T.resources[MATERIAL_GRAPHENE] = rand(3,5)
+
+	if(!tmp_cell)
+		TRANSLATE_AND_VERIFY_COORD(T.x, T.y)
+
+	if(tmp_cell < rare_val)      // Surface metals.
+		T.resources[MATERIAL_IRON] =     rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+		T.resources[MATERIAL_GOLD] =     rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_SILVER] =   rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_DIAMOND] =  0
+		T.resources[MATERIAL_PHORON] =   0
+		T.resources[MATERIAL_OSMIUM] =   0
+		T.resources[MATERIAL_HYDROGEN] = 0
+	else if(tmp_cell < deep_val) // Rare metals.
+		T.resources[MATERIAL_GOLD] =     rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_SILVER] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_PHORON] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_OSMIUM] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_HYDROGEN] = 0
+		T.resources[MATERIAL_DIAMOND] =  0
+		T.resources[MATERIAL_IRON] =     0
+	else                             // Deep metals.
+		T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_DIAMOND] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_PHORON] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+		T.resources[MATERIAL_OSMIUM] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+		T.resources[MATERIAL_HYDROGEN] = rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_IRON] =     0
+		T.resources[MATERIAL_GOLD] =     0
+		T.resources[MATERIAL_SILVER] =   0
 
 /datum/random_map/noise/ore/get_map_char(var/value)
 	if(value < rare_val)


### PR DESCRIPTION
Fixes an issue where when a new asteroid turf is created below a mined rock, it does not generate anything in the resources list, making the big drill unusable on those spaces.

There's probably a _much_ better way of doing this, but this works and my knowledge on map generation is somewhat limited.