### PR TITLE
Holopads 'R' Us

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -19,13 +19,20 @@ Possible to do for anyone motivated enough:
 	Itegrate EMP effect to disable the unit.
 */
 
+/*
+Revised by CPU_Blanc.
+-Multiple hologram users at the same time added (conference calls)
+-Power usage reworked to scale with additional holograms
+-Languages are now preserved
+-Both holopads must be within range of eachother's max range to connect
+-Visible emotes now only pass through the pad if the source is visible to the user (Either as a hologram, or if the player's eye is in that location)
+*/
+
 
 /*
  * Holopad
  */
 
-#define HOLOPAD_PASSIVE_POWER_USAGE 1
-#define HOLOGRAM_POWER_USAGE 2
 #define RANGE_BASED 4
 #define AREA_BASED 6
 
@@ -41,16 +48,18 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 	var/power_per_hologram = 500 //per usage per hologram
 	idle_power_usage = 5
+	active_power_usage = 50
 
-	var/list/mob/living/silicon/ai/masters = new() //List of AIs that use the holopad
+	var/conference = FALSE
+	var/scan_range = 2	//Range of mobs to capture for conference calls
+	var/list/masters = new() //List of mobs that are projecting on the holopad
 	var/last_request = 0 //to prevent request spam. ~Carn
 	var/holo_range = 5 // Change to change how far the AI can move away from the holopad before deactivating.
 
-	var/incoming_connection = 0
+	var/incoming_connection = FALSE
 	var/mob/living/caller_id
-	var/obj/machinery/hologram/holopad/sourcepad
-	var/obj/machinery/hologram/holopad/targetpad
-	var/last_message
+	var/obj/machinery/hologram/holopad/connected
+	var/list/tracked = list()
 
 	var/map_range = -1 //how far on overmap can it connect, -1 for local zlevels only
 
@@ -61,23 +70,34 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	..()
 	desc = "It's a floor-mounted device for projecting holographic images. Its ID is '[loc.loc]'"
 
+/obj/machinery/hologram/holopad/power_change()
+	. = ..()
+	if(stat & NOPOWER)
+		for(var/mob/M in masters)
+			remove_holo(M)
+		end_call()
+		update_use_power(POWER_USE_OFF)
+	else
+		update_use_power(POWER_USE_IDLE)
+
 /obj/machinery/hologram/holopad/attack_hand(var/mob/living/carbon/human/user) //Carn: Hologram requests.
 	if(!istype(user))
 		return
-	if(incoming_connection && caller_id)
-		if(QDELETED(sourcepad)) // If the sourcepad was deleted, most likely.
-			incoming_connection = 0
-			clear_holo()
+	if(stat & NOPOWER)
+		return
+	if(incoming_connection)
+		if(QDELETED(connected)) // If the sourcepad was deleted, most likely.
+			end_call()
 			return
 		visible_message("The pad hums quietly as it establishes a connection.")
-		if(caller_id.loc!=sourcepad.loc)
+		if(caller_id && caller_id.loc != connected.loc)
 			visible_message("The pad flashes an error message. The caller has left their holopad.")
 			return
-		take_call(user)
+		take_call()
 		return
-	else if(caller_id && !incoming_connection)
-		audible_message("Severing connection to distant holopad.")
-		end_call(user)
+	else if(connected && !incoming_connection)
+		visible_message("Severing connection to distant holopad.")
+		end_call()
 		return
 	switch(alert(user,"Would you like to request an AI's presence or establish communications with another pad?", "Holopad","AI","Holocomms","Cancel"))
 		if("AI")
@@ -91,61 +111,94 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 			else
 				to_chat(user, "<span class='notice'>A request for AI presence was already sent recently.</span>")
 		if("Holocomms")
-			if(user.loc != src.loc)
+			var/call_type = alert(user, "Would you like to make it a conference call?", "Holopad", "Yes", "No")
+			if(call_type == "Yes")
+				conference = TRUE
+			if(user.loc != src.loc && !conference)
 				to_chat(user, "<span class='info'>Please step onto the holopad.</span>")
 				return
 			if(last_request + 200 < world.time) //don't spam other people with requests either, you jerk!
-				last_request = world.time
 				var/list/holopadlist = list()
 				var/zlevels = GetConnectedZlevels(z)
 				if(GLOB.using_map.use_overmap && map_range >= 0)
-					var/obj/effect/overmap/O = map_sectors["[z]"]
-					for(var/obj/effect/overmap/OO in range(O,map_range))
-						zlevels |= OO.map_z
-				for(var/obj/machinery/hologram/holopad/H in SSmachines.machinery)
-					if((H.z in zlevels) && H.operable())
-						holopadlist["[H.loc.loc.name]"] = H	//Define a list and fill it with the area of every holopad in the world
+					var/obj/effect/overmap/baseOM = map_sectors["[z]"]
+					for(var/obj/machinery/hologram/holopad/H in SSmachines.machinery)
+						if(!H.operable())
+							continue
+						if(H.map_range >= 0)
+							var/obj/effect/overmap/targetOM = map_sectors["[H.z]"]
+							if(targetOM == baseOM || ((targetOM in range(baseOM,map_range)) && (baseOM in range(targetOM,H.map_range))))
+								holopadlist["[H.loc.loc.name]"] = H
+						else if(H.z in zlevels)
+							holopadlist["[H.loc.loc.name]"] = H
+				else
+					for(var/obj/machinery/hologram/holopad/H in SSmachines.machinery)
+						if((H.z in zlevels) && H.operable())
+							holopadlist["[H.loc.loc.name]"] = H	//Define a list and fill it with the area of every holopad in the world			
 				holopadlist = sortAssoc(holopadlist)
 				var/temppad = input(user, "Which holopad would you like to contact?", "holopad list") as null|anything in holopadlist
-				targetpad = holopadlist["[temppad]"]
-				if(targetpad==src)
+				var/obj/machinery/hologram/holopad/targetpad = holopadlist["[temppad]"]
+				if(!targetpad)
+					return
+				if(targetpad == src)
 					to_chat(user, "<span class='info'>Using such sophisticated technology, just to talk to yourself seems a bit silly.</span>")
 					return
-				if(targetpad && targetpad.caller_id)
+				if(targetpad.connected)
 					to_chat(user, "<span class='info'>The pad flashes a busy sign. Maybe you should try again later..</span>")
 					return
-				if(targetpad)
-					make_call(targetpad, user)
+				last_request = world.time
+				make_call(targetpad, conference ? null : user)
 			else
 				to_chat(user, "<span class='notice'>A request for holographic communication was already sent recently.</span>")
 
 
 /obj/machinery/hologram/holopad/proc/make_call(var/obj/machinery/hologram/holopad/targetpad, var/mob/living/carbon/user)
+	connected = targetpad
+	set_pad_effects()
+	targetpad.connected = src //This marks the holopad you are making the call from
+	targetpad.incoming_connection = TRUE
 	targetpad.last_request = world.time
-	targetpad.sourcepad = src //This marks the holopad you are making the call from
-	targetpad.caller_id = user //This marks you as the caller
-	targetpad.incoming_connection = 1
+	targetpad.conference = conference
 	playsound(targetpad.loc, 'sound/machines/chime.ogg', 25, 5)
-	targetpad.icon_state = "[targetpad.base_icon]1"
-	targetpad.audible_message("<b>\The [src]</b> announces, \"Incoming communications request from [targetpad.sourcepad.loc.loc].\"")
-	to_chat(user, "<span class='notice'>Trying to establish a connection to the holopad in [targetpad.loc.loc]... Please await confirmation from recipient.</span>")
+	targetpad.set_pad_effects()
+	if(user)
+		targetpad.caller_id = user //This marks you as the caller	
+		targetpad.audible_message("<b>\The [connected]</b> announces, \"Incoming communications request from [connected.connected.loc.loc].\"")
+		to_chat(user, "<span class='notice'>Trying to establish a connection to the holopad in [connected.loc.loc]... Please await confirmation from recipient.</span>")
+	else
+		targetpad.audible_message("<b>\The [connected]</b> announces, \"Incoming holo-conference request from [connected.connected.loc.loc].\"")
+		visible_message("<span class='notice'>Trying to establish a connection to the holopad in [connected.loc.loc]... Please await confirmation from recipient.</span>")
 
+/obj/machinery/hologram/holopad/proc/take_call()
+	incoming_connection = FALSE
+	if(caller_id)
+		caller_id.machine = connected
+		caller_id.reset_view(src)
+		if(!masters[caller_id])//If there is no hologram, possibly make one.
+			add_hologram(caller_id)
+		log_admin("[key_name(caller_id)] just established a holopad connection from [connected.loc.loc] to [src.loc.loc]")
 
-/obj/machinery/hologram/holopad/proc/take_call(mob/living/carbon/user)
-	incoming_connection = 0
-	caller_id.machine = sourcepad
-	caller_id.reset_view(src)
-	if(!masters[caller_id])//If there is no hologram, possibly make one.
-		activate_holocall(caller_id)
-	log_admin("[key_name(caller_id)] just established a holopad connection from [sourcepad.loc.loc] to [src.loc.loc]")
-
-/obj/machinery/hologram/holopad/proc/end_call(mob/user)
-	if(!caller_id)
-		return
-	caller_id.unset_machine()
-	caller_id.reset_view() //Send the caller back to his body
-	clear_holo(0, caller_id) // destroy the hologram
-	caller_id = null
+/obj/machinery/hologram/holopad/proc/end_call(var/ended = TRUE)
+	if(ended && connected)
+		connected.end_call(FALSE)
+	else
+		visible_message("<span class='notice'>The holocall has been terminated</span>")
+	connected = null
+	incoming_connection = FALSE
+	if(caller_id)
+		caller_id.unset_machine()
+		caller_id.reset_view() //Send the caller back to his body
+		remove_holo(caller_id) // destroy the hologram
+		caller_id = null
+	if(conference)
+		conference = FALSE
+		for(var/mob/M in masters)
+			if(isAI(M))
+				continue
+			remove_holo(M)
+		tracked = list()
+	if(!length(masters))
+		set_pad_effects(FALSE)
 
 /obj/machinery/hologram/holopad/check_eye(mob/user)
 	return 0
@@ -159,191 +212,246 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	if(user.eyeobj && (user.eyeobj.loc != src.loc))//Set client eye on the object if it's not already.
 		user.eyeobj.setLoc(get_turf(src))
 	else if(!masters[user])//If there is no hologram, possibly make one.
-		activate_holo(user)
+		add_hologram(user)
 	else//If there is a hologram, remove it.
-		clear_holo(user)
+		remove_holo(user)
 	return
 
-/obj/machinery/hologram/holopad/proc/activate_holo(mob/living/silicon/ai/user)
-	if(!(stat & NOPOWER) && user.eyeobj && user.eyeobj.loc == src.loc)//If the projector has power and client eye is on it
-		if (user.holo)
-			to_chat(user, "<span class='danger'>ERROR:</span> Image feed in progress.")
-			return
-		src.visible_message("A holographic image of [user] flicks to life right before your eyes!")
-		create_holo(user)//Create one.
+
+//HOLOGRAM STUFF//
+
+/obj/machinery/hologram/holopad/proc/add_hologram(mob/living/user)
+	if(isAI(user))
+		var/mob/living/silicon/ai/AI = user
+		if(!(stat & NOPOWER) && AI.eyeobj && AI.eyeobj.loc == src.loc)
+			if(AI.holo)
+				to_chat(AI, "<span class='danger'>ERROR:</span> Image feed in progress.")
+				return
+			create_holo(AI, TRUE)//Create one.
+		else
+			to_chat(user, "<span class='danger'>ERROR:</span> Unable to project hologram.")
+	else if(isliving(user))
+		create_holo(user)
+
+/obj/machinery/hologram/holopad/proc/create_holo(mob/living/user, isAI = FALSE, turf/T = loc)
+	var/obj/effect/overlay/hologram = new(T)//Spawn a blank effect at the location.
+
+	if(isAI)
+		var/mob/living/silicon/ai/AI = user
+		hologram.overlays += holopadType == HOLOPAD_LONG_RANGE ? AI.holo_icon_longrange : AI.holo_icon
+		if(AI.holo_icon_malf == TRUE)
+			hologram.overlays += icon("icons/effects/effects.dmi", "malf-scanline")
+		AI.holo = src
+		set_pad_effects()
 	else
-		to_chat(user, "<span class='danger'>ERROR:</span> Unable to project hologram.")
-	return
+		hologram.overlays += getHologramIcon(getFullIcon(user), hologram_color = holopadType) // Add the callers image as an overlay to keep coloration!
+		hologram.forceMove(get_step(src,1))
 
-/obj/machinery/hologram/holopad/proc/activate_holocall(mob/living/carbon/caller_id)
-	if(caller_id)
-		src.visible_message("A holographic image of [caller_id] flicks to life right before your eyes!")
-		create_holo(0,caller_id)//Create one.
+	hologram.mouse_opacity = 0//So you can't click on it.
+	hologram.plane = ABOVE_HUMAN_PLANE
+	hologram.layer = ABOVE_HUMAN_LAYER //Above all the other objects/mobs. Or the vast majority of them.
+	hologram.anchored = 1//So space wind cannot drag it.
+	hologram.SetName("[user.name] (Hologram)")
+	masters[user] = hologram
+	hologram.set_light(1, 0.1, 2)	//hologram lighting
+	hologram.color = color //painted holopad gives coloured holograms
+	visible_message("A holographic image of [user] flicks to life right before your eyes!")
+	change_power_consumption(active_power_usage + power_per_hologram, POWER_USE_ACTIVE)
+	return 1
+
+/obj/machinery/hologram/holopad/proc/remove_holo(mob/living/user)
+	if(user)
+		qdel(masters[user])//Get rid of user's hologram
+		masters -= user //Remove the user from the list of masters
+		change_power_consumption(max(active_power_usage - power_per_hologram, initial(active_power_usage)), POWER_USE_ACTIVE)
+		if(isAI(user))
+			var/mob/living/silicon/ai/AI = user
+			AI.holo = null
+
+	if(!length(masters))	//If no users left
+		set_pad_effects(FALSE)
+		if(connected && !incoming_connection)
+			end_call()
+	return 1
+
+/obj/machinery/hologram/holopad/proc/move_hologram(mob/living/user, var/x, var/y, var/dir)
+	if(masters[user])
+		if(isAI(user))
+			step_to(masters[user], user.eyeobj) // So it turns.
+			var/obj/effect/overlay/H = masters[user]
+			H.dropInto(user.eyeobj)
+			masters[user] = H
+
+			if(!(H in view(src)))
+				remove_holo(user)
+				return 0
+
+			if((HOLOPAD_MODE == RANGE_BASED && (get_dist(user.eyeobj, src) > holo_range)))
+				remove_holo(user)
+
+			if(HOLOPAD_MODE == AREA_BASED)
+				var/area/holo_area = get_area(src)
+				var/area/hologram_area = get_area(H)
+				if(hologram_area != holo_area)
+					remove_holo(user)
+			return 1
+
+		else
+			var/obj/effect/overlay/H = masters[user]
+			var/dest = locate(src.x + x, src.y + y, src.z)
+			step_to(H, dest)
+			H.dropInto(dest)
+			H.dir = dir
+			return 1
+
+/obj/machinery/hologram/holopad/proc/set_dir_hologram(new_dir, mob/living/user)
+	if(masters[user])
+		var/obj/effect/overlay/hologram = masters[user]
+		hologram.dir = new_dir
+
+/obj/machinery/hologram/holopad/proc/set_pad_effects(var/on = TRUE)
+	if(on)
+		set_light(1, 0.1, 2)
+		update_use_power(POWER_USE_ACTIVE)
+		icon_state = "[base_icon]1"
 	else
-		to_chat(caller_id, "<span class='danger'>ERROR:</span> Unable to project hologram.")
-	return
+		set_light(0)
+		update_use_power(POWER_USE_IDLE)
+		icon_state = "[base_icon]0"
 
-/*This is the proc for special two-way communication between AI and holopad/people talking near holopad.
-For the other part of the code, check silicon say.dm. Particularly robot talk.*/
-// Note that speaking may be null here, presumably due to echo effects/non-mob transmission.
+
+//PROCESS STUFF//
+
+/obj/machinery/hologram/holopad/Process()
+	for(var/mob/living/silicon/ai/master in masters)
+		var/active_ai = (master && !master.incapacitated() && master.client && master.eyeobj)//If there is an AI with an eye attached, it's not incapacitated, and it has a client
+		if((stat & NOPOWER) || !active_ai)
+			remove_holo(master)
+			continue
+
+		if(!(masters[master] in view(src)))
+			remove_holo(master)
+			continue
+
+	if(last_request + 200 < world.time && incoming_connection == TRUE)
+		if(connected)
+			connected.visible_message("<i><span class='game say'>The holopad connection timed out.</span></i>")
+			connected.end_call()
+		incoming_connection = FALSE
+
+	if(caller_id && connected)
+		if(caller_id.loc != connected.loc)
+			connected.visible_message("<span class='notice'>Severing connection to distant holopad.</span>")
+			connected.end_call()
+	
+	if(conference && connected)
+		process_mobs()
+
+	return TRUE
+
+/obj/machinery/hologram/holopad/proc/process_mobs()
+	if(!connected)
+		return
+	if(incoming_connection || connected.incoming_connection)
+		return
+
+	var/list/scanned = view(scan_range, src)
+
+	for(var/mob/living/M in tracked)
+		if(isAI(M))
+			continue
+		if(M in scanned)
+			if(tracked[M]["x"] != M.x || tracked[M]["y"] != M.y)
+				connected.move_hologram(M, M.x - src.x, M.y - src.y, M.dir)
+				tracked[M]["x"] = M.x
+				tracked[M]["y"] = M.y
+				tracked[M]["dir"] = M.dir
+			else if(tracked[M]["dir"] != M.dir)
+				connected.set_dir_hologram(M.dir, M)
+				tracked[M]["dir"] = M.dir
+		else
+			connected.remove_holo(M)
+			tracked -= M
+
+	var/list/new_targets = tracked ^ scanned
+
+	for(var/mob/living/M in new_targets)
+		connected.add_hologram(M)
+		connected.move_hologram(M, M.x - src.x, M.y - src.y, M.dir)
+		tracked[M] = list("x" = M.x, "y" = M.y, "dir" = M.dir)
+
+
+
+//EMOTES & SPEECH STUFF//
+
 /obj/machinery/hologram/holopad/hear_talk(mob/living/M, text, verb, datum/language/speaking)
-	if(M)
-		for(var/mob/living/silicon/ai/master in masters)
-			var/ai_text = text
-			if(!master.say_understands(M, speaking))//The AI will be able to understand most mobs talking through the holopad.			
-				if(speaking)
-					ai_text = speaking.scramble(text)
-				else
-					ai_text = stars(text)
-			var/name_used = M.GetVoice()
-			//This communication is imperfect because the holopad "filters" voices and is only designed to connect to the master only.
-			master.show_message(get_hear_message(name_used, ai_text, verb, speaking), 2)
-	var/name_used = M.GetVoice()
-	var/message = get_hear_message(name_used, text, verb, speaking)
-	if(targetpad) //If this is the pad you're making the call from
-		targetpad.audible_message(message)
-		targetpad.last_message = message
-	if(sourcepad) //If this is a pad receiving a call
-		if(name_used==caller_id||text==last_message||findtext(text, "Holopad received")) //prevent echoes
+	var/used_voice = M.GetVoice()
+	for(var/mob/living/silicon/ai/AI in masters)
+		var/message = text
+		if(!AI.say_understands(M, speaking))
+			message = speaking ? speaking.scramble(text) : stars(text)
+		AI.show_message(get_hear_message(used_voice, message, verb, speaking), 2)
+	if(connected && !incoming_connection)
+		if(!connected.connected)
+			end_call()
 			return
-		sourcepad.audible_message(message)
+		connected.broadcast_message(M, text, verb, speaking)
+
+//Leaving this here, but as far as I can see, nowhere actually calls this proc???
+/obj/machinery/hologram/holopad/see_emote(mob/living/M, text)
+	for(var/mob/living/silicon/ai/AI in masters)
+		var/rendered = "<i><span class='game say'>Holopad received, <span class='message'>[text]</span></span></i>"
+		AI.show_message(rendered, 2)
+	if(connected && !incoming_connection)
+		if(!connected.connected)	//Fallback for wonky behaviour
+			end_call()
+			return
+		connected.visible_message("<i><span class='message'>[text]</span></i>")
+
+/obj/machinery/hologram/holopad/show_message(msg, type, alt, alt_type)
+	for(var/mob/living/spectator in masters)
+		if(spectator == caller_id || isAI(spectator))
+			spectator.show_message(msg, type)	//Anyone with their view set over to the holopad sees everything as normal
+	if(connected && !incoming_connection)
+		if(!connected.connected)
+			end_call()
+			return
+		var/rendered
+		for(var/mob/M in connected.masters)
+			if(findtext(msg, M.name))
+				rendered = "<i><span class='game say'>The holographic image of <span class='message'>[msg]</span></span></i>"
+				break
+		if(type == AUDIBLE_MESSAGE && !rendered)	//Or what the holopad can hear
+			rendered = "<i><span class='game say'>Holopad received, <span class='message'>[msg]</span></span></i>"
+		if(rendered)
+			for(var/mob/living/mobs in view(connected))
+				if(mobs == caller_id)
+					continue
+				mobs.show_message(rendered, type)
 
 /obj/machinery/hologram/holopad/proc/get_hear_message(name_used, text, verb, datum/language/speaking)
 	if(speaking)
 		return "<i><span class='game say'>Holopad received, <span class='name'>[name_used]</span> [speaking.format_message(text, verb)]</span></i>"
 	return "<i><span class='game say'>Holopad received, <span class='name'>[name_used]</span> [verb], <span class='message'>\"[text]\"</span></span></i>"
 
-/obj/machinery/hologram/holopad/see_emote(mob/living/M, text)
-	if(M)
-		for(var/mob/living/silicon/ai/master in masters)
-			//var/name_used = M.GetVoice()
-			var/rendered = "<i><span class='game say'>Holopad received, <span class='message'>[text]</span></span></i>"
-			//The lack of name_used is needed, because message already contains a name.  This is needed for simple mobs to emote properly.
-			master.show_message(rendered, 2)
-		for(var/mob/living/carbon/master in masters)
-			//var/name_used = M.GetVoice()
-			var/rendered = "<i><span class='game say'>Holopad received, <span class='message'>[text]</span></span></i>"
-			//The lack of name_used is needed, because message already contains a name.  This is needed for simple mobs to emote properly.
-			master.show_message(rendered, 2)
-		if(targetpad)
-			targetpad.visible_message("<i><span class='message'>[text]</span></i>")
+//Because the holopads can't 'speak', this is used to preserve languages on the other side.
+//This is essentially atom.audible_message() except with language taken into account
+/obj/machinery/hologram/holopad/proc/broadcast_message(mob/living/M, text, verb, datum/language/speaking)
+	var/turf/T = get_turf(src)
+	var/list/mobs = list()
+	var/list/objs = list()
+	get_mobs_and_objs_in_view_fast(T, world.view, mobs, objs)
 
-/obj/machinery/hologram/holopad/show_message(msg, type, alt, alt_type)
-	for(var/mob/living/silicon/ai/master in masters)
-		var/rendered = "<i><span class='game say'>The holographic image of <span class='message'>[msg]</span></span></i>"
-		master.show_message(rendered, type)
-	if(findtext(msg, "Holopad received,"))
-		return
-	for(var/mob/living/carbon/master in masters)
-		var/rendered = "<i><span class='game say'>The holographic image of <span class='message'>[msg]</span></span></i>"
-		master.show_message(rendered, type)
-	if(targetpad)
-		for(var/mob/living/carbon/master in view(targetpad))
-			var/rendered = "<i><span class='game say'>The holographic image of <span class='message'>[msg]</span></span></i>"
-			master.show_message(rendered, type)
+	var/used_name = M.GetVoice()
+	var/understood = get_hear_message(used_name, text, verb, speaking)
+	var/gibberish = get_hear_message(used_name, speaking ? speaking.scramble(text) : stars(text), verb, speaking)
 
-/obj/machinery/hologram/holopad/proc/create_holo(mob/living/silicon/ai/A, mob/living/carbon/caller_id, turf/T = loc)
-	var/obj/effect/overlay/hologram = new(T)//Spawn a blank effect at the location.
-	if(caller_id)
-		var/datum/computer_file/report/crew_record/R = get_crewmember_record(caller_id.name)
-		if(R)
-			hologram.overlays += getHologramIcon(icon(R.photo_front), hologram_color = holopadType) // Add the callers image as an overlay to keep coloration!
-	else if(A)
-		if(holopadType == HOLOPAD_LONG_RANGE)
-			hologram.overlays += A.holo_icon_longrange
-		else
-			hologram.overlays += A.holo_icon // Add the AI's configured holo Icon
-	if(A)
-		if(A.holo_icon_malf == TRUE)
-			hologram.overlays += icon("icons/effects/effects.dmi", "malf-scanline")
-	hologram.mouse_opacity = 0//So you can't click on it.
-	hologram.plane = ABOVE_HUMAN_PLANE
-	hologram.layer = ABOVE_HUMAN_LAYER //Above all the other objects/mobs. Or the vast majority of them.
-	hologram.anchored = 1//So space wind cannot drag it.
-	if(caller_id)
-		hologram.SetName("[caller_id.name] (Hologram)")
-		hologram.forceMove(get_step(src,1))
-		masters[caller_id] = hologram
-	else
-		hologram.SetName("[A.name] (Hologram)") //If someone decides to right click.
-		A.holo = src
-		masters[A] = hologram
-	hologram.set_light(1, 0.1, 2)	//hologram lighting
-	hologram.color = color //painted holopad gives coloured holograms
-	set_light(1, 0.1, 2)			//pad lighting
-	icon_state = "[base_icon]1"
-	return 1
+	for(var/mob/hearer in mobs)
+		hearer.show_message(hearer.say_understands(M, speaking) ? understood : gibberish,2,null,1)
 
-/obj/machinery/hologram/holopad/proc/clear_holo(mob/living/silicon/ai/user, mob/living/carbon/caller_id)
-	if(user)
-		qdel(masters[user])//Get rid of user's hologram
-		user.holo = null
-		masters -= user //Discard AI from the list of those who use holopad
-	if(caller_id)
-		qdel(masters[caller_id])//Get rid of user's hologram
-		masters -= caller_id //Discard the caller from the list of those who use holopad
-	if (!masters.len)//If no users left
-		set_light(0)			//pad lighting (hologram lighting will be handled automatically since its owner was deleted)
-		icon_state = "[base_icon]0"
-		if(sourcepad)
-			sourcepad.targetpad = null
-			sourcepad = null
-			caller_id = null
-	return 1
-
-
-/obj/machinery/hologram/holopad/Process()
-	for (var/mob/living/silicon/ai/master in masters)
-		var/active_ai = (master && !master.incapacitated() && master.client && master.eyeobj)//If there is an AI with an eye attached, it's not incapacitated, and it has a client
-		if((stat & NOPOWER) || !active_ai)
-			clear_holo(master)
-			continue
-
-		if(!(masters[master] in view(src)))
-			clear_holo(master)
-			continue
-
-		use_power_oneoff(power_per_hologram)
-	if(last_request + 200 < world.time&&incoming_connection==1)
-		if(sourcepad)
-			sourcepad.audible_message("<i><span class='game say'>The holopad connection timed out</span></i>")
-		incoming_connection = 0
-		end_call()
-	if (caller_id&&sourcepad)
-		if(caller_id.loc!=sourcepad.loc)
-			sourcepad.to_chat(caller_id, "Severing connection to distant holopad.")
-			end_call()
-			audible_message("The connection has been terminated by the caller.")
-	return 1
-
-/obj/machinery/hologram/holopad/proc/move_hologram(mob/living/silicon/ai/user)
-	if(masters[user])
-		step_to(masters[user], user.eyeobj) // So it turns.
-		var/obj/effect/overlay/H = masters[user]
-		H.dropInto(user.eyeobj)
-		masters[user] = H
-
-		if(!(H in view(src)))
-			clear_holo(user)
-			return 0
-
-		if((HOLOPAD_MODE == RANGE_BASED && (get_dist(user.eyeobj, src) > holo_range)))
-			clear_holo(user)
-
-		if(HOLOPAD_MODE == AREA_BASED)
-			var/area/holo_area = get_area(src)
-			var/area/hologram_area = get_area(H)
-			if(hologram_area != holo_area)
-				clear_holo(user)
-	return 1
-
-
-/obj/machinery/hologram/holopad/proc/set_dir_hologram(new_dir, mob/living/silicon/ai/user)
-	if(masters[user])
-		var/obj/effect/overlay/hologram = masters[user]
-		hologram.dir = new_dir
-
-
+	for(var/obj/O in objs)
+		if(O != src)	//Prevents echoes
+			O.show_message(understood,2,null,1)
 
 /*
  * Hologram
@@ -368,8 +476,9 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	return
 
 /obj/machinery/hologram/holopad/Destroy()
-	for (var/mob/living/master in masters)
-		clear_holo(master)
+	for(var/mob/living/master in masters)
+		remove_holo(master)
+	end_call()
 	return ..()
 
 /*
@@ -405,7 +514,7 @@ Holographic project of everything else.
 
 /obj/machinery/hologram/holopad/longrange
 	name = "long range holopad"
-	desc = "It's a floor-mounted device for projecting holographic images. This one utilizes bluespace transmitter to communicate with far away locations."
+	desc = "It's a floor-mounted device for projecting holographic images. This one utilizes a bluespace transmitter to communicate with far away locations."
 	icon_state = "holopad-Y0"
 	map_range = 2
 	power_per_hologram = 1000 //per usage per hologram
@@ -414,5 +523,3 @@ Holographic project of everything else.
 
 #undef RANGE_BASED
 #undef AREA_BASED
-#undef HOLOPAD_PASSIVE_POWER_USAGE
-#undef HOLOGRAM_POWER_USAGE


### PR DESCRIPTION
The current holopad code has been driving me nuts with various bugs, oversights and general mess. This is a (hopefully better) refactor of the code, as well as some added features.
Changes are as follows:

- Holopad power consumption is now properly handled, and scales with each additional hologram as well as depending on normal or long ranged versions
- Code refactor should address an odd bug that would occasionally happen where holopads would continue to transmit voice, despite the call being ended. A fallback sanity check has been added.
- Holopad range limits have been tweaked to require _both_ pads to be within each other's range. Previously a long-range pad could call a normal pad even if the normal pad would not be able to dial back, this way, long-range pads can only dial other long-range pads if the standard range has been exceeded.
- Languages are now preserved through holocalls. Previously all languages were magically translated by holopads, this is no longer the case as a proc has been added to allow the pad to 'speak'.
- Emote behaviour has been changed to make more sense. Now, not _all_ emotes are broadcast to the other side. **Visible** emotes require the other party to be able to actually see the source; either their 'eye'/camera must be viewing the source (as with a standard holocall), or if the source is projecting a hologram of themselves. For example; in a standard holocall where person A has dialled person B while person C is close by A (A is projecting a hologram), A can see all visible emotes B performs while C cannot, while B can see all visible emotes only A performs (hologram) and not C. Anyone else in the room with B would also be able to see A's emotes. All **audible** emotes are transmitted regardless. This means you will no longer get visible emotes for random stuff the player cannot actually see (looking at you, sudden acceleration messages!).
- Added conference calls. This is an extra option that appears while starting a holocall. If selected, both holopads work in a phonecall loudspeaker sort of ways, where **everyone** in a 2 tile radius (default) of each holopad is transmitted to the other side in their relative locations. AI's can still use the pads while this mode is active, however currently they won't be able to hear or speak to the other end of the call.

Below are a couple of screenshots highlighting the conference feature. The location of the mobs relative to the pad would match either side (as well as direction), just in this example the mobs had moved between shots. For an added bonus, animals and simplemobs are also captured for fun! Be careful if using this on the Trajan however, as long range pads use more power, and so do additional projected holograms!
![image](https://user-images.githubusercontent.com/54823378/146869677-46eb8e04-afa0-4b87-a18d-5c7414f62ad3.png)
![image](https://user-images.githubusercontent.com/54823378/146869777-39dac00e-0804-422a-a71f-86e61bee7402.png)


Sorry if there's any issues, this code has been sitting 70% done for a while and I've only recently come back to it, but as far as I've tested, it all seems to work as intended.
