### PR TITLE
[Feature] Adds character slots as an option for AI holograms

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -809,7 +809,7 @@ proc // Creates a single icon from a given /atom or /image.  Only the first argu
 		return
 	var/icon/complete = icon('icons/effects/effects.dmi', "icon_state"="nothing")
 	for(var/currdir in list(NORTH, SOUTH, EAST, WEST))
-		var/icon/icon_dir = getFlatIcon(A,currdir)
+		var/icon/icon_dir = getFlatIcon(A,currdir,always_use_defdir=1)
 		complete.Insert(icon_dir,dir=currdir)
 		qdel(icon_dir)
 	return complete

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -107,7 +107,7 @@ AngleToHue(hue)
 	Converts an angle to a hue in the valid range.
 RotateHue(hsv, angle)
 	Takes an HSV or HSVA value and rotates the hue forward through red, green, and blue by an angle from 0 to 360.
-	(Rotating red by 60° produces yellow.) The result is another HSV or HSVA color with the same saturation and value
+	(Rotating red by 60Â° produces yellow.) The result is another HSV or HSVA color with the same saturation and value
 	as the original, but a different hue.
 GrayScale(rgb)
 	Takes an RGB or RGBA color and converts it to grayscale. Returns an RGB or RGBA string.
@@ -803,6 +803,16 @@ proc // Creates a single icon from a given /atom or /image.  Only the first argu
 			//Also, icons cannot directly set icon_state. Slower than changing variables but whatever.
 			alpha_mask.Blend(image_overlay,ICON_OR)//OR so they are lumped together in a nice overlay.
 		return alpha_mask//And now return the mask.
+
+/proc/getFullIcon(atom/A)	//Returns a complete flat icon for all dirs
+	if(!A)
+		return
+	var/icon/complete = icon('icons/effects/effects.dmi', "icon_state"="nothing")
+	for(var/currdir in list(NORTH, SOUTH, EAST, WEST))
+		var/icon/icon_dir = getFlatIcon(A,currdir)
+		complete.Insert(icon_dir,dir=currdir)
+		qdel(icon_dir)
+	return complete
 
 /mob/proc/AddCamoOverlay(atom/A)//A is the atom which we are using as the overlay.
 	var/icon/opacity_icon = new(A.icon, A.icon_state)//Don't really care for overlays/underlays.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -527,39 +527,65 @@ var/list/ai_verbs_default = list(
 	if(check_unable())
 		return
 
-	var/input
-	if(alert("Would you like to select a hologram based on a crew member or switch to unique avatar?",,"Crew Member","Unique")=="Crew Member")
+	var/option = alert("Where should we get our hologram from?",,"Crew Member","Unique","Character Slot")
+	switch(option)
+		if("Crew Member")
+			var/personnel_list[] = list()
 
-		var/personnel_list[] = list()
+			for(var/datum/computer_file/report/crew_record/t in GLOB.all_crew_records)//Look in data core locked.
+				personnel_list["[t.get_name()]: [t.get_rank()]"] = t.photo_front//Pull names, rank, and image.
 
-		for(var/datum/computer_file/report/crew_record/t in GLOB.all_crew_records)//Look in data core locked.
-			personnel_list["[t.get_name()]: [t.get_rank()]"] = t.photo_front//Pull names, rank, and image.
+			if(personnel_list.len)
+				var/input = input("Select a crew member:") as null|anything in personnel_list
+				var/icon/character_icon = personnel_list[input]
+				if(character_icon)
+					qdel(holo_icon)//Clear old icon so we're not storing it in memory.
+					qdel(holo_icon_longrange)
+					holo_icon = getHologramIcon(icon(character_icon))
+					holo_icon_longrange = getHologramIcon(icon(character_icon), hologram_color = HOLOPAD_LONG_RANGE)
+			else
+				alert("No suitable records found. Aborting.")
 
-		if(personnel_list.len)
-			input = input("Select a crew member:") as null|anything in personnel_list
-			var/icon/character_icon = personnel_list[input]
-			if(character_icon)
-				qdel(holo_icon)//Clear old icon so we're not storing it in memory.
+		if("Unique")
+			var/list/hologramsAICanUse = list()
+			var/holograms_by_type = decls_repository.get_decls_of_subtype(/decl/ai_holo)
+			for (var/holo_type in holograms_by_type)
+				var/decl/ai_holo/holo = holograms_by_type[holo_type]
+				if (holo.may_be_used_by_ai(src))
+					hologramsAICanUse.Add(holo)
+			var/decl/ai_holo/choice = input("Please select a hologram:") as null|anything in hologramsAICanUse
+			if(choice)
+				qdel(holo_icon)
 				qdel(holo_icon_longrange)
-				holo_icon = getHologramIcon(icon(character_icon))
-				holo_icon_longrange = getHologramIcon(icon(character_icon), hologram_color = HOLOPAD_LONG_RANGE)
-		else
-			alert("No suitable records found. Aborting.")
+				holo_icon = getHologramIcon(icon(choice.icon, choice.icon_state), noDecolor=choice.bypass_colorize)
+				holo_icon_longrange = getHologramIcon(icon(choice.icon, choice.icon_state), noDecolor=choice.bypass_colorize, hologram_color = HOLOPAD_LONG_RANGE)
+				holo_icon_malf = choice.requires_malf
 
-	else
-		var/list/hologramsAICanUse = list()
-		var/holograms_by_type = decls_repository.get_decls_of_subtype(/decl/ai_holo)
-		for (var/holo_type in holograms_by_type)
-			var/decl/ai_holo/holo = holograms_by_type[holo_type]
-			if (holo.may_be_used_by_ai(src))
-				hologramsAICanUse.Add(holo)
-		var/decl/ai_holo/choice = input("Please select a hologram:") as null|anything in hologramsAICanUse
-		if(choice)
-			qdel(holo_icon)
-			qdel(holo_icon_longrange)
-			holo_icon = getHologramIcon(icon(choice.icon, choice.icon_state), noDecolor=choice.bypass_colorize)
-			holo_icon_longrange = getHologramIcon(icon(choice.icon, choice.icon_state), noDecolor=choice.bypass_colorize, hologram_color = HOLOPAD_LONG_RANGE)
-			holo_icon_malf = choice.requires_malf
+		if("Character Slot")	//Allows players to use a character slot for their hologram. Changes with loadout/job gear selection.
+			if(!client || !client.prefs)	//Shouldn't be possible but... Never hurts
+				return
+
+			var/savefile/S = new /savefile(client.prefs.path)
+			if(S)
+				var/list/characters = list()
+				for(var/i=1, i<= config.character_slots, i++)
+					S.cd = GLOB.using_map.character_load_path(S, i)
+					var/name
+					S["real_name"] >> name
+					characters[name] = i
+				var/chosen_character = input("Which slot do you want to use?") in characters
+				var/prev_slot = client.prefs.default_slot	//So we leave the loaded slot to whatever the player originally set it to
+				client.prefs.load_character(characters[chosen_character])
+				var/mob/living/carbon/human/dummy/mannequin = new()
+				client.prefs.dress_preview_mob(mannequin)
+				client.prefs.load_character(prev_slot)
+				qdel(holo_icon)
+				qdel(holo_icon_longrange)
+				holo_icon = getHologramIcon(getFullIcon(mannequin))
+				holo_icon_longrange = getHologramIcon(getFullIcon(mannequin), hologram_color = HOLOPAD_LONG_RANGE)
+				qdel(mannequin)
+			else
+				alert("No character slots found. Aborting.")
 	return
 
 //Toggles the luminosity and applies it by re-entereing the camera.


### PR DESCRIPTION
Small PR that adds the ability to load a character's icons from a player's character slots, and use it as the AI's hologram.
The hologram will use any job or loadout gear as displayed on the character creation preview (including show/hide gear toggles). This will allow AI players to essentially create their own custom AI holograms if they so wish.

Due to how this works, a new helper has also been added: `getFullIcon()`. As `getFlatIcon()` is limited to returning an icon with a single dir; this proc returns a flat icon containing all 4 dirs, allowing the holograms to turn much like the default ones do.

Thank you to Bealdor for the idea!