### PR TITLE
Fixes issues with stacking stacks

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -121,9 +121,10 @@
 
 	if (use(required))
 		var/atom/O = recipe.spawn_result(user, user.loc, produced)
-		O.add_fingerprint(user)
+		if(O)
+			O.add_fingerprint(user)
 
-		user.put_in_hands(O)
+			user.put_in_hands(O)
 
 /obj/item/stack/Topic(href, href_list)
 	..()
@@ -167,6 +168,9 @@
 	if(!uses_charge)
 		amount -= used
 		if (amount <= 0)
+			var/obj/item/weapon/storage/ST = src.loc	//Let's check if it's in storage and remove any references to the object so it can be qdel'd
+			if(istype(ST))
+				ST.remove_from_storage(src,ST.get_loc_turf())
 			qdel(src) //should be safe to qdel immediately since if someone is still using this stack it will persist for a little while longer
 		return 1
 	else

--- a/code/modules/materials/recipes_stacks.dm
+++ b/code/modules/materials/recipes_stacks.dm
@@ -29,6 +29,9 @@
 	if(istype(S))
 		S.amount = amount
 		S.add_to_stacks(user, 1)
+		if(S.amount <= 0)
+			qdel(S)
+			return
 	return S
 
 /datum/stack_recipe/tile/metal/floor


### PR DESCRIPTION
- Fixes 0 amount stacks spawning when making multiple tiles from construction. Caused by a stupidly long chain of references to the item after `qdel` has already been called in `use()`, resulting in the 0 amount stack taking a long time to be deleted.
- Fixes that annoying bug where combining stacks directly to/from an inventory causes a phantom stack to float forever in your UI. Again, caused by active references after the `qdel` call in `use()`. Added a check in `use()` to drop 0 amount stacks out of the inventory to remove references before `qdel` is called.

To be honest, the `qdel` in `use()` could probably do with a refactor as this feels a little sloppy imo, but that  would be a lot of work and these workaround these issues for now.