### PR TITLE
Bugfixing again

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -56,7 +56,7 @@
 	dir = EAST
 	var/width = 1
 	airlock_type = /obj/machinery/door/airlock/multi_tile
-	glass_type = "/multi_tile/glass"
+	glass_type = "/obj/machinery/door/airlock/multi_tile/glass"
 
 	New()
 		if(dir in list(EAST, WEST))

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -91,7 +91,7 @@
 	var/list/processed_evac_options = list()
 	if(!isnull(evacuation_controller))
 		for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
-			if(EO.abandon_ship)
+			if(EO.abandon_ship && security_state.current_security_level_is_lower_than(security_state.high_security_level))
 				continue
 			var/list/option = list()
 			option["option_text"] = EO.option_text

--- a/code/modules/power/power_usage.dm
+++ b/code/modules/power/power_usage.dm
@@ -104,7 +104,7 @@ This is /obj/machinery level code to properly manage power usage from the area.
 		power_channel = new_channel
 		return
 	var/old_channel = power_channel
-	if(old_channel == old_channel)
+	if(old_channel == new_channel)
 		return
 	var/power = get_power_usage()
 	REPORT_POWER_CONSUMPTION_CHANGE(power, 0)


### PR DESCRIPTION
Just a few bugfixes that have been annoying me.

- Emergency lighting now actually works. Was caused by a var comparing itself to... itself. Then exiting if it equated itself.. lolwut
- Fixed double glass airlock construction. Caused by a incomplete build path. Airlock repairs are go!
- Allowed the crew to abandon the ship via escape pods under red alert or higher. Seemed to just be completely missing and impossible to do without admin intervention. Because a crew transfer doesn't seem quite fitting if half the ship is missing and floating into the endless void...