### PR TITLE
Fixes shield bypass bug

### DIFF
--- a/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
@@ -6,7 +6,7 @@
 	use_power = 1
 	anchored = 1
 	density = 1
-	var/pass_shield = TRUE
+	var/pass_shield = FALSE
 	var/shield_damage = 0
 	var/hull_damage = 0
 	var/shipid = null


### PR DESCRIPTION
Fixes a bug where all ship weapons bypass hostile shields.

This was changed to `TRUE` in #1020 . Am I missing some sort of reason for this @Glloyd or is it an oversight?
Because right now, **all** weapons except some torpedo warheads pass through shields :L
