### PR TITLE
Removes Unathi regen

### DIFF
--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -73,13 +73,13 @@
 		)
 	breathing_sound = 'sound/voice/lizard.ogg'
 
-	base_auras = list(
+	/*base_auras = list(
 		/obj/aura/regenerating/human/unathi
 		)
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/diona_heal_toggle
-		)
+		)*/
 
 	prone_overlay_offset = list(-4, -4)
 


### PR DESCRIPTION
Well, comments it out. 

Unathi are still Tougher Than You, but will no longer walk everything off with enough time and steak dinners, bringing them closer to humans health-wise.

I accept my fate.