### PR TITLE
Reloadable Energy/Smart Gun Fixes

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -147,7 +147,10 @@ GLOBAL_LIST_INIT(registered_cyborg_weapons, list())
 			playsound(loc, mag_remove_sound, 50, 1)
 			power_supply.update_icon()
 			power_supply = null
-			icon_state = "[initial(icon_state)][0]"
+			if(modifystate)
+				icon_state = "[modifystate][0]"
+			else
+				icon_state = "[initial(icon_state)][0]"
 			update_icon()
 		else
 			to_chat(user, "<span class='warning'>[src] is empty.</span>")


### PR DESCRIPTION
Didn't realize that energy guns and smart guns apparently change their icons differently compared to other guns. Thank you Blanc and Asea for letting me know about the issue. Previously basically the issue was that removing the cell from just energy guns or smart guns would change the icon_state incorrectly so it would have no sprite, this basically just adds a very based 3 line code check that changes it properly.
