### PR TITLE
Tacticool Gun Reloading

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -123,8 +123,16 @@
 					to_chat(user, "<span class='warning'>\The [A] won't fit into [src].</span>")
 					return
 				if(ammo_magazine)
-					to_chat(user, "<span class='warning'>[src] already has a magazine loaded.</span>")//already a magazine here
-
+					//tacticool reloading
+					ammo_magazine.dropInto(loc)
+					user.visible_message(
+						"[user] ejects the [ammo_magazine], it falls out and clatters on the floor!",
+						"<span class='notice'>You eject the [ammo_magazine], it falls out and clatters on the floor!</span>"
+						)
+					playsound(loc, mag_remove_sound, 50, 1)
+					ammo_magazine.update_icon()
+					ammo_magazine = null
+					update_icon()
 					return
 				if(!user.unEquip(AM, src))
 					return


### PR DESCRIPTION
Streamlines the reloading process, allowing you to seamlessly eject and load in a new magazine in fewer mouse clicks. Basically those cool John Wick reloads. Should hopefully be more intuitive for everyone and is a fairly light weight change that will be applied to all guns that already have external magazines (so pistols, rifles etc but not shotguns or revolvers).

Previously reloading a gun needed the following steps:
1. Use empty hand to eject empty magazine.
2. Drop empty magazine from hand.
3. Take new magazine from pocket/backpack.
4. Insert new magazine into gun.

Now it is simplified:
1. Take new magazine from pocket/backpack.
2. Click once on the gun with magazine in hand to eject the old magazine onto the floor. Click again to load in new magazine (basically, double clicking quickly can do both of these steps).

Prior to this change, all you would see when trying to reload a gun with a magazine already loaded would be a message telling you the gun is full, this changes that check.