### PR TITLE
Changes spare PDAs to spawn off

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -31,15 +31,12 @@
 	desc = "A box of spare PDA microcomputers."
 	icon = 'icons/obj/pda.dmi'
 	icon_state = "pdabox"
+	startswith = list(/obj/item/modular_computer/pda = 5)
 
 /obj/item/weapon/storage/box/PDAs/Initialize()
 	. = ..()
-
-	new /obj/item/modular_computer/pda(src)
-	new /obj/item/modular_computer/pda(src)
-	new /obj/item/modular_computer/pda(src)
-	new /obj/item/modular_computer/pda(src)
-	new /obj/item/modular_computer/pda(src)
+	for(var/obj/item/modular_computer/pda/pda in contents)
+		pda.shutdown_computer(0) //Because 5 PDAs all on in a box use SO much power
 
 // PDA types
 /obj/item/modular_computer/pda/medical


### PR DESCRIPTION
Small PR. Changes boxes of spare PDAs to spawn them offline rather than on. A box of 5 online PDAs actually uses a stupid amount of power and adds necessary drain on APCs which can be critical during lowpop with no engineers. See the SO's office APC during roundstart :P