### PR TITLE
Adds a faction tab to the contract database

### DIFF
--- a/code/modules/urist/modules/newtrading/contracts/contract_computer.dm
+++ b/code/modules/urist/modules/newtrading/contracts/contract_computer.dm
@@ -12,43 +12,115 @@
 
 /datum/nano_module/contract_database
 	name = "Contract Database"
+	var/display_state = 1
+	var/datum/factions/focused
 //	var/selected_category
 //	var/list/category_names
 //	var/list/category_contents
 
-/datum/nano_module/contract_database/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
+/datum/nano_module/contract_database/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
 
 //	category_contents = list()
-	var/list/category[0]
-	for(var/datum/contract/C in GLOB.using_map.contracts)
-//		if(C.is_category())
-//		category_names.Add(C.faction)
-//			category_names.Add(C.name)
-		category.Add(list(list(
-			"name" = C.name,
-			"desc" = C.desc,
-			"issuer" = C.faction.name,
-			"money" = C.money,
-			"amount" = C.amount,
-			"progress" = C.completed
-		)))
-		data["existing_contracts"] = category
-//		category_contents = category
+	data["display_state"] = display_state
+	
+	switch(display_state)
+		if(1)	//Contracts
+			var/list/category[0]
+			for(var/datum/contract/C in GLOB.using_map.contracts)
+		//		if(C.is_category())
+		//		category_names.Add(C.faction)
+		//			category_names.Add(C.name)
+				category.Add(list(list(
+					"name" = C.name,
+					"desc" = C.desc,
+					"issuer" = C.faction.name,
+					"money" = C.money,
+					"amount" = C.amount,
+					"progress" = C.completed
+				)))
+			data["existing_contracts"] = category
+		//		category_contents = category
 
-	data["credits"] = "[SSsupply.points]"
-	data["currency"] = GLOB.using_map.supply_currency_name
-//	data["categories"] = category_names
-//	if(selected_category)
-//	data["category"] = selected_category
-//	data["existing_contracts"] = category_contents
+			data["credits"] = "[SSsupply.points]"
+			data["currency"] = GLOB.using_map.supply_currency_name
+		//	data["categories"] = category_names
+		//	if(selected_category)
+		//	data["category"] = selected_category
+		//	data["existing_contracts"] = category_contents
+
+		if(2)	//Factions
+			var/list/factions[0]
+			for(var/datum/factions/f in SSfactions.factions)
+				var/col = 2 //1 = red, 2 = yellow, 3 = green
+				if(f.hostile)
+					col = 1
+				else 
+					if(f.reputation < -30)	//-100 to -30 but not hostile
+						col = 1
+					else if(f.reputation < -10)	//-30 to -10 but not hostile
+						col = 2
+					else if(f.reputation > 30)	// 30 to 100
+						col = 3
+					else if (f.reputation > 10)	//10 to 30
+						col = 2
+				factions.Add(list(list(
+					"name" = f.name,
+					"col" = col,
+					"ref" = "\ref[f]"
+				)))
+			data["factions"] = factions
+
+		if(3)	//Detailed faction view
+			var/col = 2 //1 = red, 2 = yellow, 3 = green
+			var/standing = "<span class='average'>Neutral</span>"	//-10 to 10
+			if(focused.hostile)
+				standing = "<span class='bad'>Hostile</span>"
+				col = 1
+			else 
+				if(focused.reputation < -30)	//-100 to -30 but not hostile
+					standing = "<span class='bad'>Threatening</span>"
+					col = 1
+				else if(focused.reputation < -10)	//-30 to -10 but not hostile
+					standing = "<span class='average'>Dubious</span>"
+					col = 2
+				else if(focused.reputation > 30)	// 30 to 100
+					standing = "<span class='good'>Friendly</span>"
+					col = 3
+				else if (focused.reputation > 10)	//10 to 30
+					standing = "<span class='average'>Warm</span>"
+					col = 2
+			data["name"] = focused.name
+			data["rep"] = focused.reputation
+			data["col"] = col
+			data["standing"] = standing
+			data["desc"] = focused.desc
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "contract_database.tmpl", name, 1050, 800, state = state)
+		ui = new(user, src, ui_key, "contract_database.tmpl", name, 1050, 800)
 		ui.set_auto_update(1)
 		ui.set_initial_data(data)
 		ui.open()
+
+/datum/nano_module/contract_database/Topic(href, href_list)
+	if(..())
+		return ..()
+
+	if(href_list["display_state"])
+		display_state = text2num(href_list["display_state"])
+		return TOPIC_REFRESH
+
+	if(href_list["return"])
+		display_state = 2
+		focused = null
+		return TOPIC_REFRESH
+
+	if(href_list["more"])
+		focused = locate(href_list["more"])
+		display_state = 3
+		return TOPIC_REFRESH
+
 /*
 /datum/nano_module/contract_database/Topic(href, href_list)
 //	var/mob/user = usr

--- a/nano/templates/contract_database.tmpl
+++ b/nano/templates/contract_database.tmpl
@@ -1,17 +1,57 @@
-<hr>
-<span>Current balance: {{:data.credits}} {{:data.currency}}</span>
-<hr>
-<div class='block'>
-<table style="width:100%">
-<tr><th style="width:15%">Contract<th style="width:50%">Description<th style="width:15%">Issuer<th style="width:10%">Value<th style="width:5%">Required Amount<th style="width:5%">Amount Completed
-{{for data.existing_contracts}}
-	<tr>
-	<td>{{:value.name}}
-	<td>{{:value.desc}}
-	<td><center>{{:value.issuer}}</center>
-	<td><center>{{:value.money}} {{:data.currency}}</center>
-	<td><center>{{:value.amount}}</center>
-	<td><center>{{:value.progress}}</center>
-{{/for}}
-</table>
-</div>
+{{if data.display_state != 3}}
+	<hr>
+	{{:helper.link('Contracts','script',{'display_state':1}, data.display_state == 1 ? 'selected' : null)}}
+	{{:helper.link('Factions','flag',{'display_state':2}, data.display_state == 2 ? 'selected' : null)}}
+{{/if}}
+{{if data.display_state == 1}}
+	<br>
+	<hr>
+	<span>Current balance: {{:data.credits}} {{:data.currency}}</span>
+	<div class='block'>
+	<table style="width:100%">
+	<tr><th style="width:15%">Contract<th style="width:50%">Description<th style="width:15%">Issuer<th style="width:10%">Value<th style="width:5%">Required Amount<th style="width:5%">Amount Completed
+	{{for data.existing_contracts}}
+		<tr>
+		<td>{{:value.name}}
+		<td>{{:value.desc}}
+		<td><center>{{:value.issuer}}</center>
+		<td><center>{{:value.money}} {{:data.currency}}</center>
+		<td><center>{{:value.amount}}</center>
+		<td><center>{{:value.progress}}</center>
+	{{/for}}
+	</table>
+	</div>
+{{else data.display_state == 2}}
+	<br>
+	<hr>
+	<div class ='block'>
+		<h1><center>Factions</center></h1>
+		<br>
+		{{for data.factions}}
+			<h3>
+			{{if value.col == 1}}
+				<span class='bad'>
+			{{else value.col == 2}}
+				<span class='average'>
+			{{else}}
+				<span class='good'>
+			{{/if}}
+			{{:helper.capitalizeFirstLetter(value.name)}} {{:helper.link('','extlink',{'more' : value.ref})}}</span></h3>
+			<br>
+		{{/for}}
+	</div>
+{{else}}
+	<div class='block'>
+		<span class='floatRight'>{{:helper.link('Return', 'arrowreturnthick-1-w',{'return' : null})}}</span>
+		<h1><center>{{:helper.capitalizeFirstLetter(data.name)}}</center></h1>
+		<br>
+		{{:helper.displayBar(data.rep,-100,100,data.col == 1 ? 'bad' : data.col == 2 ? 'average' : 'good','<center><b>Reputation: ' + data.rep) + '</b></center>'}}
+		<span class='floatRight'>
+			<h3><b>Standing:</b> {{:data.standing}}</h3>
+		</span>
+		<br>
+		<hr>
+		<br>
+		{{:data.desc}}
+	</div>
+{{/if}}


### PR DESCRIPTION
As requested c:

Faction tab that displays all factions in the sector, with a detailed view displaying standings, reputation and the faction description.
Standing text is somewhat a placeholder but can always be changed later on, should the faction subsystem get expanded.