### PR TITLE
Various NPC trader tweaks/bugfixes

### DIFF
--- a/code/modules/urist/modules/newtrading/NPC/NPC_types/complex_traders.dm
+++ b/code/modules/urist/modules/newtrading/NPC/NPC_types/complex_traders.dm
@@ -41,7 +41,7 @@
 	trade_categories_by_name = list("atmospherics","tools","bulky","medical")
 
 	sell_modifier = 0.8
-	price_increase = 1.1
+	price_modifier = 0.1
 	wander = 0
 	npc_item_amount = 30
 	interact_screen = 2

--- a/code/modules/urist/modules/newtrading/NPC/NPC_types/simple_traders.dm
+++ b/code/modules/urist/modules/newtrading/NPC/NPC_types/simple_traders.dm
@@ -45,8 +45,8 @@
 /mob/living/simple_animal/hostile/npc/colonist/trader/crop_trader/get_trade_value(var/obj/O)
 	. = get_value(O) * 25
 
-/mob/living/simple_animal/hostile/npc/colonist/trader/crop_trader/player_sell(var/obj/O, var/mob/M, var/worth, var/resell = 1)
-	return ..(O, M, worth, 0)
+/mob/living/simple_animal/hostile/npc/colonist/trader/crop_trader/player_sell(var/obj/O, var/mob/M, var/resell = 1)
+	return ..(O, M, 0)
 
 
 //mineral trader
@@ -85,7 +85,7 @@
 
 	npc_item_amount = 26
 	randomize_value = 0
-	price_increase = 1 //no price increase
+	price_modifier = 0 //no price increase
 	interact_screen = 2
 
 //TC guy

--- a/code/modules/urist/modules/newtrading/NPC/npc.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc.dm
@@ -90,7 +90,7 @@
 	var/datum/controller/process/trade_controller/trade_controller_debug
 
 	var/sell_modifier = 0.90 //how much less than the sell price will the merchants buy items from you
-	var/price_increase = 1.02 //how much does the price go up after they sell an item. a value of 1 means no increase.
+	var/price_modifier = 0.08 //how much the price changes on trades in % of base price. 0 is no change -- 8% increase/decrease per trade
 	var/no_resell = 0
 
 	var/npc_item_amount = 8

--- a/code/modules/urist/modules/newtrading/NPC/npc_buysell.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc_buysell.dm
@@ -1,7 +1,7 @@
-/mob/living/simple_animal/hostile/npc/proc/player_sell(var/obj/O, var/mob/M, var/worth, var/resell = 1)
+/mob/living/simple_animal/hostile/npc/proc/player_sell(var/obj/O, var/mob/M, var/resell = 1)
 	if(no_resell)
 		resell = 0
-
+	var/worth = get_trade_value(O)	//Update the price here aswell as nanoUI updates are slow and can allow for multiple sales at the same rate
 	if(!worth)
 		to_chat(M,"<span class = 'warning'>It's not worth your time to do that.</span>")
 		return
@@ -52,7 +52,7 @@
 	var/datum/trade_item/T = trade_items_inventory_by_type[O.type]
 	if(T)
 		T.quantity += 1
-		T.value = round(T.value * src.sell_modifier)		//price goes down a little
+		T.value = round(T.value * (1-src.price_modifier))		//price goes down a little
 		update_trade_item_ui(T)
 		return 1
 	return 0
@@ -131,7 +131,7 @@
 
 	//update the inventory
 	D.quantity -= 1
-	D.value = round(D.value * src.price_increase)		//price goes up a little
+	D.value = round(D.value * (1+src.price_modifier))		//price goes up a little
 	update_trade_item_ui(D)
 
 /mob/living/simple_animal/hostile/npc/proc/GiveFreeItem(var/datum/trade_item/D, var/mob/M)

--- a/code/modules/urist/modules/newtrading/NPC/npc_interact.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc_interact.dm
@@ -58,7 +58,7 @@
 		if(M.l_hand)
 			data["l_hand"] = M.l_hand
 			data["l_hand_icon"] = getFlatIcon(M.l_hand)
-			data["l_hand_worth"] = round(get_trade_value(M.l_hand) * 0.9)	//always rebuy for less due to depreciation
+			data["l_hand_worth"] = get_trade_value(M.l_hand)
 			if(check_tradeable(M.l_hand))
 				data["l_sellable"] = 1
 			else
@@ -74,12 +74,13 @@
 		if(M.r_hand)
 			data["r_hand"] = M.r_hand
 			data["r_hand_icon"] = getFlatIcon(M.r_hand)
-			data["r_hand_worth"] = round(get_trade_value(M.r_hand) * 0.9)	//always rebuy for less due to depreciation
+			data["r_hand_worth"] = get_trade_value(M.r_hand)
 			if(check_tradeable(M.r_hand))
 				data["r_sellable"] = 1
 			else
 				data["r_sellable"] = -1
 
+		else
 			data["r_hand"] = "empty"
 			data["r_hand_icon"] = ""
 			data["r_hand_worth"] = "0"
@@ -113,8 +114,7 @@
 		var/mob/living/carbon/M = locate(href_list["user"])
 		if(M && istype(M))
 			var/obj/O = M.l_hand
-			var/worth = text2num(href_list["worth"])
-			player_sell(O, M, worth)
+			player_sell(O, M)
 
 	if(href_list["ask_question"])
 		var/mob/living/carbon/M = locate(href_list["user"])
@@ -128,8 +128,7 @@
 		var/mob/living/carbon/M = locate(href_list["user"])
 		if(M && istype(M))
 			var/obj/O = M.r_hand
-			var/worth = text2num(href_list["worth"])
-			player_sell(O, M, worth)
+			player_sell(O, M)
 
 	if(href_list["buy_item"])
 		var/mob/living/carbon/M = locate(href_list["user"])

--- a/code/modules/urist/modules/newtrading/NPC/npc_trade.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc_trade.dm
@@ -90,8 +90,8 @@
 /mob/living/simple_animal/hostile/npc/proc/calculate_multiple_sales(var/datum/trade_item/T , var/count)
 	if(!T || !count)
 		return
-	var/newPrice = round(T.value * sell_modifier)	//Price changes AFTER an obj is sold. Let's skip the first trade then.
-	var/total_value = newPrice
+	var/newPrice = T.value
+	var/total_value = round(T.value * sell_modifier)	//Price changes AFTER an obj is sold. Let's skip the first trade then.
 	count--
 	while(count)
 		newPrice = round((newPrice * (1-src.price_modifier)) * sell_modifier)	//Calculate what the new price would be with the devalue of selling individually, then apply the selling modifier


### PR DESCRIPTION
Fixes a few issues currently present in NPC trading:

- Fixes not being able to sell items in your right hand, due to a missing `else`.
- Fixes `get_trade_value()` simply returning the global worth and not the trader's worth due to missing returns, resulting in _very_ high sale value, and often far above the buy value, creating an infinite money pit.
- Adjusts NPCs to correctly calculate selling multiple items at once; as once a sale is made, the price changes, and we need to apply the new price to each following item to better simulate loss of demand/the same price decrease as if sold individually.
- Removes a possible exploit by selling items in both hands at the same time, causing them both to be sold at the same rate, then sold back to the NPC for profit.

As a side-effect of this PR, most prices selling to NPCs have been nerfed compared to before. This again was due to the selling price being incorrectly tied to SS13's default worth procs, rather than the individual trader's.