### PR TITLE
Update wiki link

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -216,7 +216,7 @@ GUEST_BAN
 FORUMURL "https://discord.gg/0oRsdvoS1DDd5Rv0"
 
 ## Wiki address
-WIKIURL "https://wiki.baystation12.net/Main_Page"
+WIKIURL "https://bay.ss13.me/en/Guides"
 
 ## GitHub address
 GITHUBURL https://github.com/UristMcStation/UristMcStation


### PR DESCRIPTION
Baystation have moved their wiki, meaning the link is dead. This updates the button to point to the new wiki page.