### PR TITLE
Bugfixing

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -75,7 +75,8 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	if(stat & NOPOWER)
 		for(var/mob/M in masters)
 			remove_holo(M)
-		end_call()
+		if(connected)
+			end_call()
 		update_use_power(POWER_USE_OFF)
 	else
 		update_use_power(POWER_USE_IDLE)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -219,6 +219,9 @@
 	if(emp_hardened)
 		return
 	failure_timer = max(failure_timer, round(duration))
+	update()
+	queue_icon_update()
+	force_update = 1
 	playsound(src, 'sound/machines/apc_nopower.ogg', 75, 0)
 
 /obj/machinery/power/apc/proc/make_terminal()
@@ -1004,10 +1007,7 @@
 	if(!area.requires_power)
 		return
 	if(failure_timer)
-		update()
-		queue_icon_update()
 		failure_timer--
-		force_update = 1
 		return
 
 	lastused_light = area.usage(LIGHT)


### PR DESCRIPTION
Fixes a missing check causing holopads to announce ending a call on power loss, despite not being in one.

Amusingly, this lead to the discovery of a much larger bug which has also been fixed.
Fixed an issue where APCs would constantly call `update()` and thus `area.power_change()` _every_ tick during its `Process()` when EMP'd. Corrected by moving the initial update call to its `energy_loss()` proc, having `Process()` just handle the timer.

Fuck Bay.