### PR TITLE
Auto-Wrapping Disposals Chutes + Map Tweaks

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1604,8 +1604,11 @@
 			AM.forceMove(src.loc)
 			AM.pipe_eject(dir)
 			if(unwrap && istype(AM, /obj/structure/bigDelivery))
-				qdel(AM)
-
+				var/obj/structure/bigDelivery/O = AM
+				var/atom/movable/C = O.wrapped
+				qdel(O)
+				spawn(5)
+					C.throw_at(target, 1, 1)
 			else
 				if(!istype(AM,/mob/living/silicon/robot/drone)) //Drones keep smashing windows from being fired out of chutes. Bad for the station. ~Z
 					spawn(5)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1596,7 +1596,9 @@
 
 	flick("outlet-open", src)
 	playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
-	sleep(20)	//wait until correct animation frame
+	if(H)
+		H.active = FALSE	//Stop processing the holder
+	sleep(27)	//wait until correct animation frame
 	playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
 
 	if(H)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -514,3 +514,76 @@
 	uses_charge = 1
 	charge_costs = list(1)
 	stacktype = /obj/item/stack/package_wrap
+
+/obj/machinery/disposal/deliveryChute/wrap
+	name = "wrapping delivery chute"
+	desc = "A chute for big and small packages alike! This one automatically wraps and tags packages"
+	var/currTag = 0
+
+/obj/machinery/disposal/deliveryChute/wrap/Bumped(var/atom/movable/AM)
+	if(istype(AM, /obj/item/projectile) || istype(AM, /obj/effect))	return
+	if(istype(AM, /obj/mecha))	return
+	switch(dir)
+		if(NORTH)
+			if(AM.loc.y != src.loc.y+1) return
+		if(EAST)
+			if(AM.loc.x != src.loc.x+1) return
+		if(SOUTH)
+			if(AM.loc.y != src.loc.y-1) return
+		if(WEST)
+			if(AM.loc.x != src.loc.x-1) return
+
+	if(currTag == 0)
+		playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 1)
+		audible_message("No destination tag set")
+		return
+	var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(AM.loc))
+	P.icon_state = "deliverycrate"
+	P.wrapped = AM
+	AM.forceMove(P)
+	P.sortTag = src.currTag
+	P.forceMove(src)
+	src.flush()
+
+/obj/machinery/disposal/deliveryChute/wrap/proc/openwindow(mob/user as mob)
+	var/dat = "<tt><center><h1><b>TagMaster 2.3</b></h1></center>"
+
+	dat += "<table style='width:100%; padding:4px;'><tr>"
+	for(var/i = 1, i <= GLOB.tagger_locations.len, i++)
+		dat += "<td><a href='?src=\ref[src];nextTag=[GLOB.tagger_locations[i]]'>[GLOB.tagger_locations[i]]</a></td>"
+
+		if (i%4==0)
+			dat += "</tr><tr>"
+
+	dat += "</tr></table><br>Current Selection: [currTag ? currTag : "None"]</tt>"
+	dat += "<br><a href='?src=\ref[src];nextTag=CUSTOM'>Enter custom location.</a>"
+	user << browse(dat, "window=destTagScreen;size=450x375")
+	onclose(user, "destTagScreen")
+
+/obj/machinery/disposal/deliveryChute/wrap/attack_hand(mob/user as mob)
+	. = ..()
+	openwindow(user)
+
+/obj/machinery/disposal/deliveryChute/wrap/OnTopic(user, href_list, state)
+	if(href_list["nextTag"] && href_list["nextTag"] in GLOB.tagger_locations)
+		src.currTag = href_list["nextTag"]
+		to_chat(user, "<span class='notice'>You set [src] to <b>[src.currTag]</b>.</span>")
+		playsound(src.loc, 'sound/machines/chime.ogg', 50, 1)
+		. = TOPIC_REFRESH
+	if(href_list["nextTag"] == "CUSTOM")
+		var/dest = input(user, "Please enter custom location.", "Location", src.currTag ? src.currTag : "None")
+		if(CanUseTopic(user, state))
+			if(dest && lowertext(dest) != "none")
+				src.currTag = dest
+				to_chat(user, "<span class='notice'>You designate a custom location on [src], set to <b>[src.currTag]</b>.</span>")
+				playsound(src.loc, 'sound/machines/chime.ogg', 50, 1)
+			else
+				src.currTag = 0
+				to_chat(user, "<span class='notice'>You clear [src]'s custom location.</span>")
+				playsound(src.loc, 'sound/machines/chime.ogg', 50, 1)
+			. = TOPIC_REFRESH
+		else
+			. = TOPIC_HANDLED
+
+	if(. == TOPIC_REFRESH)
+		openwindow(user)

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -528,6 +528,10 @@
 "bi" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -537,6 +541,9 @@
 /area/logistics/hangar)
 "bj" = (
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -546,6 +553,9 @@
 /area/logistics/hangar)
 "bk" = (
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -558,6 +568,9 @@
 /area/logistics/hangar)
 "bl" = (
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -570,6 +583,9 @@
 /area/logistics/hangar)
 "bm" = (
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -587,6 +603,9 @@
 /area/logistics/hangar)
 "bn" = (
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -600,6 +619,10 @@
 "bo" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable{
@@ -746,6 +769,7 @@
 /area/maintenance/fourth_deck/afp)
 "bC" = (
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -785,6 +809,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "bI" = (
@@ -1172,6 +1197,7 @@
 /area/maintenance/fourth_deck/afp)
 "cE" = (
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1272,6 +1298,7 @@
 	tag = "icon-manifold (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1639,6 +1666,7 @@
 /area/maintenance/fourth_deck/afp)
 "ds" = (
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1757,6 +1785,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -2050,6 +2079,7 @@
 /area/maintenance/fourth_deck/afp)
 "ed" = (
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -2425,6 +2455,10 @@
 	tag = "90Curve"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "eQ" = (
@@ -2446,6 +2480,9 @@
 	req_access = list("ACCESS_MAINT")
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "eS" = (
@@ -2631,6 +2668,7 @@
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -2994,15 +3032,14 @@
 "fO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -3034,6 +3071,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 1;
@@ -3058,6 +3098,9 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -3070,6 +3113,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	icon_state = "intact-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/random/tool,
 /obj/structure/catwalk,
@@ -3087,6 +3133,9 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "fU" = (
@@ -3097,6 +3146,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -4054,18 +4107,18 @@
 "hI" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (SOUTHEAST)"
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
+	dir = 4;
 	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4282,6 +4335,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "ib" = (
@@ -4299,6 +4355,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4319,6 +4378,9 @@
 	icon_state = "4-8"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "id" = (
@@ -4334,24 +4396,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "ie" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (NORTHWEST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	icon_state = "intact-supply";
-	tag = "icon-intact (SOUTHWEST)"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/structure/disposalpipe/up{
+	dir = 8;
+	tag = "icon-pipe-u (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4856,6 +4910,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -4886,9 +4944,9 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -7083,10 +7141,9 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/disposalpipe/sortjunction{
+/obj/structure/disposalpipe/segment{
 	dir = 8;
-	name = "Forensics Office";
-	sortType = "Forensics Office"
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -7105,7 +7162,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -7134,6 +7191,9 @@
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck Fore Port Maintenance APC"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "mP" = (
@@ -7150,6 +7210,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -8327,6 +8391,24 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
+"oF" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "oG" = (
 /obj/machinery/icecream_vat,
 /turf/simulated/floor/tiled/freezer,
@@ -9103,10 +9185,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qk" = (
@@ -9126,9 +9204,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "ql" = (
@@ -9147,9 +9222,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -9175,9 +9247,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qn" = (
@@ -9196,9 +9265,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -9220,9 +9286,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "qp" = (
@@ -9242,9 +9305,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -9269,9 +9329,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qr" = (
@@ -9292,9 +9349,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qs" = (
@@ -9314,9 +9368,6 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qt" = (
@@ -9332,10 +9383,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "qu" = (
@@ -9959,7 +10006,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "rs" = (
@@ -10128,10 +10174,6 @@
 	dir = 1;
 	icon_state = "camera"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "rC" = (
@@ -10151,9 +10193,6 @@
 	dir = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -10403,7 +10442,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "sd" = (
@@ -10482,9 +10520,6 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "sm" = (
@@ -10502,9 +10537,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -10526,12 +10558,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	icon_state = "pipe-j2s";
-	name = "Xenoflora Lab";
-	sortType = "Xenoflora Lab"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "sp" = (
@@ -10905,12 +10932,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
-	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/central)
@@ -10929,6 +10956,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -10940,6 +10970,11 @@
 "sQ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10953,8 +10988,6 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/central)
 "sR" = (
@@ -11045,9 +11078,6 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "sZ" = (
@@ -11069,10 +11099,6 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "td" = (
@@ -11169,8 +11195,8 @@
 	tag = "icon-warning (NORTH)"
 	},
 /obj/structure/disposaloutlet/unwrap{
-	icon_state = "outlet";
-	dir = 8
+	dir = 8;
+	icon_state = "outlet"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bottomgun)
@@ -11321,8 +11347,8 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -13850,7 +13876,7 @@
 /obj/machinery/autolathe,
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "torpedo"
+	id = "cargo_belt"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -13858,7 +13884,7 @@
 "yd" = (
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "torpedo"
+	id = "cargo_belt"
 	},
 /obj/structure/shipammo/torpedo,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -13867,7 +13893,7 @@
 "ye" = (
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "torpedo"
+	id = "cargo_belt"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -13876,17 +13902,15 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/disposal/deliveryChute{
-	dir = 8;
-	icon_state = "intake";
-	name = "cargo chute"
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
+	},
+/obj/machinery/disposal/deliveryChute/wrap{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/fabwork)
@@ -14376,13 +14400,13 @@
 "yV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -15282,8 +15306,7 @@
 /area/logistics/fabwork)
 "AD" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10;
@@ -15300,12 +15323,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10;
 	icon_state = "corner_white";
 	tag = "icon-corner_white (SOUTHWEST)"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
 "AF" = (
@@ -19343,17 +19369,19 @@
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
 "HU" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fp)
+/area/logistics/hangar)
 "HV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -20288,8 +20316,8 @@
 /obj/effect/floor_decal/floordetail/edgedrain,
 /obj/machinery/light/chromatic,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
@@ -20323,12 +20351,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -20448,7 +20476,7 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -20655,6 +20683,9 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red,
 /turf/simulated/floor/plating,
@@ -20788,6 +20819,28 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/hadrian/main)
+"MJ" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "MO" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5;
@@ -21207,10 +21260,6 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "PB" = (
@@ -21315,6 +21364,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/hadrian/main)
+"PV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "Torpedo Bay";
+	sortType = "Torpedo Bay"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fs)
 "PW" = (
 /obj/structure/table/standard,
 /obj/item/weapon/lipstick/black,
@@ -21358,10 +21423,6 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Qp" = (
@@ -21425,9 +21486,6 @@
 	},
 /obj/machinery/light/small/red,
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Qv" = (
@@ -21472,9 +21530,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access = list("ACCESS_MAINT")
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -21778,9 +21833,30 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "Rz" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/logistics/fabwork)
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/logistics/hangar)
 "RC" = (
 /obj/structure/table/standard,
 /obj/random/smokes,
@@ -21803,7 +21879,10 @@
 	dir = 6
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "RI" = (
@@ -22161,6 +22240,9 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Tu" = (
@@ -22302,7 +22384,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Ur" = (
@@ -22575,6 +22656,28 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
+"VM" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (NORTHWEST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply";
+	tag = "icon-intact (SOUTHWEST)"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "VP" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -22785,23 +22888,18 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fourth_deck/fs)
 "WB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	icon_state = "pipe-j1s";
-	name = "Torpedo Bay";
-	sortType = "Torpedo Bay";
-	tag = "icon-pipe-j1s (NORTH)"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fs)
+/area/maintenance/fourth_deck/fp)
 "WE" = (
 /obj/machinery/suit_cycler/science,
 /obj/machinery/camera/network/research{
@@ -22952,6 +23050,18 @@
 /obj/structure/stasis_cage,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
+"XD" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "XF" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23022,9 +23132,6 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "XT" = (
@@ -23132,17 +23239,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/conveyor_switch/oneway{
-	id = "torpedo"
+	id = "cargo_belt"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Cargo Workshop";
-	sortType = "Cargo Workshop"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -23173,7 +23278,7 @@
 "YC" = (
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "torpedo"
+	id = "cargo_belt"
 	},
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -43434,7 +43539,7 @@ pj
 qg
 rn
 nw
-sK
+sM
 tz
 tz
 tz
@@ -43819,7 +43924,7 @@ bC
 cE
 ds
 ed
-mp
+Rz
 fj
 fV
 gl
@@ -43838,7 +43943,7 @@ fj
 qh
 rp
 bh
-sK
+sM
 tB
 sd
 vx
@@ -44040,7 +44145,7 @@ bZ
 qi
 rq
 bh
-sK
+sM
 tC
 sd
 vx
@@ -44857,7 +44962,7 @@ xm
 Kr
 yf
 Yx
-Rz
+zP
 AD
 Wq
 BV
@@ -46845,7 +46950,7 @@ aD
 bh
 bo
 bH
-iU
+HU
 cM
 dD
 bH
@@ -46855,7 +46960,7 @@ bH
 bH
 bH
 cM
-iU
+HU
 bH
 jd
 ZP
@@ -47059,7 +47164,7 @@ gt
 hC
 ci
 iw
-bp
+je
 jT
 kP
 lC
@@ -51103,7 +51208,7 @@ hY
 kk
 hY
 hY
-mJ
+WB
 nE
 oG
 pB
@@ -51305,7 +51410,7 @@ js
 kl
 kY
 hY
-mJ
+WB
 nE
 nE
 pC
@@ -51508,7 +51613,7 @@ km
 kZ
 hY
 mN
-HU
+XD
 oH
 pD
 qG
@@ -52309,12 +52414,12 @@ aq
 aD
 fw
 aD
-hI
-iL
-iL
-iL
-iL
-iL
+MJ
+XD
+XD
+XD
+XD
+XD
 mP
 nK
 aq
@@ -52329,7 +52434,7 @@ rO
 WV
 If
 If
-WB
+PV
 DN
 DN
 DN
@@ -53722,8 +53827,8 @@ aa
 aq
 aq
 aq
-aq
-ib
+oF
+VM
 IN
 jx
 ku

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -528,10 +528,6 @@
 "bi" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -541,9 +537,6 @@
 /area/logistics/hangar)
 "bj" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -553,9 +546,6 @@
 /area/logistics/hangar)
 "bk" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -568,9 +558,6 @@
 /area/logistics/hangar)
 "bl" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -583,9 +570,6 @@
 /area/logistics/hangar)
 "bm" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -603,9 +587,6 @@
 /area/logistics/hangar)
 "bn" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -619,10 +600,6 @@
 "bo" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable{
@@ -769,7 +746,6 @@
 /area/maintenance/fourth_deck/afp)
 "bC" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -809,7 +785,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "bI" = (
@@ -1197,7 +1172,6 @@
 /area/maintenance/fourth_deck/afp)
 "cE" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1298,7 +1272,6 @@
 	tag = "icon-manifold (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1666,7 +1639,6 @@
 /area/maintenance/fourth_deck/afp)
 "ds" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -1785,7 +1757,6 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -2079,7 +2050,6 @@
 /area/maintenance/fourth_deck/afp)
 "ed" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -2455,10 +2425,6 @@
 	tag = "90Curve"
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "eQ" = (
@@ -2480,9 +2446,6 @@
 	req_access = list("ACCESS_MAINT")
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "eS" = (
@@ -2668,7 +2631,6 @@
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -3032,14 +2994,15 @@
 "fO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -3071,9 +3034,6 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 1;
@@ -3098,9 +3058,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -3113,9 +3070,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	icon_state = "intact-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/random/tool,
 /obj/structure/catwalk,
@@ -3133,9 +3087,6 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "fU" = (
@@ -3146,10 +3097,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -4107,18 +4054,18 @@
 "hI" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
+	dir = 6;
 	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4335,9 +4282,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "ib" = (
@@ -4355,9 +4299,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4378,9 +4319,6 @@
 	icon_state = "4-8"
 	},
 /obj/random/junk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "id" = (
@@ -4396,16 +4334,24 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "ie" = (
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/disposalpipe/up{
-	dir = 8;
-	tag = "icon-pipe-u (EAST)"
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (NORTHWEST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply";
+	tag = "icon-intact (SOUTHWEST)"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4910,10 +4856,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -4944,9 +4886,9 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -7141,9 +7083,10 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-c"
+	name = "Forensics Office";
+	sortType = "Forensics Office"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -7162,7 +7105,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -7191,9 +7134,6 @@
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "Fourth Deck Fore Port Maintenance APC"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "mP" = (
@@ -7210,10 +7150,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -8391,24 +8327,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
-"oF" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (SOUTHEAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	icon_state = "intact-supply"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fp)
 "oG" = (
 /obj/machinery/icecream_vat,
 /turf/simulated/floor/tiled/freezer,
@@ -9185,6 +9103,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qk" = (
@@ -9204,6 +9126,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "ql" = (
@@ -9222,6 +9147,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -9247,6 +9175,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qn" = (
@@ -9265,6 +9196,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -9286,6 +9220,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "qp" = (
@@ -9305,6 +9242,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -9329,6 +9269,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qr" = (
@@ -9349,6 +9292,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qs" = (
@@ -9368,6 +9314,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "qt" = (
@@ -9383,6 +9332,10 @@
 	icon_state = "1-8"
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "qu" = (
@@ -10006,6 +9959,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "rs" = (
@@ -10174,6 +10128,10 @@
 	dir = 1;
 	icon_state = "camera"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "rC" = (
@@ -10193,6 +10151,9 @@
 	dir = 1;
 	name = "Station Intercom (General)";
 	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -10442,6 +10403,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "sd" = (
@@ -10520,6 +10482,9 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "sm" = (
@@ -10537,6 +10502,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -10558,7 +10526,12 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	icon_state = "pipe-j2s";
+	name = "Xenoflora Lab";
+	sortType = "Xenoflora Lab"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "sp" = (
@@ -10932,12 +10905,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/central)
@@ -10956,9 +10929,6 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -10970,11 +10940,6 @@
 "sQ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -10988,6 +10953,8 @@
 	icon_state = "2-8";
 	tag = ""
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/central)
 "sR" = (
@@ -11078,6 +11045,9 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "sZ" = (
@@ -11099,6 +11069,10 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "td" = (
@@ -14400,13 +14374,13 @@
 "yV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -15306,7 +15280,8 @@
 /area/logistics/fabwork)
 "AD" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10;
@@ -15323,15 +15298,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10;
 	icon_state = "corner_white";
 	tag = "icon-corner_white (SOUTHWEST)"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
 "AF" = (
@@ -19369,19 +19341,17 @@
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
 "HU" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/logistics/hangar)
+/area/maintenance/fourth_deck/fp)
 "HV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -20351,12 +20321,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -20476,7 +20446,7 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
@@ -20683,9 +20653,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red,
 /turf/simulated/floor/plating,
@@ -20819,28 +20786,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/hadrian/main)
-"MJ" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (SOUTHEAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	icon_state = "intact-supply"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fp)
 "MO" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5;
@@ -21260,6 +21205,10 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "PB" = (
@@ -21364,22 +21313,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hadrian/main)
-"PV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "Torpedo Bay";
-	sortType = "Torpedo Bay"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fs)
 "PW" = (
 /obj/structure/table/standard,
 /obj/item/weapon/lipstick/black,
@@ -21423,6 +21356,10 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Qp" = (
@@ -21486,6 +21423,9 @@
 	},
 /obj/machinery/light/small/red,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Qv" = (
@@ -21530,6 +21470,9 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access = list("ACCESS_MAINT")
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -21833,30 +21776,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "Rz" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	icon_state = "map-supply"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/logistics/hangar)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/fabwork)
 "RC" = (
 /obj/structure/table/standard,
 /obj/random/smokes,
@@ -21879,10 +21801,7 @@
 	dir = 6
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "RI" = (
@@ -22240,9 +22159,6 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Tu" = (
@@ -22384,6 +22300,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Ur" = (
@@ -22656,28 +22573,6 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
-"VM" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (NORTHWEST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	icon_state = "intact-supply";
-	tag = "icon-intact (SOUTHWEST)"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fp)
 "VP" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -22888,18 +22783,23 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fourth_deck/fs)
 "WB" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	icon_state = "pipe-j1s";
+	name = "Torpedo Bay";
+	sortType = "Torpedo Bay";
+	tag = "icon-pipe-j1s (NORTH)"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fp)
+/area/maintenance/fourth_deck/fs)
 "WE" = (
 /obj/machinery/suit_cycler/science,
 /obj/machinery/camera/network/research{
@@ -23050,18 +22950,6 @@
 /obj/structure/stasis_cage,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
-"XD" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fp)
 "XF" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23132,6 +23020,9 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "XT" = (
@@ -23239,15 +23130,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargo_belt"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Cargo Workshop";
+	sortType = "Cargo Workshop"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -43539,7 +43432,7 @@ pj
 qg
 rn
 nw
-sM
+sK
 tz
 tz
 tz
@@ -43924,7 +43817,7 @@ bC
 cE
 ds
 ed
-Rz
+mp
 fj
 fV
 gl
@@ -43943,7 +43836,7 @@ fj
 qh
 rp
 bh
-sM
+sK
 tB
 sd
 vx
@@ -44145,7 +44038,7 @@ bZ
 qi
 rq
 bh
-sM
+sK
 tC
 sd
 vx
@@ -44962,7 +44855,7 @@ xm
 Kr
 yf
 Yx
-zP
+Rz
 AD
 Wq
 BV
@@ -46950,7 +46843,7 @@ aD
 bh
 bo
 bH
-HU
+iU
 cM
 dD
 bH
@@ -46960,7 +46853,7 @@ bH
 bH
 bH
 cM
-HU
+iU
 bH
 jd
 ZP
@@ -47164,7 +47057,7 @@ gt
 hC
 ci
 iw
-je
+bp
 jT
 kP
 lC
@@ -51208,7 +51101,7 @@ hY
 kk
 hY
 hY
-WB
+mJ
 nE
 oG
 pB
@@ -51410,7 +51303,7 @@ js
 kl
 kY
 hY
-WB
+mJ
 nE
 nE
 pC
@@ -51613,7 +51506,7 @@ km
 kZ
 hY
 mN
-XD
+HU
 oH
 pD
 qG
@@ -52414,12 +52307,12 @@ aq
 aD
 fw
 aD
-MJ
-XD
-XD
-XD
-XD
-XD
+hI
+iL
+iL
+iL
+iL
+iL
 mP
 nK
 aq
@@ -52434,7 +52327,7 @@ rO
 WV
 If
 If
-PV
+WB
 DN
 DN
 DN
@@ -53827,8 +53720,8 @@ aa
 aq
 aq
 aq
-oF
-VM
+aq
+ib
 IN
 jx
 ku

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -6073,6 +6073,10 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandport)
 "alf" = (
@@ -6093,8 +6097,7 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
@@ -6833,6 +6836,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandport)
 "amo" = (
@@ -6843,7 +6847,6 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "amp" = (
@@ -7464,10 +7467,7 @@
 	tag = ""
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "any" = (
@@ -7475,23 +7475,10 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Port Gun Bay";
-	sortType = "Port Gun Bay"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "anz" = (
-/obj/structure/disposalpipe/down{
-	dir = 8;
-	icon_state = "pipe-d";
-	tag = "icon-pipe-d (WEST)"
-	},
-/obj/structure/lattice,
-/turf/simulated/open{
-	initial_gas = null
-	},
+/turf/simulated/floor/plating,
 /area/hallway/commandport)
 "anA" = (
 /obj/machinery/light/small{
@@ -8223,6 +8210,9 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
 "aoS" = (
@@ -8235,6 +8225,9 @@
 /obj/machinery/door/airlock/command{
 	name = "Boarding Armoury";
 	req_access = list("ACCESS_FIRST_OFFICER")
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
@@ -8256,7 +8249,10 @@
 	tag = ""
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "aoU" = (
@@ -9138,11 +9134,6 @@
 	tag = ""
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 2;
-	name = "Starboard Gun Bay";
-	sortType = "Starboard Gun Bay"
-	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "aqj" = (
@@ -9153,10 +9144,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
@@ -9822,7 +9809,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandport)
 "ark" = (
@@ -9841,7 +9827,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "arl" = (
@@ -11307,6 +11292,10 @@
 	dir = 4;
 	icon_state = "map-scrubbers"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -11318,9 +11307,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "asF" = (
@@ -11334,7 +11320,6 @@
 	pixel_x = 28;
 	tag = "icon-intercom (WEST)"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "asG" = (
@@ -12077,7 +12062,6 @@
 	dir = 4;
 	icon_state = "corner_white"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "atW" = (
@@ -12680,7 +12664,6 @@
 	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
 "auX" = (
@@ -13469,7 +13452,6 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
 "aws" = (
@@ -14048,7 +14030,6 @@
 /turf/simulated/floor/carpet/green,
 /area/command/meeting)
 "axA" = (
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
 "axB" = (
@@ -15183,7 +15164,6 @@
 /area/command/meeting)
 "azB" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
 "azC" = (
@@ -18072,7 +18052,6 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/fadeblue,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aEr" = (
@@ -19095,7 +19074,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aFP" = (
@@ -19574,7 +19552,6 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aGS" = (
@@ -20353,7 +20330,6 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aIm" = (
@@ -21047,7 +21023,6 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aJx" = (
@@ -21605,7 +21580,6 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aKy" = (
@@ -22304,7 +22278,6 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aLD" = (
@@ -23056,7 +23029,13 @@
 	icon_state = "2-4"
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	icon_state = "pipe-j1s";
+	name = "Starboard Gun Bay";
+	sortType = "Starboard Gun Bay";
+	tag = "icon-pipe-j1s (NORTH)"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/commandstarboard)
 "aMK" = (
@@ -23072,14 +23051,13 @@
 	pixel_y = 0
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10;
 	icon_state = "intact-supply";
 	tag = "icon-intact-supply (SOUTHWEST)"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/commandstarboard)
@@ -23090,13 +23068,13 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandstarboard)
@@ -29308,9 +29286,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 8;
-	icon_state = "pipe-c"
+	icon_state = "pipe-j1";
+	tag = "icon-pipe-j1 (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
@@ -29563,8 +29542,10 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Port Gun Bay";
+	sortType = "Port Gun Bay"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/commandport)
@@ -30642,13 +30623,13 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
 	icon_state = "intact-supply";
 	tag = "icon-intact-supply (SOUTHEAST)"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandstarboard)
@@ -31030,16 +31011,6 @@
 /obj/effect/paint_stripe/paleblue,
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/chemistry)
-"sMx" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bridge Maintenance";
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_GUNNERY"))
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hallway/commandport)
 "sPc" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -31106,7 +31077,7 @@
 	icon_state = "pipe-t"
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "starboardgunbelt"
 	},
 /turf/simulated/floor/plating,
@@ -61943,7 +61914,7 @@ air
 ajT
 icd
 air
-sMx
+amp
 air
 air
 emJ

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -4372,8 +4372,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
@@ -6073,10 +6073,6 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandport)
 "alf" = (
@@ -6097,7 +6093,8 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
@@ -6836,7 +6833,6 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandport)
 "amo" = (
@@ -6847,6 +6843,7 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "amp" = (
@@ -7467,7 +7464,10 @@
 	tag = ""
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "any" = (
@@ -7475,10 +7475,23 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Port Gun Bay";
+	sortType = "Port Gun Bay"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "anz" = (
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/down{
+	dir = 8;
+	icon_state = "pipe-d";
+	tag = "icon-pipe-d (WEST)"
+	},
+/obj/structure/lattice,
+/turf/simulated/open{
+	initial_gas = null
+	},
 /area/hallway/commandport)
 "anA" = (
 /obj/machinery/light/small{
@@ -8210,9 +8223,6 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
 "aoS" = (
@@ -8225,9 +8235,6 @@
 /obj/machinery/door/airlock/command{
 	name = "Boarding Armoury";
 	req_access = list("ACCESS_FIRST_OFFICER")
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
@@ -8249,10 +8256,7 @@
 	tag = ""
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "aoU" = (
@@ -9134,6 +9138,11 @@
 	tag = ""
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 2;
+	name = "Starboard Gun Bay";
+	sortType = "Starboard Gun Bay"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "aqj" = (
@@ -9144,6 +9153,10 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
@@ -9809,6 +9822,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandport)
 "ark" = (
@@ -9827,6 +9841,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "arl" = (
@@ -11292,10 +11307,6 @@
 	dir = 4;
 	icon_state = "map-scrubbers"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -11307,6 +11318,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "asF" = (
@@ -11320,6 +11334,7 @@
 	pixel_x = 28;
 	tag = "icon-intercom (WEST)"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "asG" = (
@@ -12062,6 +12077,7 @@
 	dir = 4;
 	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "atW" = (
@@ -12664,6 +12680,7 @@
 	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
 "auX" = (
@@ -13452,6 +13469,7 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
 "aws" = (
@@ -14030,6 +14048,7 @@
 /turf/simulated/floor/carpet/green,
 /area/command/meeting)
 "axA" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
 "axB" = (
@@ -15164,6 +15183,7 @@
 /area/command/meeting)
 "azB" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
 "azC" = (
@@ -18052,6 +18072,7 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/fadeblue,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aEr" = (
@@ -19074,6 +19095,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aFP" = (
@@ -19552,6 +19574,7 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aGS" = (
@@ -20330,6 +20353,7 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aIm" = (
@@ -21023,6 +21047,7 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aJx" = (
@@ -21580,6 +21605,7 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aKy" = (
@@ -22278,6 +22304,7 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aLD" = (
@@ -23029,13 +23056,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	icon_state = "pipe-j1s";
-	name = "Starboard Gun Bay";
-	sortType = "Starboard Gun Bay";
-	tag = "icon-pipe-j1s (NORTH)"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/hallway/commandstarboard)
 "aMK" = (
@@ -23051,13 +23072,14 @@
 	pixel_y = 0
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10;
 	icon_state = "intact-supply";
 	tag = "icon-intact-supply (SOUTHWEST)"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/commandstarboard)
@@ -23068,13 +23090,13 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandstarboard)
@@ -23378,8 +23400,8 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/genstorage)
@@ -24344,8 +24366,8 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/smmon)
@@ -28878,8 +28900,8 @@
 /area/security/portgun)
 "dmy" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/third_deck/fp)
@@ -29286,10 +29308,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 8;
-	icon_state = "pipe-j1";
-	tag = "icon-pipe-j1 (WEST)"
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
@@ -29344,7 +29365,7 @@
 	pixel_x = 24;
 	pixel_y = -24
 	},
-/obj/machinery/conveyor_switch{
+/obj/machinery/conveyor_switch/oneway{
 	id = "starboardgunbelt"
 	},
 /obj/structure/catwalk,
@@ -29386,7 +29407,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "portgunbelt"
 	},
 /turf/simulated/floor/plating,
@@ -29542,10 +29563,8 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Port Gun Bay";
-	sortType = "Port Gun Bay"
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/commandport)
@@ -29580,7 +29599,7 @@
 	pixel_y = -22
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "starboardgunbelt"
 	},
 /turf/simulated/floor/plating,
@@ -29834,7 +29853,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "portgunbelt"
 	},
 /turf/simulated/floor/plating,
@@ -29942,8 +29961,8 @@
 	req_access = list("ACCESS_EXTERNAL")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -30056,8 +30075,8 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
@@ -30071,8 +30090,8 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -30089,8 +30108,8 @@
 "lfC" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/third_deck/fs)
@@ -30212,8 +30231,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
 /area/security/starboardexternalgun)
@@ -30520,12 +30539,12 @@
 /area/logistics/lockers)
 "oGG" = (
 /obj/structure/disposaloutlet/unwrap{
-	icon_state = "outlet";
-	dir = 4
+	dir = 4;
+	icon_state = "outlet"
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Starboard External Gun Bay";
@@ -30533,7 +30552,7 @@
 	icon_state = "camera"
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "starboardgunbelt"
 	},
 /turf/simulated/floor/plating,
@@ -30582,12 +30601,12 @@
 /area/command/eva)
 "oUy" = (
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "portgunbelt"
 	},
 /obj/structure/disposaloutlet/unwrap{
-	icon_state = "outlet";
-	dir = 4
+	dir = 4;
+	icon_state = "outlet"
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera/network/command{
@@ -30623,13 +30642,13 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
 	icon_state = "intact-supply";
 	tag = "icon-intact-supply (SOUTHEAST)"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandstarboard)
@@ -30641,8 +30660,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -30910,11 +30929,11 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "portgunbelt"
 	},
 /turf/simulated/floor/plating,
@@ -31012,10 +31031,15 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/chemistry)
 "sMx" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/space,
-/area/space)
+/obj/machinery/door/airlock/maintenance{
+	name = "Bridge Maintenance";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_GUNNERY"))
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/commandport)
 "sPc" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -31078,8 +31102,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/machinery/conveyor{
 	dir = 8;
@@ -31208,7 +31232,7 @@
 /area/security/lockers)
 "uip" = (
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "starboardgunbelt"
 	},
 /obj/item/device/radio/intercom{
@@ -31222,9 +31246,9 @@
 "urB" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -31247,8 +31271,8 @@
 	name = "cargo chute"
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/plating,
 /area/security/starboardexternalgun)
@@ -31268,7 +31292,7 @@
 	pixel_x = 24;
 	pixel_y = 24
 	},
-/obj/machinery/conveyor_switch{
+/obj/machinery/conveyor_switch/oneway{
 	id = "portgunbelt"
 	},
 /obj/structure/catwalk,
@@ -31571,8 +31595,8 @@
 "wSn" = (
 /obj/machinery/light/small/red,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
@@ -31603,8 +31627,8 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/abandonedoffice)
@@ -61919,7 +61943,7 @@ air
 ajT
 icd
 air
-amp
+sMx
 air
 air
 emJ
@@ -64973,7 +64997,7 @@ aaa
 aaa
 aaa
 aaa
-sMx
+akb
 akb
 sZY
 akb


### PR DESCRIPTION
This PR aims to make the process of sending ammo from cargo to the various hardpoints much easier as well as a few tweaks

Changes:
- Added an auto-wrapping chute to replace the regular chute in the lower cargo bay. This is to match the unwrappers introduced in the various gun bays. These will wrap items on bump, and tag them with the destination set on the chute. Clicking the chute with an empty hand brings up the same menu you would see with the handheld taggers (I'm lazy and didn't want to make a whole new UI). Now random torpedoes won't end up in the mailing office/disposals! This should also make making batches of ammo much easier.
- Reverted the merging of the torpedo and gun bay disposal lines from the main loop in order to facilitate faster movement of ammo from cargo to their intended weapons. This will need to be double-checked as the disposals loop is a bit of a maze, but I've done my best to revert it to how it used to be, while adding a new dedicated line for the hardpoints. If this is unwanted, let me know and I'll merge them back again.
- Separated the cargo conveyor belt switch from the torpedo loading belt.
- Changed the switches in both gun bays to one directional  to bring them in line with other loading belts.
- Removed duplicate lattice outside the Starboard Gun Bay, which has been causing a runtime on every boot.
- Added `throw_at()` proc call to atoms being vented from unwrapper outlets to bring them in line with other outlets. This has been dialled back to a throw distance of 1 however to avoid issues in the gun bays. This also allows torpedoes to be placed directly on the belt, as previously it would exit onto the floor and would need to be dragged to load or get onto the belt.

Any issues, let me know!