### PR TITLE
Nerfs flash rounds to be blocked by sunglasses

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -26,7 +26,7 @@
 
 	//blind and confuse adjacent people
 	for (var/mob/living/carbon/M in viewers(T, flash_range))
-		if(M.eyecheck() < FLASH_PROTECTION_MAJOR)
+		if(M.eyecheck() < FLASH_PROTECTION_MODERATE)
 			M.flash_eyes()
 			M.eye_blurry += (brightness / 2)
 			M.confused += (brightness / 2)


### PR DESCRIPTION
This puts flash rounds in line with real flashes, as both are blocked by sunglasses.