### PR TITLE
Bug Fixes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -222,7 +222,7 @@
 		show_category = choice
 		. = TOPIC_REFRESH
 
-	else if(!busy && href_list["make"] && machine_recipes)
+	else if(href_list["make"] && machine_recipes)
 		. = TOPIC_REFRESH
 		var/index = text2num(href_list["make"])
 		var/datum/autolathe/recipe/making
@@ -314,6 +314,7 @@
 			if(stored_material[material] < round(making.resources[material] * mat_efficiency))
 				visible_message("<span class='warning'>[src] buzzes, 'Not enough materials for [making.name], flushing queue.'</span>")
 				queue.Cut(1)
+				busy = 0
 				return TOPIC_REFRESH
 
 	//Consume materials.

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -183,7 +183,7 @@
 	..()
 
 /obj/machinery/door/window/CanFluidPass(var/coming_from)
-	return ((dir in GLOB.cardinal) && coming_from != dir)
+	return ((dir in GLOB.cardinal) && (!density || coming_from != dir))
 
 /obj/machinery/door/window/attackby(obj/item/weapon/I as obj, mob/user as mob)
 

--- a/code/modules/augment/active/polytool.dm
+++ b/code/modules/augment/active/polytool.dm
@@ -56,11 +56,11 @@
 		var/list/options = list()
 		var/obj/item
 
-		for(item in src)
-			var/image/radial_button = image(icon = I.icon, icon_state = I.icon_state)
-			options[I] = radial_button
+		for(var/obj/tool in items)
+			var/image/radial_button = image(icon = tool.icon, icon_state = tool.icon_state)
+			options[tool] = radial_button
 
-		item = show_radial_menu(src, src, options, radius = 42, tooltips = TRUE)
+		item = show_radial_menu(owner, owner, options, radius = 42, tooltips = TRUE)
 
 		if(!item)
 			return

--- a/code/modules/urist/random.dm
+++ b/code/modules/urist/random.dm
@@ -30,6 +30,9 @@
 
 /obj/effect/urist/spawn_bomb/Initialize()
 	.=..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/urist/spawn_bomb/LateInitialize()
 	if(empulse)
 		empulse(src.loc, dmg_hvy, dmg_lgt, 0, 0)
 


### PR DESCRIPTION
Bunch of bugs that have been annoying me for far too long

- Fixed autolathes getting stuck when they've ran out of materials, due to not unsetting `busy`
- Fixed autolathes not being able to queue more than one item. This was a weird one; the presence of a queue suggests you should be able to add items to the queue, but the queue would lock as soon as the machine was busy? Removed busy check.
- Fixed windoors magically blocking water while open. Caused by a missing density check in `CanFluidPass()`
- Fixed the augmented surgical and engineering toolkits. Caused by iterating through a list of items without assigning them a variable, then trying to interact with said items, as well as incorrect variables passed to the radial menu
- Moved `/obj/effect/urist/spawn_bomb` to Lateinitialize to prevent runtimes caused by uninitialised material datums