### PR TITLE
Bugfixes + Pirate balance changes

### DIFF
--- a/code/modules/urist/modules/shipbattles/overmapships/components/component_weapons.dm
+++ b/code/modules/urist/modules/shipbattles/overmapships/components/component_weapons.dm
@@ -57,14 +57,14 @@
 
 /datum/shipcomponents/weapons/ioncannon
 	name = "ion cannon"
-	firedelay = 14 SECONDS
+	firedelay = 18 SECONDS
 	projectile_type = /obj/item/projectile/ion/ship
 	weapon_type = /obj/machinery/shipweapons/beam/ion
 	burst = 2
 
 /datum/shipcomponents/weapons/ioncannon/heavy
 	name = "heavy ion cannon"
-	firedelay = 22 SECONDS
+	firedelay = 26 SECONDS
 	projectile_type = /obj/item/projectile/ion/ship/heavy
 	burst = 2
 

--- a/code/modules/urist/modules/shipbattles/overmapships/components/components.dm
+++ b/code/modules/urist/modules/shipbattles/overmapships/components/components.dm
@@ -32,21 +32,30 @@
 	var/recharging = 0 //are we waiting for the next recharge delay?
 	var/recharge_delay = 5 SECONDS //how long do we wait between recharges
 	var/overcharged = FALSE //only for stations, we stop torpedos from doing hull damage. they can still hurt components though
+	var/recovery_threashold = 0	//The amount of total recharge needed to recover the shields once offline. Ie a value of 100 requires 100 shield strength to be recharged before the shields recover and block attacks
+	var/recovery_debt = 0 //Amount of recharge remaining before shields are online
 
 /datum/shipcomponents/shield/DoActivate()
 	if(!broken && !recharging)
-		if(mastership.shields <= strength)
-			mastership.shields += recharge_rate
-			if(mastership.shields >= strength)
-				mastership.shields = strength
+		if(recovery_debt)
+			if(recovery_debt >= recharge_rate)
+				recovery_debt -= recharge_rate
+			else
+				mastership.shields = min(recovery_threashold + (recharge_rate - recovery_debt),strength)	//Amount required to recharge + anything left over
+				recovery_debt = 0
+		else if(mastership.shields < strength)
+			mastership.shields = min(mastership.shields + recharge_rate, strength)
 
-			recharging = 1
-			spawn(recharge_delay)
-				recharging = 0
+		else
+			return
+		recharging = 1
+		spawn(recharge_delay)
+			recharging = 0
 
 /datum/shipcomponents/shield/BlowUp()
 	strength = 0
 	recharge_rate = 0
+	recovery_debt = 0
 	mastership.shields = src.strength
 	..()
 
@@ -59,56 +68,64 @@
 	strength = 750
 	health = 200
 	recharge_rate = 75
-	recharge_delay = 10 SECONDS
+	recharge_delay = 12 SECONDS
+	recovery_threashold = 100
 
 /datum/shipcomponents/shield/medium
 	name = "medium shield"
 	strength = 1200
 	health = 400
 	recharge_rate = 70
-	recharge_delay = 10 SECONDS
+	recharge_delay = 12 SECONDS
+	recovery_threashold = 100
 
 /datum/shipcomponents/shield/freighter
 	name = "freighter shield"
 	strength = 1000
 	health = 300
 	recharge_rate = 50
-	recharge_delay = 10 SECONDS
+	recharge_delay = 12 SECONDS
+	recovery_threashold = 120
 
 /datum/shipcomponents/shield/fighter
 	name = "high performance ultralight shield"
 	strength = 460
 	health = 100
 	recharge_rate = 50
-	recharge_delay = 5 SECONDS
+	recharge_delay = 7 SECONDS
+	recovery_threashold = 60
 
 /datum/shipcomponents/shield/combat
 	name = "high performance combat shield"
 	strength = 1000
 	health = 300
 	recharge_rate = 75
-	recharge_delay = 8 SECONDS
+	recharge_delay = 10 SECONDS
+	recovery_threashold = 100
 
 /datum/shipcomponents/shield/alien_light
 	name = "light alien shield"
 	strength = 300
 	health = 200
 	recharge_rate = 60
-	recharge_delay = 5 SECONDS
+	recharge_delay = 7 SECONDS
+	recovery_threashold = 80
 
 /datum/shipcomponents/shield/alien_heavy
 	name = "heavy alien shield"
 	strength = 600
 	health = 200
 	recharge_rate = 60
-	recharge_delay = 8 SECONDS
+	recharge_delay = 10 SECONDS
+	recovery_threashold = 80
 
 /datum/shipcomponents/shield/pirate_station
 	name = "overcharged station shield"
 	strength = 1500
 	health = 500
 	recharge_rate = 100
-	recharge_delay = 35 SECONDS
+	recharge_delay = 37 SECONDS
+	recovery_threashold = 150
 	overcharged = TRUE
 
 //evasion

--- a/code/modules/urist/modules/shipbattles/overmapships/components/components.dm
+++ b/code/modules/urist/modules/shipbattles/overmapships/components/components.dm
@@ -68,7 +68,7 @@
 	strength = 750
 	health = 200
 	recharge_rate = 75
-	recharge_delay = 12 SECONDS
+	recharge_delay = 10 SECONDS
 	recovery_threashold = 100
 
 /datum/shipcomponents/shield/medium
@@ -76,7 +76,7 @@
 	strength = 1200
 	health = 400
 	recharge_rate = 70
-	recharge_delay = 12 SECONDS
+	recharge_delay = 10 SECONDS
 	recovery_threashold = 100
 
 /datum/shipcomponents/shield/freighter
@@ -84,7 +84,7 @@
 	strength = 1000
 	health = 300
 	recharge_rate = 50
-	recharge_delay = 12 SECONDS
+	recharge_delay = 10 SECONDS
 	recovery_threashold = 120
 
 /datum/shipcomponents/shield/fighter
@@ -92,7 +92,7 @@
 	strength = 460
 	health = 100
 	recharge_rate = 50
-	recharge_delay = 7 SECONDS
+	recharge_delay = 5 SECONDS
 	recovery_threashold = 60
 
 /datum/shipcomponents/shield/combat
@@ -100,7 +100,7 @@
 	strength = 1000
 	health = 300
 	recharge_rate = 75
-	recharge_delay = 10 SECONDS
+	recharge_delay = 8 SECONDS
 	recovery_threashold = 100
 
 /datum/shipcomponents/shield/alien_light
@@ -108,7 +108,7 @@
 	strength = 300
 	health = 200
 	recharge_rate = 60
-	recharge_delay = 7 SECONDS
+	recharge_delay = 5 SECONDS
 	recovery_threashold = 80
 
 /datum/shipcomponents/shield/alien_heavy
@@ -116,7 +116,7 @@
 	strength = 600
 	health = 200
 	recharge_rate = 60
-	recharge_delay = 10 SECONDS
+	recharge_delay = 8 SECONDS
 	recovery_threashold = 80
 
 /datum/shipcomponents/shield/pirate_station
@@ -124,7 +124,7 @@
 	strength = 1500
 	health = 500
 	recharge_rate = 100
-	recharge_delay = 37 SECONDS
+	recharge_delay = 35 SECONDS
 	recovery_threashold = 150
 	overcharged = TRUE
 

--- a/code/modules/urist/modules/shipbattles/overmapships/overmapships.dm
+++ b/code/modules/urist/modules/shipbattles/overmapships/overmapships.dm
@@ -76,7 +76,7 @@
 	if(incombat)
 		for(var/datum/shipcomponents/M in src.components)
 			if(M.broken)
-				return
+				continue
 			else
 				M.DoActivate()
 

--- a/code/modules/urist/modules/shipbattles/ship_overmaps.dm
+++ b/code/modules/urist/modules/shipbattles/ship_overmaps.dm
@@ -54,7 +54,7 @@
 
 		for(var/datum/shipcomponents/M in target.components)
 			if(M.broken)
-				return
+				continue
 			else
 				M.DoActivate()
 

--- a/code/modules/urist/modules/shipbattles/shipweapons/beam_weapons.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/beam_weapons.dm
@@ -6,7 +6,7 @@
 
 /obj/machinery/shipweapons/beam/lightlaser //lasers are pretty good against shields, relatively weak against hulls
 	name = "light laser cannon"
-	shield_damage = 200 //13.33 dps
+	shield_damage = 220 //14.66 dps
 	hull_damage = 100 //6.67 dps
 	icon_state = "lasercannon"
 	idle_power_usage = 10

--- a/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
@@ -150,18 +150,20 @@
 					if(OM.shields)
 						var/shieldbuffer = OM.shields
 						OM.shields = max(OM.shields - shield_damage, 0) //take the hit
-						if(!OM.shields && hull_damage) //if we're left with less than 0 shields
-							shieldbuffer = hull_damage-shieldbuffer //hull_damage is slightly mitigated by the existing shield
-							if(shieldbuffer > 0) //but if the shield was really strong, we don't do anything
-								OM.health = max(OM.health - shieldbuffer, 0)
+						if(!OM.shields)
+							for(var/datum/shipcomponents/shield/S in OM.components)
+								S.recovery_debt = S.recovery_threashold
+							if(hull_damage) //if we're left with less than 0 shields
+								shieldbuffer = hull_damage-shieldbuffer //hull_damage is slightly mitigated by the existing shield
+								if(shieldbuffer > 0) //but if the shield was really strong, we don't do anything
+									OM.health = max(OM.health - shieldbuffer, 0)
+									for(var/datum/shipcomponents/shield/S in OM.components)
+										if(!S.broken)
+											var/component_damage = hull_damage * 0.1
+											S.health -= component_damage
 
-								for(var/datum/shipcomponents/shield/S in OM.components)
-									if(!S.broken)
-										var/component_damage = hull_damage * 0.1
-										S.health -= component_damage
-
-										if(S.health <= 0)
-											S.BlowUp()
+											if(S.health <= 0)
+												S.BlowUp()
 
 					else	//no shields? easy
 						if(targeted_component)

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -3544,6 +3544,7 @@
 /obj/machinery/shieldwallgen{
 	anchored = 1;
 	max_range = 30;
+	power_draw = 60000;
 	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/structure/cable,
@@ -25750,6 +25751,7 @@
 /obj/machinery/shieldwallgen{
 	anchored = 1;
 	max_range = 30;
+	power_draw = 60000;
 	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/structure/cable{


### PR DESCRIPTION
This PR was originally meant to be a simple balance pass, but I ended up falling down a rabbit hole of bugfixes along the way...

### Changes:
**Balance Changes**
- Pirate Ion weapon cooldowns increased by 4 seconds
- Pirate shield regen rate slowed by 2 seconds
- Introduction of `recovery_debt` to mimic Nerva shields. Pirate shields will now need to recharge a certain amount before they block projectiles again (similar to shield generators' 'Recovering' stage). Amount regenerated is not lost, shields are simply not effective until this threshold has passed. Set the amount required using `recovery_threashold` on each shield module. Eyeballed these numbers for now to aim for at least 1 regen cycle without shields coming online
- Slight buff to the light laser cannon. Taking it from an anti-shield DPS of 13.33 to 14.66
- Shieldwall generators now evenly split the energy load between both units, rather than picking a unit at random; sometimes causing extremely asymmetrical loads and shutting a single unit down while the other is untouched.
- Buff to the bridge shieldwall max draw, see below in bugfixes for reason

**Bugfixes/Tweaks**
- Fixed a bug present in pirate ship module activation causing all modules to not activate once a single module was destroyed. This was caused by a pesky `return` in the for loops during module activation rather then skipping the broken module with `continue`
- Fixed a runtime caused by passing a turf to the shieldwall's `New()` proc rather than its expected generator object type, causing multiple issues with load down the line and null variable calls.
- Tweaked shieldwall generators to include their default power usage into the powernet calculation rather than after, allowing stored power to actually reach their maximum rather than max - idle usage
- As a result of fixing the incorrect `New()` call, shield loads are now properly working. Due to the large distance between the bridge's shieldwall generators, there is not enough max draw to facilitate the initial generation of the shields. As a result, the max power draw for these units was increased to compensate. Alternative solution is a decrease of the generation cost, though this would be global. Hopefully this won't be too much of an issue as this'll simply put more strain on the powernet

Any issues or ideas for further changes, let me know!