### PR TITLE
ICS Nerva: The Remappening (And bugfixing)

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -765,7 +765,11 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 					for(var/obj/O in T)
 
 						if(!istype(O,/obj) || !O.simulated)
-							continue
+							var/obj/effect/landmark/LM = O	//Check for hologram landmarks
+							if(!istype(LM))
+								continue
+							if(!LM.can_copy)
+								continue
 
 						objs += O
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -98,7 +98,7 @@
 	autolinkers = list("busWyrm", "serverWyrm", "receiverWyrm", "broadcasterWyrm", "prim_relay", "sub_relay")
 
 /obj/machinery/telecomms/hub/preset/nerva
-	autolinkers = list("busWyrm", "serverWyrm", "receiverWyrm", "broadcasterWyrm", "1_relay", "2_relay", "3_relay","4_relay", "Relay-PSR")
+	autolinkers = list("busNerva", "serverNerva", "receiverNerva", "broadcasterNerva", "1_relay", "2_relay", "3_relay","4_relay", "Relay-PSR")
 
 //Receivers
 
@@ -126,6 +126,12 @@
 	network = "tcommsat"
 	freq_listening = list(SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, SEC_FREQ, COMM_FREQ, ENG_FREQ, AI_FREQ, PUB_FREQ, ENT_FREQ)
 	autolinkers = list("receiverWyrm")
+
+/obj/machinery/telecomms/receiver/preset_nerva
+	id = "Nerva Receiver"
+	network = "tcommsat"
+	freq_listening = list(SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, SEC_FREQ, COMM_FREQ, ENG_FREQ, AI_FREQ, PUB_FREQ, ENT_FREQ, COMB_FREQ)
+	autolinkers = list("receiverNerva")
 
 //Buses
 
@@ -177,7 +183,7 @@
 	id = "Main Bus"
 	network = "tcommsat"
 	freq_listening = list(SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, SEC_FREQ, COMM_FREQ, ENG_FREQ, AI_FREQ, PUB_FREQ, ENT_FREQ, COMB_FREQ)
-	autolinkers = list("processorWyrm", "busWyrm")
+	autolinkers = list("processorNerva", "busNerva")
 
 //Processors
 
@@ -211,6 +217,11 @@
 	id = "Main Processor"
 	network = "tcommsat"
 	autolinkers = list("processorWyrm")
+
+/obj/machinery/telecomms/processor/preset_nerva
+	id = "Main Processor"
+	network = "tcommsat"
+	autolinkers = list("processorNerva")
 
 //Servers
 
@@ -308,8 +319,8 @@
 	autolinkers = list("serverWyrm", "busWyrm")
 
 /obj/machinery/telecomms/server/presets/nerva //the same, but with combat
-	id = "Wyrm NAS"
-	freq_listening = list(AI_FREQ, COMM_FREQ, ENG_FREQ, ENT_FREQ, MED_FREQ, PUB_FREQ, SCI_FREQ, SEC_FREQ, SRV_FREQ, SUP_FREQ)
+	id = "Nerva Server"
+	freq_listening = list(AI_FREQ, COMM_FREQ, ENG_FREQ, ENT_FREQ, MED_FREQ, PUB_FREQ, SCI_FREQ, SEC_FREQ, SRV_FREQ, SUP_FREQ, COMB_FREQ)
 	channel_tags = list(
 		list(AI_FREQ, "AI Private", "#ff00ff"),
 		list(COMM_FREQ, "Command", "#395a9a"),
@@ -323,7 +334,7 @@
 		list(SUP_FREQ, "Supply", "#7f6539"),
 		list(COMB_FREQ, "Combat", "#db135c"), //pank
 	)
-	autolinkers = list("serverWyrm", "busWyrm")
+	autolinkers = list("serverNerva", "busNerva")
 
 //Broadcasters
 
@@ -344,3 +355,8 @@
 	id = "Wyrm Broadcaster"
 	network = "tcommsat"
 	autolinkers = list("broadcasterWyrm")
+
+/obj/machinery/telecomms/broadcaster/preset_nerva
+	id = "Nerva Broadcaster"
+	network = "tcommsat"
+	autolinkers = list("broadcasterNerva")

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -6,6 +6,7 @@
 	unacidable = 1
 	simulated = 0
 	invisibility = 101
+	var/can_copy = FALSE //If set, will allow the landmark to be copied via the area.copy_contents_to() proc. (For holodeck mob spawns)
 	var/delete_me = 0
 
 /obj/effect/landmark/New()

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -46,6 +46,11 @@
 	icon_state = "dark"
 	initial_flooring = /decl/flooring/tiling/dark
 
+/turf/simulated/floor/holofloor/tiled/old_tile
+	name = "floor"
+	icon_state = "tile_full"
+	initial_flooring = /decl/flooring/tiling/new_tile
+
 /turf/simulated/floor/holofloor/tiled/stone
 	name = "stone floor"
 	icon_state = "stone"
@@ -122,6 +127,17 @@
 /turf/simulated/floor/holofloor/desert
 	name = "desert sand"
 	base_name = "desert sand"
+	desc = "Uncomfortably gritty for a hologram."
+	base_desc = "Uncomfortably gritty for a hologram."
+	icon_state = "desert6"
+	base_icon_state = "desert6"
+	initial_flooring = null
+	icon = 'icons/turf/desert.dmi'
+	base_icon = 'icons/turf/desert.dmi'
+
+/turf/simulated/floor/holofloor/path
+	name = "sand path"
+	base_name = "sand path"
 	desc = "Uncomfortably gritty for a hologram."
 	base_desc = "Uncomfortably gritty for a hologram."
 	icon_state = "asteroid"
@@ -231,6 +247,13 @@
 	if(istype(W, /obj/item/weapon/wrench))
 		to_chat(user, ("<span class='notice'>It's a holochair, you can't dismantle it!</span>"))
 	return
+
+/obj/structure/bed/chair/holochair/wood
+	name = "classic chair"
+	desc = "Old is never too old to not be in fashion."
+	base_icon = "wooden_chair"
+	icon_state = "wooden_chair_preview"
+	color = WOOD_COLOR_CHOCOLATE
 
 /obj/item/weapon/holo
 	damtype = PAIN
@@ -477,3 +500,8 @@
 /mob/living/simple_animal/hostile/carp/holodeck/death()
 	..(null, "fades away!", "You have been destroyed.")
 	qdel(src)
+
+//fitness
+
+/obj/structure/fitness/weightlifter/holo/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	return

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -697,7 +697,7 @@
 "bx" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "solar_tool_outer3";
 	locked = 1;
 	name = "Engineering External Access";
@@ -1058,7 +1058,7 @@
 "co" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "solar_tool_inner3";
 	locked = 1;
 	name = "Engineering External Access";
@@ -4118,24 +4118,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
-"hI" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (SOUTHEAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	icon_state = "intact-supply"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fp)
 "hJ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4150,13 +4132,6 @@
 /obj/machinery/light/small/red{
 	dir = 1;
 	icon_state = "firelight1"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4180,30 +4155,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	icon_state = "intact-supply"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/fp)
-"hL" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	icon_state = "intact-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10;
-	icon_state = "intact-supply"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4399,10 +4350,6 @@
 	icon_state = "intact-supply";
 	tag = "icon-intact (SOUTHWEST)"
 	},
-/obj/structure/cable{
-	icon_state = "16-0"
-	},
-/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "if" = (
@@ -4413,9 +4360,9 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
 	tag = ""
 	},
 /turf/simulated/floor/plating,
@@ -4763,6 +4710,7 @@
 	dir = 8;
 	pixel_x = 28
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/aiupload)
 "iU" = (
@@ -5230,7 +5178,7 @@
 "jD" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "escape_pod_2_hatch";
 	locked = 1;
 	name = "Escape Pod Hatch";
@@ -5245,7 +5193,7 @@
 "jF" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "escape_pod_3_hatch";
 	locked = 1;
 	name = "Escape Pod Hatch";
@@ -5322,6 +5270,7 @@
 	dir = 4;
 	icon_state = "corner_white_three_quarters"
 	},
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/aiupload)
 "jL" = (
@@ -6194,7 +6143,7 @@
 "lh" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "escape_pod_2_berth_hatch";
 	locked = 1;
 	name = "Escape Pod";
@@ -6210,7 +6159,7 @@
 "lj" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "escape_pod_3_berth_hatch";
 	locked = 1;
 	name = "Escape Pod";
@@ -6672,23 +6621,13 @@
 	dir = 1;
 	icon_state = "corner_white"
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/centralfourth)
-"mf" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 5;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (NORTHEAST)"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "mg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/white{
-	dir = 4
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -6698,7 +6637,8 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/white{
-	dir = 4
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -9563,7 +9503,7 @@
 /area/security/nuke_storage)
 "qM" = (
 /obj/machinery/door/airlock/vault{
-	icon_state = "door_locked";
+	icon_state = "closed";
 	locked = 1;
 	req_access = list("ACCESS_VAULT")
 	},
@@ -9851,6 +9791,7 @@
 /obj/structure/sign/deck/fourth{
 	pixel_y = -24
 	},
+/obj/machinery/vending/whitedragon,
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "rj" = (
@@ -22860,24 +22801,10 @@
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/cargo)
 "UM" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 5;
 	icon_state = "corner_white";
 	tag = "icon-corner_white (NORTHEAST)"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 0;
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -22890,6 +22817,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -23405,6 +23337,19 @@
 /obj/effect/paint_stripe/mauve,
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/chemlab)
+"WI" = (
+/obj/structure/cable{
+	d1 = 0;
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "16-0"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "WK" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/silver,
@@ -23863,6 +23808,13 @@
 	dir = 1;
 	icon_state = "map_scrubber_on"
 	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/high;
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "YO" = (
@@ -23994,6 +23946,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
 	icon_state = "map-scrubbers"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -24137,6 +24094,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"ZL" = (
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/white{
+	dir = 1;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/centralfourth)
 "ZM" = (
 /obj/item/trash/cigbutt/rand,
 /obj/item/trash/cigbutt/rand,
@@ -41288,7 +41253,7 @@ iM
 iM
 iM
 iM
-ls
+ZL
 nl
 nX
 pa
@@ -42096,7 +42061,7 @@ Yf
 Zm
 Ta
 iM
-mf
+me
 no
 oc
 pe
@@ -42298,7 +42263,7 @@ Yf
 Zm
 Te
 iM
-lT
+me
 np
 od
 pf
@@ -42702,7 +42667,7 @@ Jc
 OQ
 iM
 iM
-lr
+me
 nr
 nw
 ll
@@ -54613,7 +54578,7 @@ aa
 aa
 aq
 aq
-hI
+Sj
 ie
 IN
 jy
@@ -55219,7 +55184,7 @@ aa
 aa
 aq
 aq
-hL
+WQ
 if
 NB
 jB
@@ -55422,8 +55387,8 @@ aa
 aq
 aq
 hM
+WI
 ig
-aq
 aq
 WQ
 iL

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -13528,6 +13528,7 @@
 	dir = 1;
 	icon_state = "edge"
 	},
+/obj/item/device/geiger,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
 "xF" = (
@@ -21521,11 +21522,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Py" = (
+/obj/structure/table/rack,
+/obj/item/weapon/aiModule/protectStation,
+/obj/item/weapon/aiModule/corp,
+/obj/item/weapon/aiModule/asimov,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/item/weapon/aiModule/manifest,
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	req_access = list("ACCESS_AI_UPLOAD")
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/white/monotile,
 /area/command/aiupload)
 "PB" = (
@@ -22059,11 +22071,22 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
 "Ri" = (
+/obj/structure/table/rack,
+/obj/item/weapon/aiModule/paladin,
+/obj/item/weapon/aiModule/tyrant,
+/obj/item/weapon/aiModule/reset,
+/obj/item/weapon/aiModule/purge,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	req_access = list("ACCESS_AI_UPLOAD")
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/white/monotile,
 /area/command/aiupload)
 "Rk" = (
@@ -22468,34 +22491,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
-"Ta" = (
-/obj/structure/table/rack,
-/obj/item/weapon/aiModule/paladin,
-/obj/item/weapon/aiModule/tyrant,
-/obj/item/weapon/aiModule/reset,
-/obj/item/weapon/aiModule/purge,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access = list("ACCESS_AI_UPLOAD")
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
 "Tb" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
-"Te" = (
-/obj/structure/table/rack,
-/obj/item/weapon/aiModule/protectStation,
-/obj/item/weapon/aiModule/corp,
-/obj/item/weapon/aiModule/asimov,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/item/weapon/aiModule/manifest,
-/obj/machinery/door/window/brigdoor/northright{
-	req_access = list("ACCESS_AI_UPLOAD")
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
 "Ti" = (
 /obj/effect/paint/silver,
 /obj/machinery/light/spot{
@@ -42059,7 +42058,7 @@ Wi
 XS
 Yf
 Zm
-Ta
+iM
 iM
 me
 no
@@ -42261,7 +42260,7 @@ Wi
 Mo
 Yf
 Zm
-Te
+iM
 iM
 me
 np

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -923,6 +923,14 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/extstorage)
+"bV" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fs)
 "bW" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medbay Extra Storage"
@@ -984,6 +992,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
 "ce" = (
@@ -1197,6 +1206,10 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
 "cG" = (
@@ -1250,6 +1263,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cockpit)
 "cK" = (
@@ -1262,6 +1276,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cockpit)
 "cM" = (
@@ -1351,6 +1366,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "cV" = (
@@ -1420,6 +1438,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "d4_port_chamber_vent";
+	name = "combustion chamber vent control";
+	pixel_y = 24
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -1606,6 +1629,25 @@
 /obj/item/weapon/storage/lockbox/vials,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/extstorage)
+"do" = (
+/obj/structure/closet/excavation,
+/obj/item/stack/flag/yellow,
+/obj/item/weapon/storage/box/samplebags,
+/obj/item/weapon/wrench,
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	icon_state = "map_vent_out"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/storage)
 "dp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/med_crate/trauma,
@@ -1751,6 +1793,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cockpit)
 "dD" = (
@@ -2338,20 +2381,21 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_x = 0;
-	pixel_y = -32
-	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 1;
+	input_tag = "d4_port_chamber_in";
+	name = "Chamber Gas Control";
+	output_tag = "d4_port_chamber_out";
+	sensors = list("d4_port_chamber_sensor" = "Combustion Chamber")
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "eF" = (
 /obj/machinery/button/remote/blast_door{
-	id = "d1portnacelle";
+	dir = 1;
+	id = "d4portnacelle";
 	name = "combustion chamber blast door control";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -2360,6 +2404,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -2460,6 +2509,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
 "eT" = (
@@ -2560,29 +2610,26 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "fb" = (
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1centrenacelle"
-	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/door/blast/regular{
+	id = "d4portnacelle"
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "fc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1centrenacelle"
-	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/door/blast/regular{
+	id = "d4portnacelle"
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "fd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1centrenacelle"
-	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/door/blast/regular{
+	id = "d4portnacelle"
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "fe" = (
@@ -2658,6 +2705,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/main)
 "fl" = (
@@ -2743,6 +2791,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/cockpit)
 "fq" = (
@@ -2795,6 +2844,10 @@
 /obj/machinery/computer/ship/sensors{
 	dir = 1;
 	icon_state = "computer"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/cockpit)
@@ -2907,6 +2960,8 @@
 "fE" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
+	frequency = 1441;
+	id = "d4_port_chamber_in";
 	injecting = 1;
 	use_power = 1
 	},
@@ -2914,18 +2969,21 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "fF" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
+	frequency = 1441;
+	id = "d4_port_chamber_in";
 	injecting = 1;
 	use_power = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "fG" = (
 /obj/machinery/air_sensor{
-	id_tag = "cChamber1C";
-	output = 2
+	frequency = 1441;
+	id_tag = "d4_port_chamber_sensor";
+	output = 111
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor/reinforced,
@@ -3213,6 +3271,8 @@
 "ge" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
+	frequency = 1441;
+	id_tag = "d4_port_chamber_out";
 	internal_pressure_bound = 35000;
 	internal_pressure_bound_default = 35000
 	},
@@ -3220,6 +3280,7 @@
 	id = "engines";
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "gf" = (
@@ -3328,6 +3389,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
@@ -3464,9 +3529,12 @@
 "gI" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 1;
+	frequency = 1441;
+	id_tag = "d4_port_chamber_out";
 	internal_pressure_bound = 35000;
 	internal_pressure_bound_default = 35000
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "gJ" = (
@@ -3498,28 +3566,26 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
 "gL" = (
-/turf/simulated/floor/holofloor/reinforced,
-/area/holodeck)
-"gM" = (
-/obj/structure/closet/crate{
-	name = "anesthetic"
-	},
-/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/afp)
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/industrial/outline/orange,
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "gN" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "gO" = (
-/obj/effect/decal/cleanable/vomit,
+/obj/structure/closet/crate{
+	name = "anesthetic"
+	},
+/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "gP" = (
@@ -3652,6 +3718,7 @@
 	name = "Shuttle Atmospherics";
 	req_access = newlist()
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "gX" = (
@@ -3719,6 +3786,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/atmos)
 "hc" = (
@@ -3791,7 +3859,7 @@
 /area/maintenance/fourth_deck/fp)
 "hj" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
-	dir = 2;
+	max_pressure_setting = 35000;
 	regulate_mode = 1;
 	target_pressure = 35000;
 	use_power = 1
@@ -3807,8 +3875,7 @@
 /area/engineering/bdportengine)
 "hk" = (
 /obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "cChamber1pV";
+	id = "d4_port_chamber_vent";
 	name = "Chamber Vent"
 	},
 /turf/simulated/floor/reinforced,
@@ -4080,14 +4147,16 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small/red{
 	dir = 1;
 	icon_state = "firelight1"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4115,7 +4184,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4276,11 +4347,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4295,11 +4361,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "ic" = (
@@ -4313,11 +4374,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4329,11 +4385,6 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "ie" = (
@@ -4349,23 +4400,23 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "16-0"
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "if" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -4419,12 +4470,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
-"im" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/civilian/holodeck)
-"in" = (
-/turf/simulated/wall/prepainted,
-/area/civilian/holodeck)
 "io" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4492,6 +4537,10 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cargo)
 "iu" = (
@@ -4511,6 +4560,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/cargo)
 "iw" = (
@@ -4635,11 +4685,6 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "iM" = (
@@ -4672,67 +4717,54 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
 "iQ" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/civilian/holodeck)
+/obj/structure/sign/warning/secure_area,
+/turf/simulated/wall/r_wall/prepainted,
+/area/command/aiupload)
 "iR" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/computer/HolodeckControl{
+/obj/machinery/turretid/stun{
+	control_area = /area/command/aiupload;
 	dir = 4;
-	linkedholodeck = /area/holodeck;
-	linkedholodeck_area = /area/holodeck;
-	programs_list_id = "NervaMainPrograms"
+	icon_state = "control_stun";
+	pixel_x = -26;
+	tag = "icon-control_stun (EAST)"
 	},
-/obj/effect/floor_decal/corner/white/three_quarters{
+/obj/effect/floor_decal/corner/fadeblue/three_quarters{
 	dir = 8;
 	icon_state = "corner_white_three_quarters";
 	tag = "icon-corner_white_three_quarters (WEST)"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techmaint,
-/area/civilian/holodeck)
+/area/command/aiupload)
 "iS" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white{
+/obj/effect/floor_decal/corner/fadeblue{
 	dir = 5;
 	icon_state = "corner_white";
 	tag = "icon-corner_white (NORTHEAST)"
 	},
+/obj/machinery/camera/network/command{
+	c_tag = "AI Upload Access"
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/civilian/holodeck)
+/area/command/aiupload)
 "iT" = (
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	icon_state = "intercom";
-	pixel_x = 28;
-	tag = "icon-intercom (WEST)"
-	},
-/obj/machinery/vending/urist/autodrobe{
-	req_access = newlist()
-	},
-/obj/effect/floor_decal/corner/white/three_quarters{
+/obj/effect/floor_decal/corner/fadeblue/three_quarters{
 	dir = 1;
-	icon_state = "corner_white_three_quarters";
-	tag = "icon-corner_white_three_quarters (NORTH)"
+	icon_state = "corner_white_three_quarters"
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 8;
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/civilian/holodeck)
+/area/command/aiupload)
 "iU" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4789,6 +4821,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cargo)
 "iY" = (
@@ -5088,6 +5121,11 @@
 	icon_state = "corner_white_three_quarters";
 	tag = "icon-corner_white_three_quarters (WEST)"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "jy" = (
@@ -5096,13 +5134,8 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/item/device/radio/intercom{
-	frequency = 1343;
-	name = "AI intercom";
-	pixel_y = 28
-	},
 /obj/machinery/camera/network/command{
-	c_tag = "AI Upload Entrance"
+	c_tag = "Fourth Deck Command Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
@@ -5111,6 +5144,19 @@
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
 	dir = 1;
 	icon_state = "corner_white_three_quarters"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	name = "Station Intercom (Command)";
+	pixel_x = 0;
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -5129,6 +5175,13 @@
 	icon_state = "intact-supply";
 	tag = "icon-intact-supply (EAST)"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bottom_hallway)
 "jA" = (
@@ -5143,6 +5196,13 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "jB" = (
@@ -5156,8 +5216,10 @@
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -5192,63 +5254,76 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod3/station)
 "jG" = (
-/obj/machinery/door/airlock/glass{
-	name = "Holodeck"
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload";
+	req_access = list("ACCESS_AI_UPLOAD")
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/civilian/holodeck)
+/area/command/aiupload)
 "jH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4;
-	icon_state = "map_scrubber_on"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/white{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/floor_decal/corner/fadeblue{
 	dir = 9;
 	icon_state = "corner_white";
 	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/civilian/holodeck)
+/area/command/aiupload)
 "jI" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
 	icon_state = "intact-scrubbers"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	icon_state = "intact-supply"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/fadeblue,
 /turf/simulated/floor/tiled/techmaint,
-/area/civilian/holodeck)
+/area/command/aiupload)
 "jJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	icon_state = "map_vent_out"
 	},
-/obj/effect/floor_decal/corner/white/three_quarters{
-	dir = 4;
-	icon_state = "corner_white_three_quarters";
-	tag = "icon-corner_white_three_quarters (EAST)"
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Holodeck Control";
-	dir = 1
+/obj/effect/floor_decal/corner/fadeblue/three_quarters{
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/civilian/holodeck)
-"jK" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list("ACCESS_MAINT")
-	},
-/turf/simulated/floor/plating,
-/area/civilian/holodeck)
+/area/command/aiupload)
 "jL" = (
 /obj/machinery/light/small/red{
 	dir = 4;
@@ -5280,6 +5355,7 @@
 /area/exploration_shuttle/main)
 "jO" = (
 /obj/machinery/door/airlock/hatch,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cargo)
 "jP" = (
@@ -5656,61 +5732,62 @@
 /area/security/breakroom)
 "kp" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 9;
-	icon_state = "warning"
+	dir = 8
 	},
-/obj/machinery/light{
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24;
+	tag = "icon-alarm0 (EAST)"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
+"kq" = (
+/obj/effect/floor_decal/borderfloorgrey{
+	dir = 9
+	},
+/obj/structure/bed/chair/office/comfy/blue{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
-"kq" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9;
-	icon_state = "borderfloor_white";
-	tag = "icon-borderfloor_white (NORTHWEST)"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning";
-	tag = "icon-warning (NORTH)"
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/command/aiupload)
+/turf/simulated/floor/tiled/techmaint,
+/area/command/weapons_command)
 "kr" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5;
-	icon_state = "borderfloor_white";
-	tag = "icon-borderfloor_white (NORTHEAST)"
+/obj/effect/floor_decal/borderfloorgrey{
+	dir = 5
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning";
-	tag = "icon-warning (NORTH)"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/flasher{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/command/aiupload)
+/turf/simulated/floor/tiled/techmaint,
+/area/command/weapons_command)
 "ks" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 5;
+	dir = 4;
 	icon_state = "warning";
-	tag = "icon-warning (NORTHEAST)"
+	tag = "icon-warning (EAST)"
 	},
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
+/obj/item/modular_computer/console/preset/nervacommand{
+	dir = 8;
+	icon_state = "console";
+	tag = "icon-console (WEST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "ku" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "kv" = (
@@ -5752,11 +5829,6 @@
 	dir = 5;
 	icon_state = "intact-supply";
 	tag = "icon-intact-supply (NORTHEAST)"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -5828,9 +5900,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfourth)
 "kE" = (
-/obj/effect/floor_decal/corner/white/three_quarters,
+/obj/effect/floor_decal/corner/fadeblue/three_quarters,
 /turf/simulated/floor/tiled/techmaint,
-/area/civilian/holodeck)
+/area/command/aiupload)
 "kF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5839,18 +5911,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/corner/white/three_quarters{
+/obj/effect/floor_decal/corner/fadeblue/three_quarters{
 	dir = 4;
-	icon_state = "corner_white_three_quarters";
-	tag = "icon-corner_white_three_quarters (EAST)"
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/civilian/holodeck)
+/area/command/aiupload)
 "kG" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list("ACCESS_MAINT")
@@ -6069,63 +6135,47 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/breakroom)
 "lc" = (
-/obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24;
-	tag = "icon-alarm0 (EAST)"
-	},
-/obj/machinery/porta_turret,
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
-"ld" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/camera/network/command{
+	c_tag = "Weapons Command";
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/machinery/firealarm{
 	dir = 8;
-	icon_state = "borderfloor_white";
-	tag = "icon-borderfloor_white (WEST)"
+	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/command/aiupload)
-"le" = (
-/obj/effect/landmark/start{
-	name = "Cyborg"
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
+"ld" = (
+/obj/effect/floor_decal/borderfloorgrey{
+	dir = 8
 	},
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/turf/simulated/floor/tiled/techmaint,
+/area/command/weapons_command)
+"le" = (
+/obj/effect/floor_decal/borderfloorgrey{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4;
-	icon_state = "borderfloor_white";
-	tag = "icon-borderfloor_white (EAST)"
+/obj/structure/bed/chair/office/comfy/blue{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/command/aiupload)
+/turf/simulated/floor/tiled/techmaint,
+/area/command/weapons_command)
 "lf" = (
-/obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
-/obj/machinery/porta_turret,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	frequency = 1343;
-	icon_state = "intercom";
-	name = "AI intercom";
-	pixel_x = 22;
-	tag = "icon-intercom (WEST)"
+/obj/machinery/computer/combatcomputer/nerva{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "lg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/command{
@@ -6133,6 +6183,12 @@
 	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "lh" = (
@@ -6182,16 +6238,7 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/centralfourth)
-"lm" = (
-/obj/machinery/door/airlock/glass{
-	name = "Holodeck"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/centralfourth)
 "lo" = (
-/obj/machinery/door/airlock/glass{
-	name = "Holodeck"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -6200,8 +6247,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
-/area/civilian/holodeck)
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Upload Access";
+	req_access = list("ACCESS_AI_UPLOAD")
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/command/aiupload)
 "lp" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 4
@@ -6411,69 +6462,58 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "AI Upload";
-	dir = 4;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "lL" = (
+/obj/effect/floor_decal/borderfloorgrey{
+	dir = 10
+	},
+/obj/structure/bed/chair/office/comfy/blue,
+/turf/simulated/floor/tiled/techmaint,
+/area/command/weapons_command)
+"lM" = (
+/obj/effect/floor_decal/borderfloorgrey{
+	dir = 6
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8;
-	icon_state = "borderfloor_white";
-	tag = "icon-borderfloor_white (WEST)"
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/command/aiupload)
-"lM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10;
-	icon_state = "intact-supply"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4;
-	icon_state = "borderfloor_white";
-	tag = "icon-borderfloor_white (EAST)"
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/command/aiupload)
+/turf/simulated/floor/tiled/techmaint,
+/area/command/weapons_command)
 "lN" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/item/modular_computer/console/preset/nervacommand{
+	dir = 8;
+	icon_state = "console";
+	tag = "icon-console (WEST)"
 	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "lO" = (
 /obj/effect/floor_decal/corner/fadeblue/full,
-/obj/machinery/turretid/stun{
-	control_area = /area/command/aiupload;
-	dir = 4;
-	icon_state = "control_stun";
-	pixel_x = -26;
-	tag = "icon-control_stun (EAST)"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "lQ" = (
-/obj/structure/closet/emcloset,
-/obj/structure/closet/walllocker/emerglocker/west,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Command Bypass"
 	},
 /turf/simulated/floor/plating,
-/area/command/fourth_emergency_storage)
+/area/engineering/substation/command)
 "lR" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
@@ -6963,6 +7003,10 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/plating,
 /area/hadrian/storage)
 "mC" = (
@@ -7122,11 +7166,6 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -7146,11 +7185,6 @@
 	icon_state = "intact-supply";
 	tag = "icon-intact (SOUTHWEST)"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "mQ" = (
@@ -7163,73 +7197,54 @@
 	icon_state = "1-4";
 	tag = ""
 	},
-/obj/machinery/computer/robotics{
-	dir = 4;
-	icon_state = "computer";
-	tag = "icon-computer (WEST)"
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "mR" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10;
-	icon_state = "borderfloor_white";
-	tag = "icon-borderfloor_white (SOUTHWEST)"
-	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/old_tile,
-/area/command/aiupload)
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "mS" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6;
-	icon_state = "borderfloor_white";
-	tag = "icon-borderfloor_white (SOUTHEAST)"
-	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/old_tile,
-/area/command/aiupload)
+/obj/machinery/light/small/red,
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "mT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHEAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white/monotile,
-/area/command/aiupload)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "mU" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload";
-	req_access = list("ACCESS_AI_UPLOAD")
+	name = "Weapons Command";
+	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7244,65 +7259,43 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/command/aiupload)
+/obj/effect/floor_decal/corner/fadeblue/full,
+/turf/simulated/floor/tiled/techmaint,
+/area/command/weapons_command)
 "mV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/command/bottom_hallway)
-"mW" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fourth Deck Emergency Storage";
-	req_access = list("ACCESS_BRIDGE")
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
+	dir = 10;
 	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
-/turf/simulated/floor/plating,
-/area/command/fourth_emergency_storage)
+/turf/simulated/floor/tiled/techmaint,
+/area/command/bottom_hallway)
 "mX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Substation - Command"
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	d2 = 2;
+	icon_state = "0-2"
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/command/fourth_emergency_storage)
+/area/engineering/substation/command)
 "mY" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/bottomgun)
@@ -7400,6 +7393,10 @@
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 4 Cargo");
+	location = "Deck 4 Escape"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfourth)
@@ -7537,6 +7534,7 @@
 	name = "\improper Central Access";
 	tag = "icon-closed (WEST)"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/centralfourth)
 "nm" = (
@@ -7836,10 +7834,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "nN" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
@@ -7852,29 +7846,49 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "nP" = (
-/obj/machinery/space_heater,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 0;
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/sensor{
+	name_tag = "Command Power"
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1;
-	icon_state = "map_scrubber_on"
+	icon_state = "warning";
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/plating,
-/area/command/fourth_emergency_storage)
+/area/engineering/substation/command)
 "nQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Bridge Maintenance";
 	req_access = list(list("ACCESS_BRIDGE","ACCESS_GUNNERY"))
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/security/bottomgun)
 "nR" = (
@@ -8365,30 +8379,19 @@
 "oL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bottomgun)
 "oM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/conveyor_switch/oneway{
 	id = "torpedo"
 	},
@@ -8398,25 +8401,33 @@
 	pixel_x = 0;
 	pixel_y = 28
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bottomgun)
 "oN" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 0;
-	d2 = 8;
-	icon_state = "0-8"
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 6;
 	icon_state = "corner_white"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d1 = 0;
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/bottomgun)
@@ -8812,19 +8823,23 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/nuke_storage)
 "pH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/security/bottomgun)
@@ -8832,6 +8847,13 @@
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/security/bottomgun)
@@ -9454,22 +9476,22 @@
 	c_tag = "Fourth Deck Command Hallway";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/corner/fadeblue/three_quarters,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
-	},
-/obj/structure/cable{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
+	icon_state = "1-8";
 	pixel_x = 0;
 	tag = ""
 	},
-/obj/effect/floor_decal/corner/fadeblue/three_quarters,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (NORTHWEST)"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "qI" = (
@@ -9558,21 +9580,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
 "qN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0;
-	tag = ""
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bottomgun)
@@ -9631,6 +9651,7 @@
 	},
 /obj/machinery/atmospherics/binary/passive_gate/on{
 	dir = 1;
+	max_pressure_setting = 35000;
 	regulate_mode = 1;
 	target_pressure = 35000;
 	use_power = 1
@@ -9639,8 +9660,7 @@
 /area/engineering/bdstarengine)
 "qS" = (
 /obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "cChamber1pV";
+	id = "d4_starboard_chamber_vent";
 	name = "Chamber Vent"
 	},
 /turf/simulated/floor/reinforced,
@@ -10098,11 +10118,13 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -10274,6 +10296,11 @@
 	c_tag = "Bottom Deck Gunnery Room";
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/security/bottomgun)
 "rQ" = (
@@ -10347,11 +10374,13 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "rW" = (
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	frequency = 1441;
+	id_tag = "d4_starboard_chamber_out";
 	internal_pressure_bound = 35000;
 	internal_pressure_bound_default = 35000
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "rX" = (
@@ -10375,10 +10404,12 @@
 	name = "Central Access"
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hallway/centralfourth)
 "sa" = (
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "sb" = (
@@ -10454,7 +10485,8 @@
 /obj/structure/sign/directions/supply{
 	pixel_y = -4
 	},
-/turf/simulated/wall/prepainted,
+/obj/effect/paint_stripe/mauve,
+/turf/simulated/wall/r_wall/prepainted,
 /area/rnd/storage)
 "sj" = (
 /turf/simulated/wall/prepainted,
@@ -10517,11 +10549,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -10564,6 +10591,10 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/nuke_storage)
 "sq" = (
@@ -10598,6 +10629,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "st" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bottomgun)
 "su" = (
@@ -10648,12 +10684,14 @@
 	id = "engines";
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
+	frequency = 1441;
+	id_tag = "d4_starboard_chamber_out";
 	internal_pressure_bound = 35000;
 	internal_pressure_bound_default = 35000
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "sz" = (
@@ -11075,6 +11113,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"tb" = (
+/obj/structure/bed/chair/shuttle/black{
+	dir = 4;
+	icon_state = "shuttle_chair_preview"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled,
+/area/exploration_shuttle/main)
 "td" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Janitorial Supply Closet";
@@ -11085,11 +11143,6 @@
 "te" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -11130,6 +11183,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bottomgun)
@@ -11197,26 +11255,31 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "tq" = (
+/obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1441;
+	id = "d4_starboard_chamber_in";
 	injecting = 1;
 	use_power = 1
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "tr" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1441;
+	id = "d4_starboard_chamber_in";
 	injecting = 1;
 	use_power = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "ts" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/air_sensor{
-	id_tag = "cChamber1sb";
-	output = 2
+	frequency = 1441;
+	id_tag = "d4_starboard_chamber_sensor";
+	output = 111
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -11483,6 +11546,10 @@
 	dir = 9;
 	icon_state = "corner_white"
 	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Supply Pump"
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "tU" = (
@@ -11504,6 +11571,12 @@
 	req_access = list(list("ACCESS_BRIDGE","ACCESS_GUNNERY"))
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/security/bottomgun)
 "tW" = (
@@ -11543,8 +11616,7 @@
 "tZ" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1sbnacelle"
+	id = "d4sbnacelle"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -11552,8 +11624,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1sbnacelle"
+	id = "d4sbnacelle"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -11561,8 +11632,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "d1sbnacelle"
+	id = "d4sbnacelle"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -11766,13 +11836,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
 "uB" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
 "uE" = (
@@ -11943,6 +12012,11 @@
 "uX" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "uY" = (
@@ -12046,8 +12120,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/machinery/computer/general_air_control/large_tank_control{
+	input_tag = "d4_starboard_chamber_in";
+	name = "Chamber Gas Control";
+	output_tag = "d4_starboard_chamber_out";
+	sensors = list("d4_starboard_chamber_sensor" = "Combustion Chamber")
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -12056,15 +12133,19 @@
 	dir = 10
 	},
 /obj/machinery/button/remote/blast_door{
-	id = "d1sbnacelle";
+	id = "d4sbnacelle";
 	name = "combustion chamber blast door control";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
 	icon_state = "warning";
 	tag = "icon-warning (NORTHEAST)"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -12240,18 +12321,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	icon_state = "map-supply"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
 "vD" = (
@@ -12259,14 +12335,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6;
@@ -12290,14 +12358,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12309,17 +12369,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply";
-	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
@@ -12332,16 +12383,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	icon_state = "map-supply"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
 "vH" = (
@@ -12353,14 +12406,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
@@ -12373,13 +12431,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
@@ -12505,18 +12564,17 @@
 "vQ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "vR" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
-	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/weapon/reagent_containers/glass/bucket,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1;
+	level = 2
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
@@ -12578,7 +12636,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/safe_room)
 "vY" = (
-/obj/structure/closet/secure_closet/guncabinet/sidearm/small,
+/obj/structure/closet/secure_closet/guncabinet/sidearm/small{
+	req_access = list("ACCESS_BRIDGE")
+	},
 /obj/effect/floor_decal/techfloor{
 	dir = 6;
 	icon_state = "techfloor_edges"
@@ -12598,6 +12658,11 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "wa" = (
@@ -12779,6 +12844,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/command/seniorntoffice)
 "ww" = (
@@ -12899,8 +12965,8 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "wH" = (
@@ -13000,6 +13066,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
 "wR" = (
@@ -13056,6 +13127,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "d4_starboard_chamber_vent";
+	name = "combustion chamber vent control";
+	pixel_y = -24
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -13479,14 +13556,14 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
 	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -13520,6 +13597,7 @@
 	},
 /obj/item/weapon/weldingtool,
 /obj/item/weapon/melee/baton/loaded,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
 "xG" = (
@@ -13679,11 +13757,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "xT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -13965,6 +14038,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 3 Aft Port");
+	location = "Deck 4 Cargo"
+	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "yk" = (
@@ -14129,7 +14206,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -14281,14 +14357,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "yK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/junk,
 /obj/structure/catwalk,
@@ -14346,6 +14418,12 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Workshop";
+	departmentType = 3;
+	name = "Workshop RC";
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/white,
 /area/logistics/advwork)
@@ -14609,12 +14687,14 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8";
 	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -14627,6 +14707,10 @@
 /area/rnd/xenobiology/xenoflora)
 "zn" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
 "zo" = (
@@ -14645,12 +14729,22 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "zv" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -14659,6 +14753,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -14673,6 +14772,11 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "zz" = (
@@ -14680,6 +14784,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -14771,6 +14880,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "zH" = (
@@ -14783,11 +14893,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "zI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -15017,9 +15122,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15055,7 +15160,7 @@
 	icon_state = "crateopen";
 	opened = 1
 	},
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /obj/random/tank,
 /obj/random/tech_supply,
 /obj/random/tool,
@@ -15088,6 +15193,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Ap" = (
@@ -15095,6 +15205,11 @@
 /obj/machinery/light/small/red,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -15112,6 +15227,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -15397,11 +15517,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -15419,11 +15534,6 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -15434,11 +15544,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
 	icon_state = "intact-scrubbers"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -15504,6 +15609,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Bd" = (
@@ -15512,6 +15618,7 @@
 	d2 = 4;
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Be" = (
@@ -15524,6 +15631,12 @@
 	d2 = 4;
 	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Bf" = (
@@ -15531,6 +15644,12 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Bg" = (
@@ -15838,6 +15957,12 @@
 "BL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "BM" = (
@@ -15845,11 +15970,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/centralfourth)
 "BN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/catwalk,
@@ -16003,11 +16123,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -16017,15 +16132,10 @@
 /area/maintenance/fourth_deck/fs)
 "Ce" = (
 /obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 2;
+/obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
@@ -16063,16 +16173,7 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
-"Ck" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/maintenance/fourth_deck/afs)
 "Cl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -16081,12 +16182,17 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Cm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16101,9 +16207,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Cn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16119,9 +16225,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Co" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16441,7 +16547,7 @@
 /area/rnd/xenobiology/xenoflora)
 "CJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -16537,7 +16643,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "CW" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -16813,7 +16919,7 @@
 /area/rnd/xenobiology)
 "Dt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -16875,7 +16981,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "DA" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -17095,7 +17201,7 @@
 /area/rnd/xenobiology)
 "DN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -17163,7 +17269,7 @@
 /area/maintenance/fourth_deck/afs)
 "DW" = (
 /turf/simulated/wall/prepainted,
-/area/logistics/storage)
+/area/logistics/lockers)
 "DX" = (
 /obj/machinery/light{
 	dir = 8
@@ -17183,14 +17289,14 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
 "DZ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -17202,14 +17308,14 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
 "Ea" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17220,11 +17326,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
 "Eb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17236,11 +17337,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
 "Ec" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
 	icon_state = "intact-scrubbers"
@@ -17392,12 +17488,24 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Ep" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Eq" = (
@@ -17405,6 +17513,12 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Er" = (
@@ -17412,6 +17526,12 @@
 	dir = 4
 	},
 /obj/random/trash,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Es" = (
@@ -17419,6 +17539,12 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Et" = (
@@ -17426,6 +17552,12 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Eu" = (
@@ -17436,23 +17568,36 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Ev" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
-"Ew" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate{
-	icon_state = "crateopen";
-	opened = 1
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/yellow/three_quarters{
+	dir = 8;
+	icon_state = "corner_white_three_quarters";
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
+"Ew" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "Ex" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/ore_box,
+/obj/structure/closet/secure_closet/miner,
+/obj/item/weapon/storage/backpack/duffel/duffel_eng,
+/obj/item/clothing/suit/storage/hooded/wintercoat/miner,
+/obj/item/weapon/mining_scanner,
+/obj/item/clothing/accessory/armband/cargo,
+/obj/machinery/camera/network/cargo{
+	c_tag = "Cargo Lockers"
+	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	dir = 2;
@@ -17460,11 +17605,11 @@
 	name = "Station Intercom (General)";
 	pixel_y = 28
 	},
-/obj/machinery/camera/network/cargo{
-	c_tag = "Cargo General Storage"
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "Ey" = (
 /obj/machinery/camera/network/cargo{
 	c_tag = "Lower Cargo Bay Elevator";
@@ -17484,6 +17629,11 @@
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
 "EA" = (
@@ -17494,11 +17644,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/cargo_lift/lift)
 "EB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/warning{
@@ -17673,13 +17818,13 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "EL" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
+/obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 4;
 	icon_state = "2-4"
 	},
@@ -17703,9 +17848,9 @@
 	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -17725,9 +17870,9 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
@@ -17776,6 +17921,12 @@
 	icon_state = "cobweb1";
 	tag = "icon-cobweb1 (EAST)"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "ER" = (
@@ -17783,6 +17934,12 @@
 	dir = 4
 	},
 /obj/machinery/light/small/red,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "ES" = (
@@ -17790,58 +17947,56 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "EV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
 	icon_state = "map-scrubbers"
 	},
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "EW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
+"EX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
+"EY" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
-"EX" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
-"EY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers";
-	tag = "icon-intact-scrubbers (EAST)"
-	},
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "EZ" = (
 /obj/machinery/door/airlock/mining{
-	name = "Cargo General Storage";
+	name = "Cargo Lockers";
 	req_access = list("ACCESS_CARGO")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17854,8 +18009,13 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "Fa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -17868,6 +18028,11 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -17886,6 +18051,11 @@
 	dir = 4;
 	icon_state = "warning";
 	tag = "icon-warning (EAST)"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
@@ -17940,7 +18110,7 @@
 /area/rnd/xenobiology)
 "Fg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -17956,7 +18126,7 @@
 	name = "west bump";
 	pixel_x = -25
 	},
-/obj/structure/cable,
+/obj/structure/cable/yellow,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/disposals)
@@ -18012,42 +18182,73 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Fr" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/cargotech,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/weapon/storage/backpack/duffel/duffel_norm,
+/obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
+/obj/item/clothing/accessory/armband/cargo,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1;
 	icon_state = "map_scrubber_on"
 	},
-/obj/structure/closet/crate,
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
+/obj/effect/floor_decal/corner/yellow/three_quarters,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "Fs" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/cargotech,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/weapon/storage/backpack/duffel/duffel_norm,
+/obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
+/obj/item/clothing/accessory/armband/cargo,
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (SOUTHWEST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "Ft" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/cargotech,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/weapon/storage/backpack/duffel/duffel_norm,
+/obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
+/obj/item/clothing/accessory/armband/cargo,
+/obj/structure/cable,
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/high;
 	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable,
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (SOUTHWEST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "Fu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/cargotech,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/weapon/storage/backpack/duffel/duffel_norm,
+/obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
+/obj/item/clothing/accessory/armband/cargo,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	icon_state = "map_vent_out"
 	},
-/turf/simulated/floor/tiled,
-/area/logistics/storage)
+/obj/effect/floor_decal/corner/yellow/three_quarters{
+	dir = 4;
+	icon_state = "corner_white_three_quarters";
+	tag = "icon-corner_white_three_quarters (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "Fv" = (
 /obj/machinery/light{
 	dir = 8
@@ -18070,11 +18271,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
 "Fx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -18150,11 +18346,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
@@ -18170,6 +18361,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18238,7 +18434,7 @@
 /area/rnd/xenobiology)
 "FK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -18285,11 +18481,6 @@
 	req_access = list("ACCESS_CARGO")
 	},
 /obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/logistics/lowercargo)
@@ -18313,11 +18504,6 @@
 	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
@@ -18330,6 +18516,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	icon_state = "intact-supply"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18370,7 +18562,7 @@
 /area/rnd/xenobiology)
 "Ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -18421,16 +18613,26 @@
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
+"Gk" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9;
+	icon_state = "borderfloor_white";
+	tag = "icon-borderfloor_white (NORTHWEST)"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
 "Gn" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9;
 	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18440,11 +18642,6 @@
 	name = "Connector Port (Air Supply)"
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "Gp" = (
@@ -18453,32 +18650,17 @@
 	icon_state = "intact"
 	},
 /obj/machinery/meter,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "Gq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "Gr" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -18499,6 +18681,12 @@
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18532,7 +18720,7 @@
 /area/rnd/xenobiology)
 "Gw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -18579,14 +18767,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -18652,18 +18835,18 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "GI" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/valve/shutoff,
+/obj/effect/floor_decal/industrial/shutoff,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
 "GJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -18681,6 +18864,14 @@
 	name = "Research Wing";
 	req_access = list("ACCESS_XENOBIO")
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenoshitonlock";
+	name = "Xenobiology Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "GM" = (
@@ -18690,6 +18881,20 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenoshitonlock";
+	name = "Xenobiology Lockdown";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -18714,9 +18919,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -18734,20 +18939,10 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/catwalk_plated/white,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -18762,6 +18957,17 @@
 	tag_chamber_sensor = "hadrian_shuttle_dock_sensor";
 	tag_exterior_door = "hadrian_shuttle_dock_outer";
 	tag_interior_door = "hadrian_shuttle_dock_inner"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -18907,9 +19113,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -19423,6 +19629,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
 "HZ" = (
@@ -19444,6 +19651,10 @@
 	icon_state = "1-2";
 	pixel_y = 0;
 	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
@@ -19530,6 +19741,7 @@
 "Ii" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/airlock/hatch,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
 "Ij" = (
@@ -19543,6 +19755,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hadrian/main)
 "Ik" = (
@@ -19656,6 +19869,10 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
 /area/hadrian/main)
@@ -19777,6 +19994,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hadrian/main)
 "ID" = (
@@ -19833,15 +20051,12 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/exploration_shuttle/main)
 "II" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning";
 	tag = "icon-warning (SOUTHEAST)"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "IK" = (
@@ -19884,7 +20099,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
 "IZ" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -19904,6 +20119,38 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
+"Ja" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6;
+	icon_state = "borderfloor_white";
+	tag = "icon-borderfloor_white (SOUTHEAST)"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
+"Jb" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/high;
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
+"Jc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "Je" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -19992,6 +20239,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
+"Jo" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology)
 "Jp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -20023,6 +20282,21 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
+"Jv" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning";
+	tag = "icon-warning (NORTH)"
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/item/modular_computer/console/preset/medical,
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "Jz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
@@ -20050,15 +20324,27 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/safe_room)
+"JF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5;
+	icon_state = "warning";
+	tag = "icon-warning (NORTHEAST)"
+	},
+/obj/item/device/radio/intercom/locked/ai_private{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "JH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20134,6 +20420,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"JS" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "JT" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -20144,6 +20441,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hadrian/main)
 "Ka" = (
@@ -20212,15 +20510,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
 "Ko" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
@@ -20377,15 +20670,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/safe_room)
 "KH" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -20395,35 +20683,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "KI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 10;
 	icon_state = "corner_white"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "KN" = (
@@ -20531,15 +20802,15 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Lr" = (
@@ -20605,13 +20876,24 @@
 /turf/simulated/floor/plating,
 /area/medical/extstorage)
 "LF" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/camera/network/command{
-	c_tag = "Fourth Deck Emergency Storage";
+/obj/machinery/camera/network/engineering{
+	c_tag = "Command Substation";
 	dir = 1
 	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/high;
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1;
+	icon_state = "warningcorner";
+	tag = "icon-warningcorner (NORTH)"
+	},
 /turf/simulated/floor/plating,
-/area/command/fourth_emergency_storage)
+/area/engineering/substation/command)
 "LH" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -20660,6 +20942,23 @@
 "LR" = (
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/extstorage)
+"LY" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5;
+	icon_state = "warning";
+	tag = "icon-warning (NORTHEAST)"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	name = "Station Intercom (Command)";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "Mb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -20684,32 +20983,42 @@
 /turf/simulated/wall/titanium,
 /area/exploration_shuttle/cargo)
 "Mg" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24;
-	pixel_y = 0
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning";
+	tag = "icon-warning (WEST)"
 	},
 /turf/simulated/floor/plating,
-/area/command/fourth_emergency_storage)
+/area/engineering/substation/command)
 "Mj" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	pixel_x = 0
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning";
+	tag = "icon-warning (WEST)"
 	},
 /turf/simulated/floor/plating,
-/area/command/fourth_emergency_storage)
+/area/engineering/substation/command)
 "Mm" = (
 /obj/effect/paint/silver,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -20718,18 +21027,22 @@
 	},
 /turf/simulated/wall/titanium,
 /area/hadrian/main)
+"Mo" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
 "Mp" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "Mw" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 2;
-	layer = 2.4;
-	level = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/rnd/storage)
 "My" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -20850,10 +21163,35 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
+"Nw" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plating,
+/area/rnd/xenobiology/xenoflora)
+"NB" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "ND" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/logistics/hangar)
+"NF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9;
+	icon_state = "warning"
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "NG" = (
 /obj/machinery/shipsensors,
 /obj/structure/cable/cyan,
@@ -20864,9 +21202,9 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/safe_room)
 "NK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20918,9 +21256,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -20936,6 +21274,16 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
+"Oe" = (
+/obj/machinery/computer/upload/robot{
+	dir = 2;
+	icon_state = "computer"
+	},
+/obj/machinery/flasher{
+	pixel_y = 32
+	},
+/turf/simulated/floor/greengrid,
+/area/command/aiupload)
 "Oh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20964,13 +21312,23 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fourth_deck/fs)
 "Ox" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 5;
 	icon_state = "corner_white";
 	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -21076,9 +21434,6 @@
 /obj/item/stack/flag/yellow,
 /obj/item/weapon/storage/box/samplebags,
 /obj/item/weapon/wrench,
-/obj/effect/floor_decal/industrial/shutoff{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
 "OP" = (
@@ -21086,6 +21441,27 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/command/seniorntoffice)
+"OQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6;
+	icon_state = "warning";
+	tag = "icon-warning (SOUTHEAST)"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "Pd" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "stickyweb2";
@@ -21118,27 +21494,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/cockpit)
-"Pg" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/command{
-	name = "Fourth Deck Gun Bay";
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/security/bottomgun)
 "Pi" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/plating,
@@ -21155,6 +21510,19 @@
 	},
 /turf/space,
 /area/space)
+"Po" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "hadrian_shutters";
+	name = "Protective Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/hadrian/main)
 "Pp" = (
 /obj/machinery/self_destruct,
 /turf/simulated/floor/blackgrid,
@@ -21211,12 +21579,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
-"PB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"Py" = (
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
+"PB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
@@ -21228,7 +21599,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/logistics/storage)
+/area/logistics/lockers)
 "PC" = (
 /obj/machinery/shipsensors,
 /obj/machinery/light/spot{
@@ -21271,9 +21642,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -21311,6 +21682,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hadrian/main)
 "PW" = (
@@ -21328,6 +21700,30 @@
 /obj/item/clothing/mask/muzzle,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
+"PX" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (NORTHEAST)"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "Qc" = (
 /obj/machinery/door/airlock/medical{
 	name = "Virology";
@@ -21381,11 +21777,6 @@
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21449,12 +21840,17 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fourth_deck/afs)
 "Qx" = (
-/obj/machinery/computer/upload/robot{
-	dir = 2;
-	icon_state = "computer"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning";
+	tag = "icon-warning (NORTH)"
 	},
-/turf/simulated/floor/greengrid,
-/area/command/aiupload)
+/obj/machinery/light/small/red{
+	dir = 1;
+	icon_state = "firelight1"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/command/weapons_command)
 "Qy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21497,9 +21893,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -21528,6 +21924,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8;
+	icon_state = "map_scrubber_on"
+	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
 "QN" = (
@@ -21575,9 +21976,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -21612,9 +22013,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21624,11 +22025,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -21717,6 +22117,14 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
+"Ri" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "Rk" = (
 /obj/machinery/computer/general_air_control{
 	dir = 1;
@@ -21739,19 +22147,21 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/medical/virology)
+"Rp" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4;
+	icon_state = "borderfloor_white";
+	tag = "icon-borderfloor_white (EAST)"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
 "Rs" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Rv" = (
-/obj/effect/catwalk_plated/dark,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -21761,7 +22171,16 @@
 	icon_state = "2-4";
 	tag = ""
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
 /area/rnd/storage)
 "Ry" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21813,7 +22232,15 @@
 	name = "Research Storage";
 	req_access = list("ACCESS_XENOBIO")
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
+/area/rnd/storage)
+"RO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
 /area/rnd/storage)
 "RP" = (
 /obj/machinery/camera/network/fourth_deck{
@@ -21835,6 +22262,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/nuke_storage)
+"RR" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/item/weapon/storage/backpack/duffel/duffel_eng,
+/obj/item/clothing/suit/storage/hooded/wintercoat/miner,
+/obj/item/weapon/mining_scanner,
+/obj/item/clothing/accessory/armband/cargo,
+/obj/effect/floor_decal/corner/yellow/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/lockers)
 "RS" = (
 /turf/simulated/wall/r_wall/false{
 	icon_state = "rdebug"
@@ -21878,6 +22316,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"Sa" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Command Substation";
+	req_access = list("ACCESS_ENGINEERING")
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/substation/command)
 "Sb" = (
 /obj/effect/paint_stripe/mauve,
 /turf/simulated/wall/r_wall/prepainted,
@@ -21889,17 +22339,25 @@
 "Sh" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/space)
+"Sj" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "Sk" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21917,6 +22375,7 @@
 	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "Sm" = (
@@ -21954,6 +22413,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/fadeblue/full,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "Sy" = (
@@ -21963,6 +22426,9 @@
 /obj/random/masks,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"SD" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/command/weapons_command)
 "SF" = (
 /obj/machinery/light{
 	dir = 4
@@ -21988,6 +22454,7 @@
 /area/maintenance/fourth_deck/afp)
 "SJ" = (
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/virology)
 "SK" = (
@@ -22009,13 +22476,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
-"SU" = (
-/obj/machinery/door/airlock/glass{
-	name = "Holodeck"
+"ST" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
-/area/civilian/holodeck)
+/obj/machinery/computer/robotics{
+	dir = 4;
+	icon_state = "computer";
+	tag = "icon-computer (WEST)"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "SX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -22072,9 +22543,6 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
-"Td" = (
-/turf/simulated/wall/prepainted,
-/area/rnd/storage)
 "Te" = (
 /obj/structure/table/rack,
 /obj/item/weapon/aiModule/protectStation,
@@ -22104,9 +22572,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22142,6 +22610,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
 "Tq" = (
@@ -22167,20 +22636,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "Tz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 10;
 	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -22220,6 +22681,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
+"TG" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "TI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22236,7 +22704,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -22272,6 +22740,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
+"Ua" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8;
+	icon_state = "borderfloor_white";
+	tag = "icon-borderfloor_white (WEST)"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
 "Uc" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -22303,6 +22779,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"Up" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/afp)
 "Ur" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1;
@@ -22310,6 +22791,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/xenobiology/xenoflora)
+"Uu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/porta_turret,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "Ux" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -22373,20 +22865,43 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 5;
 	icon_state = "corner_white";
 	tag = "icon-corner_white (NORTHEAST)"
 	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 0;
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "UN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/rnd/storage)
 "UR" = (
 /obj/machinery/conveyor{
@@ -22410,6 +22925,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"UX" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/door/blast/regular{
+	id = "d4portnacelle"
+	},
+/obj/effect/wallframe_spawn/reinforced_phoron,
+/turf/simulated/floor/reinforced,
+/area/engineering/bdportengine)
 "UY" = (
 /obj/structure/bed/nice,
 /obj/item/stack/medical/bruise_pack,
@@ -22422,6 +22945,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"Ve" = (
+/obj/effect/floor_decal/floordetail/edgedrain{
+	dir = 8;
+	icon_state = "edge"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/rnd/xenobiology/xenoflora)
 "Vi" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -22439,9 +22973,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -22509,6 +23043,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
+"Vv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/command{
+	name = "Fourth Deck Gun Bay";
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/security/bottomgun)
 "Vw" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -22528,6 +23083,7 @@
 	name = "Protective Shutters";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hadrian/storage)
 "Vz" = (
@@ -22594,9 +23150,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -22622,26 +23178,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "VY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
 	dir = 8;
 	icon_state = "corner_white_three_quarters";
 	tag = "icon-corner_white_three_quarters (WEST)"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	icon_state = "map-supply"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
 "VZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10;
 	icon_state = "warning";
@@ -22662,10 +23224,20 @@
 /obj/structure/bed/nice,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
+"Wi" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
 "Wj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -22705,7 +23277,7 @@
 /area/logistics/fabwork)
 "Wo" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/command/fourth_emergency_storage)
+/area/engineering/substation/command)
 "Wq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/mining{
@@ -22726,11 +23298,6 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22743,6 +23310,11 @@
 	icon_state = "intact"
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "Wv" = (
@@ -22784,11 +23356,6 @@
 /area/maintenance/fourth_deck/fs)
 "WB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/sortjunction{
@@ -22798,8 +23365,28 @@
 	sortType = "Torpedo Bay";
 	tag = "icon-pipe-j1s (NORTH)"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"WD" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Command Substation";
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/command/bottom_hallway)
 "WE" = (
 /obj/machinery/suit_cycler/science,
 /obj/machinery/camera/network/research{
@@ -22818,22 +23405,23 @@
 /obj/effect/paint_stripe/mauve,
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/chemlab)
-"WJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/door/airlock/glass/research{
-	name = "Isolation Room 2";
-	req_access = list("ACCESS_XENOBIO")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora)
 "WK" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/silver,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod2/station)
+"WQ" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "WR" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/airless,
@@ -22852,6 +23440,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"WW" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10;
+	icon_state = "borderfloor_white";
+	tag = "icon-borderfloor_white (SOUTHWEST)"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
 "WY" = (
 /obj/machinery/light/small/red,
 /obj/structure/table/rack,
@@ -22924,10 +23521,11 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "Xx" = (
@@ -22938,14 +23536,27 @@
 /obj/machinery/button/remote/airlock{
 	id = "bridgesafedoor";
 	name = "safe room door-control";
-	pixel_x = 0;
 	pixel_y = 32;
-	req_access = newlist();
+	req_access = list("ACCESS_BRIDGE");
 	specialfunctions = 4
 	},
 /obj/structure/bed/chair/padded/blue,
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
+"XA" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourth_deck/fp)
 "XC" = (
 /obj/structure/stasis_cage,
 /turf/simulated/floor/tiled/techmaint,
@@ -22957,9 +23568,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23025,6 +23636,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"XS" = (
+/obj/machinery/ai_slipper,
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
 "XT" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -23046,6 +23661,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"Yf" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
 "Yg" = (
 /obj/structure/closet,
 /obj/random/maintenance/clean,
@@ -23115,6 +23734,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"Yv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/rnd/xenobiology/xenoflora)
 "Yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -23149,6 +23775,7 @@
 	name = "Xenoflora Wing";
 	req_access = list("ACCESS_XENOBIO")
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "YB" = (
@@ -23189,6 +23816,20 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"YH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "AI Upload";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "YL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23209,23 +23850,18 @@
 	dir = 5;
 	icon_state = "corner_white"
 	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/weapon/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "YN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
 	dir = 4;
 	icon_state = "corner_white_three_quarters"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -23308,6 +23944,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
+"Za" = (
+/obj/machinery/porta_turret,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "Zc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -23332,10 +23979,21 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
 	dir = 1;
 	icon_state = "corner_white_three_quarters"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bottom_hallway)
@@ -23353,6 +24011,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
 "Zl" = (
@@ -23362,6 +24024,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"Zm" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/command/aiupload)
 "Zu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -23379,7 +24055,8 @@
 "Zv" = (
 /obj/machinery/door/airlock/vault/bolted{
 	id_tag = "bridgesafedoor";
-	name = "Bridge Safe Room"
+	name = "Bridge Safe Room";
+	req_access = list("ACCESS_BRIDGE")
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23410,9 +24087,9 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 8;
+	d2 = 4;
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -23432,6 +24109,18 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/safe_room)
+"ZJ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5;
+	icon_state = "borderfloor_white";
+	tag = "icon-borderfloor_white (NORTHEAST)"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/command/aiupload)
 "ZK" = (
 /obj/item/weapon/storage/box/beakers,
 /obj/item/weapon/storage/box/beakers,
@@ -23506,16 +24195,18 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance";
 	req_access = list("ACCESS_XENOBIO")
 	},
 /obj/structure/catwalk,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenoshitonlock";
+	name = "Xenobiology Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
 "ZW" = (
@@ -37152,7 +37843,7 @@ bw
 cY
 dT
 eD
-fd
+UX
 fG
 cm
 gI
@@ -40212,10 +40903,10 @@ zH
 Au
 Bf
 BL
-Ck
-Ck
-Ck
-Ck
+zG
+zG
+zG
+zG
 Eo
 nT
 yF
@@ -40588,16 +41279,16 @@ ap
 ap
 ap
 fN
-ap
-ap
-ap
-ap
-ap
-ap
-ap
-ap
-fJ
-mb
+iM
+iM
+iM
+iM
+iM
+iM
+iM
+iM
+iM
+ls
 nl
 nX
 pa
@@ -40790,15 +41481,15 @@ No
 eM
 fe
 fO
-ap
-gL
-gL
-gL
-gL
-gL
-gL
-gL
-ll
+iM
+iM
+iM
+iM
+iM
+iM
+iM
+iM
+iM
 mc
 nm
 nZ
@@ -40992,15 +41683,15 @@ dZ
 eM
 ff
 fP
-ap
+iM
+iM
 gL
-gL
-gL
-gL
-gL
-gL
-gL
-ll
+TG
+Za
+YH
+ST
+iM
+iM
 md
 nn
 oa
@@ -41194,15 +41885,15 @@ ea
 eN
 fg
 fQ
-ap
-gL
-gL
-gL
-gL
-gL
-gL
-gL
-lm
+iM
+iM
+Py
+Gk
+Ua
+WW
+Jb
+iM
+iM
 me
 no
 ob
@@ -41396,15 +42087,15 @@ eb
 eM
 fh
 fR
-ap
-gL
-gL
-gL
-gL
-gL
-gL
-gL
-ll
+iM
+iM
+jw
+Wi
+XS
+Yf
+Zm
+Ta
+iM
 mf
 no
 oc
@@ -41598,15 +42289,15 @@ af
 ap
 ap
 fR
-ap
-gL
-gL
-gL
-gL
-gL
-gL
-gL
-lm
+iM
+iM
+Oe
+Wi
+Mo
+Yf
+Zm
+Te
+iM
 lT
 np
 od
@@ -41800,15 +42491,15 @@ af
 dY
 ap
 fR
-ap
-gL
-gL
-gL
-gL
-gL
-gL
-gL
-ll
+iM
+iM
+Ri
+ZJ
+Rp
+Ja
+PX
+iM
+iM
 mg
 nq
 oe
@@ -42002,15 +42693,15 @@ LC
 dh
 ap
 fR
-ap
+iM
+iM
 gL
-gL
-gL
-gL
-gL
-gL
-gL
-ll
+JF
+Uu
+Jc
+OQ
+iM
+iM
 lr
 nr
 nw
@@ -42204,15 +42895,15 @@ af
 di
 aB
 fS
-ap
-ap
-ap
-ap
-im
-iQ
+iM
+iM
+iM
+iM
+iM
+iM
 jG
 iQ
-im
+iM
 mh
 Jf
 nw
@@ -42233,9 +42924,9 @@ zI
 zI
 BN
 Cl
-Ck
-Ck
-Ck
+zG
+zG
+zG
 Et
 nT
 nT
@@ -42406,15 +43097,15 @@ af
 VX
 cu
 fR
-eM
-gM
-hp
-hQ
-in
+iM
+iM
+iM
+iM
+iM
 iR
 jH
 kE
-SU
+iM
 mi
 ns
 nw
@@ -42609,10 +43300,10 @@ ap
 eK
 fR
 gk
-gN
-aB
-gN
-in
+Up
+hp
+hQ
+iM
 iS
 jI
 kF
@@ -42814,11 +43505,11 @@ eM
 gO
 hq
 gN
-in
+iM
 iT
 jJ
-in
-in
+iM
+iM
 mk
 nu
 nw
@@ -43016,10 +43707,10 @@ eM
 gP
 hr
 hR
-in
-in
-jK
-in
+iM
+iM
+iM
+iM
 lp
 ml
 nv
@@ -44257,7 +44948,7 @@ Cs
 Da
 DE
 BT
-Ev
+RR
 EY
 Fu
 DW
@@ -44626,7 +45317,7 @@ cF
 du
 ef
 cc
-fl
+tb
 fW
 gm
 gS
@@ -46259,7 +46950,7 @@ oo
 pn
 qr
 rz
-Td
+KN
 WE
 uA
 uA
@@ -46463,7 +47154,7 @@ qn
 rA
 RJ
 UN
-UN
+RO
 Mw
 vG
 wt
@@ -46663,7 +47354,7 @@ cg
 cg
 qs
 Lc
-Td
+KN
 Rv
 GI
 uB
@@ -46865,10 +47556,10 @@ oq
 ZP
 qt
 rB
-Td
+KN
 QI
 OL
-OL
+do
 vI
 ws
 RT
@@ -47067,7 +47758,7 @@ or
 jT
 qu
 rC
-Td
+KN
 tL
 tL
 tL
@@ -47292,7 +47983,7 @@ Ff
 FE
 FU
 Gs
-GG
+Jo
 GM
 GS
 GY
@@ -47511,7 +48202,7 @@ Il
 JJ
 Iv
 IC
-Vp
+Po
 Hn
 aa
 aa
@@ -48314,8 +49005,8 @@ aa
 aa
 aa
 Hn
-Vp
-Vp
+Po
+Po
 Hn
 aa
 aa
@@ -49697,11 +50388,11 @@ Qt
 tM
 tM
 uN
-WJ
+QF
 tM
 xD
 yz
-zm
+Ve
 Ac
 tM
 uQ
@@ -50102,10 +50793,10 @@ tM
 tU
 uP
 II
-uN
+Nw
 xF
 Tp
-zo
+Yv
 Ae
 tM
 xJ
@@ -51515,7 +52206,7 @@ sn
 te
 te
 te
-oH
+bV
 Ys
 tM
 wJ
@@ -52307,7 +52998,7 @@ aq
 aD
 fw
 aD
-hI
+Sj
 iL
 iL
 iL
@@ -52510,13 +53201,13 @@ aq
 aq
 aO
 ia
-aq
-aq
-aq
-aq
-aq
-aq
-aq
+SD
+SD
+SD
+SD
+SD
+SD
+SD
 Xk
 Xk
 Xk
@@ -52712,13 +53403,13 @@ gC
 hf
 aO
 ib
-iM
-iM
+SD
+NF
 kp
 lc
 lK
 mQ
-iM
+SD
 Xk
 Pp
 qI
@@ -52914,13 +53605,13 @@ gD
 hg
 aO
 ib
-iM
-jw
+SD
+Jv
 kq
 ld
 lL
 mR
-Ta
+SD
 Xk
 Pp
 qJ
@@ -53116,13 +53807,13 @@ gE
 hh
 aO
 ic
-iM
+SD
 Qx
 kr
 le
 lM
 mS
-Te
+SD
 Xk
 Pp
 qK
@@ -53318,13 +54009,13 @@ gF
 hi
 hH
 id
-iM
-iM
+SD
+LY
 ks
 lf
 lN
 mT
-iM
+SD
 Xk
 pG
 qL
@@ -53520,13 +54211,13 @@ aq
 aq
 aq
 ib
-iM
-iM
-iM
-iM
-iM
+SD
+SD
+SD
+SD
+SD
 mU
-iM
+SD
 Xk
 RU
 qM
@@ -53927,11 +54618,11 @@ ie
 IN
 jy
 kv
-Wo
-Wo
-mW
-Wo
-Wo
+IN
+IN
+IN
+WD
+IN
 Ox
 Tz
 rO
@@ -54133,7 +54824,7 @@ Wo
 lQ
 mX
 nP
-Wo
+IN
 UM
 KI
 Zv
@@ -54335,7 +55026,7 @@ Wo
 Mg
 Mj
 LF
-Wo
+IN
 Zd
 YN
 rO
@@ -54530,16 +55221,16 @@ aq
 aq
 hL
 if
-iL
+NB
 jB
 kx
-aq
-aq
-aq
+Wo
+Sa
+Wo
 mY
 mY
+Vv
 mY
-Pg
 mY
 mY
 mY
@@ -54734,10 +55425,10 @@ hM
 ig
 aq
 aq
-hL
+WQ
 iL
-if
-iL
+XA
+JS
 nQ
 oL
 pH

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -20309,8 +20309,8 @@
 	pixel_x = 22
 	},
 /obj/machinery/computer/merch{
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
@@ -28464,7 +28464,6 @@
 	name = "Holodeck"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/civilian/holodeck)
 "cZy" = (
@@ -28591,8 +28590,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "dKO" = (
+/obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/vending/dinnerware,
+/obj/machinery/smartfridge/foods,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "dOK" = (
@@ -28694,6 +28694,7 @@
 "elg" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/light,
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "emJ" = (
@@ -31905,6 +31906,7 @@
 	name = "Kitchen";
 	req_access = list("ACCESS_KITCHEN")
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "xQE" = (
@@ -31914,6 +31916,7 @@
 	id = "kitchenholodeck";
 	name = "kitchen shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "xQT" = (
@@ -57097,9 +57100,9 @@ aoD
 apR
 are
 asl
-atH
-auM
+atC
 dKO
+axo
 axo
 elg
 auM
@@ -57299,7 +57302,7 @@ aoE
 apS
 arf
 oax
-atC
+atH
 auM
 avY
 axl

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -430,6 +430,7 @@
 /area/medical/treatment)
 "abj" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/full,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/surgery)
 "abk" = (
@@ -1562,6 +1563,7 @@
 	req_access = list("ACCESS_SURGERY")
 	},
 /obj/machinery/holosign/surgery,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "adF" = (
@@ -1834,6 +1836,7 @@
 /area/medical/treatment)
 "aeg" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/full,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/ward)
 "aeh" = (
@@ -1935,6 +1938,11 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
@@ -3044,6 +3052,7 @@
 	name = "Brig Lockdown";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/brig)
 "agf" = (
@@ -3179,23 +3188,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
-"agr" = (
-/obj/random/trash,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/third_deck/fp)
 "ags" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -3207,6 +3200,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
@@ -3306,10 +3304,6 @@
 /obj/machinery/smartfridge/secure/medbay,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
-/area/medical/treatment)
-"agC" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
 /area/medical/treatment)
 "agD" = (
 /obj/structure/cable{
@@ -3421,6 +3415,7 @@
 	name = "Interrogation Room";
 	req_access = list("ACCESS_SECURITY")
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/interrogation)
 "agO" = (
@@ -3439,6 +3434,13 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
 	req_access = list("ACCESS_SECURITY")
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/security/office)
@@ -3470,6 +3472,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/black/full,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
 "agX" = (
@@ -3480,6 +3483,7 @@
 	},
 /obj/effect/floor_decal/corner/black/full,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
 "agY" = (
@@ -3488,6 +3492,7 @@
 	req_access = list("ACCESS_ARMORY")
 	},
 /obj/effect/floor_decal/corner/black/full,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
 "agZ" = (
@@ -3509,21 +3514,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/third_deck/fp)
-"ahc" = (
-/obj/machinery/light/small/red,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
 "ahd" = (
@@ -3538,6 +3528,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/security/portgun)
 "ahf" = (
@@ -4147,6 +4143,9 @@
 /obj/machinery/camera/network/security{
 	c_tag = "Brig Hall Aft"
 	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
 "ahY" = (
@@ -4238,6 +4237,13 @@
 	dir = 1;
 	icon_state = "bordercolor";
 	tag = "icon-bordercolor (NORTH)"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -4345,19 +4351,6 @@
 /obj/item/device/analyzer,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
-"aiq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bridge Maintenance";
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_GUNNERY"))
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/hallway/commandport)
 "air" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
@@ -4377,6 +4370,12 @@
 	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
 "ait" = (
@@ -5244,6 +5243,13 @@
 	icon_state = "2-8";
 	tag = ""
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "ajG" = (
@@ -5381,6 +5387,7 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/black/border,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
 "ajN" = (
@@ -5469,12 +5476,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
 "ajR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1;
 	icon_state = "borderfloor_white"
@@ -5541,6 +5542,7 @@
 	icon_state = "corner_white";
 	tag = "icon-corner_white (NORTHEAST)"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
 "ajW" = (
@@ -5554,6 +5556,12 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
 "ajX" = (
@@ -5731,18 +5739,6 @@
 /obj/effect/paint_stripe/paleblue,
 /turf/simulated/wall/prepainted,
 /area/medical/lobby)
-"akt" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "infirmaryquar";
-	name = "Infirmary Emergency Quarantine Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/medical/lobby)
 "aku" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/blast/shutters{
@@ -5908,6 +5904,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/checkpoint)
 "akP" = (
@@ -6058,12 +6055,6 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -6128,6 +6119,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
 "alh" = (
@@ -6154,6 +6146,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/portgun)
@@ -6755,6 +6753,7 @@
 	pixel_x = 0;
 	tag = ""
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/freezer,
 /area/security/evidence)
 "amf" = (
@@ -7108,6 +7107,7 @@
 /area/medical/lobby)
 "amO" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/full,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/lobby)
 "amP" = (
@@ -7204,10 +7204,6 @@
 /obj/random/medical/lite,
 /turf/simulated/floor/tiled/white,
 /area/medical/storage)
-"amX" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/chemistry)
 "amY" = (
 /obj/structure/table/standard,
 /obj/machinery/reagentgrinder,
@@ -7461,14 +7457,19 @@
 "anx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "any" = (
@@ -7476,10 +7477,22 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "anz" = (
-/turf/simulated/floor/plating,
+/obj/structure/lattice,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "32-8"
+	},
+/turf/simulated/open,
 /area/hallway/commandport)
 "anA" = (
 /obj/machinery/light/small{
@@ -7890,6 +7903,10 @@
 	icon_state = "2-4"
 	},
 /obj/item/device/radio/beacon,
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 3 Port Central");
+	location = "Medbay"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/lobby)
 "aoi" = (
@@ -8205,24 +8222,12 @@
 	frequency = 1439;
 	id_tag = null
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
 "aoS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/machinery/door/airlock/command{
 	name = "Boarding Armoury";
 	req_access = list("ACCESS_FIRST_OFFICER")
@@ -8230,6 +8235,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
 "aoT" = (
@@ -8237,11 +8243,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
 	icon_state = "map-scrubbers"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9683,6 +9684,7 @@
 /area/maintenance/third_deck/centp)
 "arb" = (
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/entrance)
 "arc" = (
@@ -9781,6 +9783,7 @@
 	},
 /obj/effect/floor_decal/corner/red/full,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "ari" = (
@@ -9789,6 +9792,7 @@
 	id = "boarding_armory";
 	name = "Boarding Armory Blast Door"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/boardarmoury)
 "arj" = (
@@ -9930,6 +9934,7 @@
 	layer = 3.3;
 	name = "Engine Waste Handling Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "arv" = (
@@ -10716,12 +10721,13 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
-	},
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Fore Hallway - Aft Port"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -10760,9 +10766,6 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers";
@@ -10771,13 +10774,15 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2";
-	tag = "icon-pipe-j2 (WEST)"
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -11191,12 +11196,6 @@
 	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -11228,12 +11227,6 @@
 	tag = "icon-pdoor1"
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11250,12 +11243,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 9;
@@ -11275,12 +11262,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
@@ -11297,17 +11278,13 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/catwalk_plated/dark,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "asF" = (
@@ -11358,12 +11335,13 @@
 	dir = 1;
 	icon_state = "corner_white_three_quarters"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/machinery/camera/xray/command{
 	c_tag = "Bridge Port"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -11670,6 +11648,10 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/lightgrey,
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Medbay");
+	location = "Deck 3 Aft Port"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "atk" = (
@@ -11871,15 +11853,6 @@
 	dir = 1;
 	icon_state = "map_vent_out"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/third_deck)
-"atE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/third_deck)
-"atF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "atG" = (
@@ -12269,6 +12242,7 @@
 	layer = 3.3;
 	name = "Engine Waste Handling Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "aul" = (
@@ -12380,6 +12354,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/lobby)
 "aut" = (
@@ -12440,6 +12415,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/lobby)
 "auw" = (
@@ -12538,37 +12514,12 @@
 /area/hallway/central/third_deck)
 "auG" = (
 /turf/simulated/wall/prepainted,
-/area/civilian/messhall)
+/area/hallway/central/third_deck)
 "auH" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/civilian/messhall)
-"auI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/civilian{
-	name = "\improper Cafeteria"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"auJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"auK" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/multi_tile/glass/civilian{
-	name = "\improper Cafeteria"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"auL" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
+/area/hallway/fore/third_deck)
 "auM" = (
 /obj/effect/paint_stripe/white,
 /turf/simulated/wall/prepainted,
@@ -12617,6 +12568,7 @@
 	name = "black curtain"
 	},
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/civilian/bar)
 "auR" = (
@@ -13136,138 +13088,34 @@
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
 "avO" = (
-/obj/machinery/vending/coffee,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"avP" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/vending/whitedragon,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
+/turf/simulated/floor/holofloor/reinforced,
+/area/holodeck)
 "avQ" = (
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"avR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"avS" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Mess Hall Port"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"avT" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/corner/white/three_quarters{
 	dir = 1;
-	icon_state = "pipe-c"
+	icon_state = "corner_white_three_quarters";
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
-/obj/effect/floor_decal/corner/beige/diagonal{
+/obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"avU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"avV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"avW" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"avX" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/civilian/holodeck)
+"avW" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/button/remote/blast_door{
+	id = "kitchen";
+	name = "Kitchen Shutters Control";
+	pixel_x = -5;
+	pixel_y = 26;
+	req_access = list("ACCESS_KITCHEN");
+	tag = "icon-blastctrl (EAST)"
 	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "avY" = (
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/bar_soft/full,
@@ -13315,7 +13163,7 @@
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Kitchen Backroom"
 	},
-/obj/machinery/cooker/oven,
+/obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "awc" = (
@@ -13330,6 +13178,13 @@
 	dir = 1;
 	icon_state = "tube_map";
 	tag = "icon-tube_map (NORTH)"
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 2;
+	listening = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 28
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
@@ -13838,75 +13693,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
-"axe" = (
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4;
-	icon_state = "map_scrubber_on"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"axf" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	icon_state = "map-scrubbers"
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"axg" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"axh" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"axi" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"axj" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
 "axk" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/door/firedoor,
@@ -14455,128 +14241,32 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/central/third_deck)
-"ayl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aym" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
 	dir = 8;
-	icon_state = "closed";
-	name = "\improper Cafeteria";
+	name = "\improper Holodeck";
 	tag = "icon-closed (WEST)"
 	},
 /turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"ayn" = (
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"ayo" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
+/area/hallway/central/third_deck)
 "ayp" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/civilian/holodeck)
 "ayq" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"ayr" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"ays" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/cooker/oven,
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "ayt" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/cooker/fryer,
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "ayu" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/hygiene/sink{
@@ -14613,15 +14303,14 @@
 	c_tag = "Bar";
 	dir = 4
 	},
-/obj/structure/hygiene/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -11;
-	tag = "icon-sink (WEST)"
-	},
 /obj/machinery/button/remote/curtains{
 	id = "barcurtains";
 	pixel_x = -26
+	},
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/bar_alc/full{
+	dir = 4;
+	icon_state = "booze_dispenser"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
@@ -14660,11 +14349,9 @@
 	id_tag = null
 	},
 /obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/wood/walnut,
-/area/civilian/bar)
-"ayE" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/material/ashtray/bronze,
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
 "ayF" = (
@@ -14744,9 +14431,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
 "ayM" = (
-/obj/machinery/computer/combatcomputer/nerva{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -14760,6 +14444,11 @@
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 6;
 	icon_state = "corner_white"
+	},
+/obj/item/modular_computer/console/preset/nervacommand{
+	dir = 8;
+	icon_state = "console";
+	tag = "icon-console (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
@@ -14819,7 +14508,7 @@
 "ayU" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
 	dir = 8;
-	icon_state = "map_on";
+	max_pressure_setting = 35000;
 	tag = "icon-map_on (WEST)"
 	},
 /turf/simulated/floor/plating,
@@ -14932,10 +14621,6 @@
 "aze" = (
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
-"azf" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/civilian/cryo1)
 "azg" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 9;
@@ -15009,6 +14694,10 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Security");
+	location = "Hydroponics"
+	},
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
 "azm" = (
@@ -15057,6 +14746,16 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "azp" = (
@@ -15065,73 +14764,20 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
-"azq" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"azr" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"azs" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
 "azv" = (
 /obj/machinery/light_switch{
 	pixel_x = -22
 	},
 /obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/bar_alc/full{
+/obj/machinery/chemical_dispenser/bar_soft/full{
 	dir = 4;
-	icon_state = "booze_dispenser"
+	icon_state = "soda_dispenser"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
@@ -15139,6 +14785,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Bridge Starboard");
+	location = "Bar"
+	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
 "azx" = (
@@ -15210,10 +14860,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/item/modular_computer/console/preset/nervacommand{
-	dir = 8;
-	icon_state = "console";
-	tag = "icon-console (WEST)"
+/obj/machinery/computer/ship/navigation{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
@@ -15273,6 +14921,7 @@
 	name = "Reactor Blast Door";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/engine)
 "azJ" = (
@@ -15287,6 +14936,7 @@
 	name = "Reactor Blast Door";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/engine)
 "azK" = (
@@ -15664,27 +15314,22 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
-"aAk" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/door/blast/shutters{
-	density = 1;
-	dir = 4;
-	icon_state = "shutter1";
-	id = "kitchen";
-	name = "kitchen shutters";
-	opacity = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
-/area/civilian/kitchen)
 "aAl" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
 	layer = 2.4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
@@ -15722,20 +15367,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
-"aAp" = (
-/obj/structure/table/standard,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	icon_state = "intercom";
-	pixel_x = -28;
-	tag = "icon-intercom (EAST)"
-	},
-/obj/machinery/chemical_dispenser/bar_soft/full{
-	dir = 4;
-	icon_state = "soda_dispenser"
-	},
-/turf/simulated/floor/wood/walnut,
-/area/civilian/bar)
 "aAq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -15820,9 +15451,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
 "aAA" = (
-/obj/machinery/computer/ship/navigation{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -15838,6 +15466,11 @@
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 6;
 	icon_state = "corner_white"
+	},
+/obj/item/modular_computer/console/preset/nervacommand{
+	dir = 8;
+	icon_state = "console";
+	tag = "icon-console (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
@@ -15863,6 +15496,12 @@
 	c_tag = "Supermatter Exterior";
 	dir = 8;
 	icon_state = "camera"
+	},
+/obj/structure/sign/warning/secure_area{
+	desc = "A warning sign which reads 'EJECTION/VENTING PORT'.";
+	name = "\improper EJECTION/VENTING PORT";
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -15913,6 +15552,7 @@
 	dir = 4;
 	level = 2
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aAJ" = (
@@ -16237,6 +15877,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aBq" = (
@@ -16245,16 +15890,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
-"aBr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass/civilian{
-	dir = 8;
-	icon_state = "closed";
-	name = "\improper Cafeteria";
-	tag = "icon-closed (WEST)"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
 "aBs" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/cable{
@@ -16267,20 +15902,6 @@
 	name = "Cook"
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/civilian/kitchen)
-"aBt" = (
-/obj/machinery/door/blast/shutters{
-	density = 1;
-	dir = 4;
-	icon_state = "shutter1";
-	id = "kitchen";
-	name = "kitchen shutters";
-	opacity = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "aBu" = (
@@ -16341,11 +15962,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
 "aBB" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 4;
 	icon_state = "corner_white"
@@ -16353,6 +15969,13 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 1;
 	icon_state = "corner_white"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Bridge";
+	departmentType = 5;
+	name = "Bridge RC";
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -16393,10 +16016,8 @@
 "aBF" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
-	icon_state = "pdoor1";
 	id = "Engine Vent Control";
-	name = "Supply Shuttle";
-	p_open = 0
+	name = "Core Emergency Vent"
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/reinforced/airless,
@@ -16442,6 +16063,7 @@
 	name = "Reactor Blast Door";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aBK" = (
@@ -16859,71 +16481,42 @@
 	pixel_x = -26
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
-"aCr" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
 "aCs" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/beige/diagonal{
+/obj/effect/floor_decal/corner/white/three_quarters,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
+	icon_state = "map_scrubber_on"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"aCt" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Mess Hall Starboard";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
-"aCu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
+/turf/simulated/floor/tiled/techmaint,
+/area/civilian/holodeck)
 "aCv" = (
-/obj/effect/floor_decal/corner/beige/diagonal{
+/obj/effect/floor_decal/corner/white/three_quarters{
 	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
+	icon_state = "corner_white_three_quarters";
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-05";
-	tag = "icon-plant-05"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	icon_state = "intercom";
-	pixel_x = 28;
-	tag = "icon-intercom (WEST)"
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/civilian/holodeck)
 "aCw" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 1;
@@ -16938,20 +16531,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/spagetti,
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough,
 /obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	icon_state = "blastctrl";
-	id = "kitchen";
-	name = "Kitchen Shutters Control";
-	pixel_x = -22;
-	pixel_y = -5;
-	req_access = list("ACCESS_KITCHEN");
-	tag = "icon-blastctrl (EAST)"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 4
-	},
 /obj/item/device/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
@@ -17153,6 +16732,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aCS" = (
@@ -17343,6 +16923,11 @@
 	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aDf" = (
@@ -17353,14 +16938,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
-"aDg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/multi_tile/glass/civilian{
-	name = "\improper Cafeteria"
-	},
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
 "aDh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17719,6 +17296,10 @@
 	name = "Disposals";
 	sortType = "Disposals"
 	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 2 Aft Port");
+	location = "Deck 3 Aft Starboard"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "aDJ" = (
@@ -17914,6 +17495,11 @@
 	tag = "icon-corner_white (NORTH)"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aDZ" = (
@@ -17926,10 +17512,6 @@
 /area/hallway/fore/third_deck)
 "aEb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/hallway/fore/third_deck)
-"aEc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aEd" = (
@@ -18190,6 +17772,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aED" = (
@@ -18488,6 +18071,15 @@
 	name = "\improper Central Access";
 	tag = "icon-closed (WEST)"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "aFc" = (
@@ -18497,6 +18089,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -18510,6 +18111,15 @@
 	name = "Deck 3 Hallway";
 	sortType = "Deck 3 Hallway"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aFe" = (
@@ -18522,14 +18132,8 @@
 	name = "Robotics";
 	sortType = "Robotics"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aFf" = (
@@ -18657,6 +18261,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aFm" = (
@@ -18670,6 +18279,12 @@
 	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/effect/floor_decal/corner/purple,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aFn" = (
@@ -18693,6 +18308,12 @@
 	name = "\improper Central Access";
 	tag = "icon-closed (WEST)"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aFo" = (
@@ -18708,6 +18329,12 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFp" = (
@@ -18723,6 +18350,12 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 10;
 	icon_state = "corner_white"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -18742,22 +18375,19 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/light,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/effect/floor_decal/corner/purple{
-	dir = 10;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/fore/third_deck)
-"aFs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/floor_decal/corner/purple{
 	dir = 10;
 	icon_state = "corner_white"
@@ -18767,16 +18397,50 @@
 	icon_state = "intact-scrubbers";
 	tag = "icon-intact-scrubbers (EAST)"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
+"aFs" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFt" = (
 /obj/effect/floor_decal/borderfloor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10;
-	icon_state = "intact-supply"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -18795,6 +18459,21 @@
 	tag = "icon-corner_white (WEST)"
 	},
 /obj/effect/floor_decal/corner/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFw" = (
@@ -18985,6 +18664,10 @@
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
 	dir = 4;
 	icon_state = "corner_white_three_quarters"
+	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Personnel");
+	location = "Bridge Starboard"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/commandstarboard)
@@ -19292,6 +18975,7 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/civilian/janitor)
 "aGp" = (
@@ -19315,28 +18999,34 @@
 /turf/simulated/wall/prepainted,
 /area/logistics/mailing)
 "aGr" = (
-/obj/machinery/door/airlock/glass/mining{
-	name = "Delivery Office";
-	req_access = list("ACCESS_SORTING")
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/beige/full,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "deliveryentry";
+	name = "Delivery Office Entry Shutter";
+	opacity = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aGs" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/logistics/mailing)
-"aGt" = (
+/obj/effect/floor_decal/corner/beige/full,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_access = list("ACCESS_SORTING")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "deliveryentry";
+	name = "Delivery Office Entry Shutter";
+	opacity = 0
 	},
-/obj/machinery/door/window/northleft,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aGu" = (
 /turf/simulated/wall/prepainted,
@@ -19350,6 +19040,7 @@
 	tag = "icon-shutter1"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mechbay)
 "aGw" = (
@@ -19377,13 +19068,6 @@
 /area/hallway/central/third_deck)
 "aGz" = (
 /turf/simulated/wall/prepainted,
-/area/rnd/office)
-"aGA" = (
-/obj/machinery/door/airlock/glass/research{
-	name = "NanoTrasen Office";
-	req_access = list("ACCESS_XENOBIO")
-	},
-/turf/simulated/floor/wood/walnut,
 /area/rnd/office)
 "aGB" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -19435,6 +19119,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/command/eva)
 "aGG" = (
@@ -19445,6 +19130,7 @@
 	name = "EVA Access Shutters";
 	tag = "icon-shutter1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
 "aGH" = (
@@ -19471,6 +19157,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/command/eva)
 "aGJ" = (
@@ -19845,10 +19532,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
 "aHq" = (
@@ -19858,52 +19542,26 @@
 /turf/simulated/wall/prepainted,
 /area/logistics/mailing)
 "aHr" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
+/obj/effect/floor_decal/corner/beige/three_quarters{
 	dir = 8
 	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "packageSort1"
+/obj/structure/bed/chair{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/logistics/mailing)
-"aHs" = (
-/obj/effect/floor_decal/corner/beige/three_quarters{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aHt" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
-"aHu" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 5
-	},
-/obj/effect/landmark/start{
-	name = "Supply Technician"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aHv" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/effect/floor_decal/corner/beige/three_quarters{
 	dir = 1
 	},
@@ -19970,7 +19628,6 @@
 	pixel_y = 26;
 	req_access = list("ACCESS_ROBOTICS")
 	},
-/obj/item/weapon/FixOVein,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
 "aHB" = (
@@ -20097,6 +19754,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	icon_state = "intact-supply"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
@@ -20590,18 +20253,6 @@
 /obj/item/weapon/storage/box/cleangrenades,
 /turf/simulated/floor/plating,
 /area/civilian/janitor)
-"aIF" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/third_deck/afs)
 "aIG" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -20610,28 +20261,15 @@
 /turf/simulated/floor/plating,
 /area/logistics/mailing)
 "aIH" = (
-/obj/item/weapon/stool/padded,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/corner/orange{
-	dir = 6;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (SOUTHEAST)"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aII" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 9;
-	icon_state = "corner_white"
-	},
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	pixel_x = -30;
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
@@ -20639,15 +20277,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aIK" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/box,
 /obj/effect/floor_decal/corner/beige{
 	dir = 6;
 	icon_state = "corner_white";
 	tag = "icon-corner_white (SOUTHEAST)"
 	},
-/obj/item/weapon/storage/box,
-/obj/item/weapon/storage/box,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
@@ -20919,6 +20553,10 @@
 	dir = 8;
 	icon_state = "bordercolor"
 	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "EVA");
+	location = "Personnel"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aJp" = (
@@ -21180,40 +20818,26 @@
 /turf/simulated/floor/plating,
 /area/civilian/janitor)
 "aJM" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "packageSort1"
+/obj/effect/floor_decal/corner/beige/three_quarters,
+/obj/structure/bed/chair{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/turf/simulated/floor/plating,
-/area/logistics/mailing)
-"aJN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/orange{
-	dir = 6;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (SOUTHEAST)"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
-"aJO" = (
+"aJN" = (
 /obj/effect/floor_decal/corner/beige{
-	dir = 9;
+	dir = 10;
 	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
-"aJP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
-	icon_state = "intact-scrubbers"
-	},
-/obj/machinery/hologram/holopad,
+"aJO" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aJQ" = (
@@ -21223,25 +20847,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aJR" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/package_wrap/twenty_five,
-/obj/item/stack/package_wrap/twenty_five,
-/obj/item/stack/package_wrap/twenty_five,
-/obj/item/stack/package_wrap/twenty_five,
-/obj/item/stack/package_wrap/twenty_five,
-/obj/effect/floor_decal/corner/beige{
-	dir = 6;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (SOUTHEAST)"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/cargo{
-	c_tag = "Mailing Office Main";
-	dir = 8;
-	icon_state = "camera"
+/obj/effect/floor_decal/corner/beige/three_quarters{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
@@ -21875,6 +21482,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
 "aKT" = (
@@ -21890,33 +21501,26 @@
 /turf/simulated/floor/plating,
 /area/logistics/mailing)
 "aKU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/effect/landmark/start{
+	name = "Supply Technician"
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aKV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
-"aKW" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/stamp/cargo,
+/obj/item/weapon/stamp/denied,
 /obj/effect/floor_decal/corner/beige{
-	dir = 6;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (SOUTHEAST)"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
-"aKX" = (
-/obj/machinery/door/airlock/research{
-	name = "Robotics";
-	req_access = list("ACCESS_ROBOTICS")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mechbay)
 "aKY" = (
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor/tiled/steel_grid,
@@ -22533,84 +22137,42 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
 "aLZ" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 9;
+	icon_state = "corner_white"
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/orange{
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
+"aMb" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
+"aMc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
+"aMd" = (
+/obj/effect/floor_decal/corner/beige{
 	dir = 6;
 	icon_state = "corner_white";
 	tag = "icon-corner_white (SOUTHEAST)"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor_switch{
-	id = "packageSort1"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
-"aMa" = (
-/obj/effect/floor_decal/corner/beige/three_quarters,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/high;
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
-"aMb" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 10;
-	icon_state = "corner_white"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
-"aMc" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 10;
-	icon_state = "corner_white"
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/effect/landmark/start{
-	name = "Supply Technician"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
-"aMd" = (
 /obj/structure/table/reinforced,
-/obj/item/device/destTagger{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/item/stack/package_wrap/twenty_five,
+/obj/item/stack/package_wrap/twenty_five,
+/obj/item/stack/package_wrap/twenty_five,
+/obj/item/stack/package_wrap/twenty_five,
+/obj/item/stack/package_wrap/twenty_five,
+/obj/machinery/button/remote/blast_door{
+	id = "deliveryentry";
+	name = "Delivery Office Entry Shutters";
+	pixel_x = 32;
+	req_access = list("ACCESS_SORTING")
 	},
-/obj/item/device/destTagger{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/effect/floor_decal/corner/beige/three_quarters{
-	dir = 4
-	},
-/obj/item/weapon/tape_roll,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aMe" = (
@@ -23101,6 +22663,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/starboardgun)
 "aMN" = (
@@ -23121,6 +22684,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/security/starboardgun)
@@ -23219,6 +22788,7 @@
 	dir = 4
 	},
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aMY" = (
@@ -23311,6 +22881,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/smmon)
 "aNg" = (
@@ -23421,8 +22992,8 @@
 /turf/simulated/floor/tiled/white/server,
 /area/engineering/tcomms)
 "aNm" = (
-/obj/machinery/telecomms/processor/preset_wyrm,
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/telecomms/processor/preset_nerva,
 /turf/simulated/floor/tiled/white/server,
 /area/engineering/tcomms)
 "aNn" = (
@@ -23431,8 +23002,8 @@
 /turf/simulated/floor/tiled/white/server,
 /area/engineering/tcomms)
 "aNo" = (
-/obj/machinery/telecomms/server/presets/wyrm,
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/telecomms/server/presets/nerva,
 /turf/simulated/floor/tiled/white/server,
 /area/engineering/tcomms)
 "aNp" = (
@@ -23467,24 +23038,16 @@
 /turf/simulated/floor/plating,
 /area/logistics/mailing)
 "aNs" = (
-/turf/simulated/wall/prepainted,
-/area/logistics/lockers)
-"aNt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Lockers";
-	req_access = list("ACCESS_CARGO")
+/obj/machinery/conveyor_switch{
+	id = "packageSort1"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/effect/floor_decal/corner/beige/three_quarters,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/beige/full,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "aNu" = (
 /obj/machinery/door/blast/shutters/open{
 	dir = 2;
@@ -23531,6 +23094,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
 "aNx" = (
@@ -23682,12 +23246,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -23707,12 +23265,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -23729,12 +23281,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -23745,17 +23291,17 @@
 "aNK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	icon_state = "pipe-j2s";
 	name = "Chief of Security";
 	sortType = "Chief of Security"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/commandoffices)
@@ -24125,11 +23671,6 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -24193,6 +23734,7 @@
 	dir = 10;
 	icon_state = "corner_white"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/starboardgun)
 "aOf" = (
@@ -24202,6 +23744,11 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/security/starboardgun)
 "aOg" = (
@@ -24238,6 +23785,7 @@
 	icon_state = "intact"
 	},
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aOl" = (
@@ -24416,30 +23964,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
 "aOA" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light_switch{
-	pixel_x = -22
+/obj/effect/floor_decal/corner/beige{
+	dir = 9;
+	icon_state = "corner_white"
 	},
-/obj/effect/floor_decal/corner/beige/three_quarters{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
-"aOB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 5;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "aOE" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/corner/beige/three_quarters{
@@ -24806,19 +24339,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bodyguard)
-"aPm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Bridge Maintenance";
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_GUNNERY"))
-	},
-/turf/simulated/floor/plating,
-/area/hallway/commandstarboard)
 "aPn" = (
 /obj/machinery/light{
 	dir = 8
@@ -24829,6 +24349,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/security/starboardgun)
 "aPo" = (
@@ -24988,7 +24513,8 @@
 /area/engineering/smmon)
 "aPE" = (
 /obj/machinery/computer/telecomms/monitor{
-	dir = 4
+	dir = 4;
+	network = "tcommsat"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -25096,56 +24622,50 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
 "aPN" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 9;
 	icon_state = "corner_white"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4;
+	icon_state = "map_scrubber_on"
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	icon_state = "intercom";
+	pixel_x = -23;
+	tag = "icon-intercom (EAST)"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "aPO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
+"aPP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
-"aPP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "aPQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -25167,7 +24687,7 @@
 	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "aPR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -25188,8 +24708,9 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/beige/full,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "aPS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -25699,15 +25220,9 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
@@ -25744,6 +25259,11 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Bridge Maintenance";
 	req_access = list(list("ACCESS_BRIDGE","ACCESS_GUNNERY"))
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/security/starboardgun)
@@ -25813,7 +25333,8 @@
 /area/engineering/smmon)
 "aQN" = (
 /obj/machinery/computer/telecomms/server{
-	dir = 4
+	dir = 4;
+	network = "tcommsat"
 	},
 /obj/machinery/camera/motion/command{
 	c_tag = "Telecommunications Monitoring";
@@ -26105,6 +25626,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Mailing Office");
+	location = "Deck 3 Cargo"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "aRo" = (
@@ -26335,19 +25860,14 @@
 "aRL" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aRM" = (
 /obj/machinery/light/small/red,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aRN" = (
@@ -26731,6 +26251,12 @@
 	dir = 9;
 	icon_state = "intact-supply"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
 "aSv" = (
@@ -26745,6 +26271,12 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
 /area/command/eva)
 "aSw" = (
@@ -26757,6 +26289,12 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
 /area/command/eva)
 "aSx" = (
@@ -26765,11 +26303,23 @@
 	dir = 10;
 	icon_state = "intact-supply"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
 /area/command/eva)
 "aSy" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list("ACCESS_MAINT")
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/command/eva)
@@ -26969,6 +26519,12 @@
 /area/command/bodyguard)
 "aSO" = (
 /obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aSP" = (
@@ -27415,8 +26971,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
 "aTL" = (
-/obj/machinery/telecomms/receiver/preset_wyrm,
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/telecomms/receiver/preset_nerva,
 /turf/simulated/floor/tiled/white/server,
 /area/engineering/tcomms)
 "aTM" = (
@@ -27425,8 +26981,8 @@
 /turf/simulated/floor/tiled/white/server,
 /area/engineering/tcomms)
 "aTN" = (
-/obj/machinery/telecomms/broadcaster/preset_wyrm,
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/telecomms/broadcaster/preset_nerva,
 /turf/simulated/floor/tiled/white/server,
 /area/engineering/tcomms)
 "aTP" = (
@@ -27748,11 +27304,23 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aUs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
@@ -27760,6 +27328,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
@@ -28173,10 +27747,21 @@
 	icon_state = "cobweb1";
 	tag = "icon-cobweb1 (EAST)"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aVi" = (
 /obj/random/trash,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aVj" = (
@@ -28639,6 +28224,17 @@
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/commandstarboard)
+"bdp" = (
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id = "kitchenbar";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/green/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "bpF" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
@@ -28646,6 +28242,9 @@
 /obj/effect/paint_stripe/mauve,
 /turf/simulated/wall/prepainted,
 /area/rnd/dorms)
+"brf" = (
+/turf/simulated/wall/prepainted,
+/area/civilian/holodeck)
 "btX" = (
 /obj/structure/lattice,
 /turf/simulated/open{
@@ -28693,6 +28292,21 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/evidence)
+"bOq" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/logistics/mailing)
 "bXZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28714,6 +28328,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
+"bZk" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker,
+/turf/simulated/floor/wood/walnut,
+/area/civilian/bar)
 "csj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -28726,23 +28345,22 @@
 /turf/simulated/floor/wood/walnut,
 /area/civilian/abandonedoffice)
 "cwk" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/weapon/storage/backpack/duffel/duffel_norm,
-/obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
-/obj/machinery/light,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10;
 	icon_state = "corner_white"
 	},
-/obj/item/clothing/accessory/armband/cargo,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/high;
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/obj/structure/table/rack,
+/obj/item/stack/material/cardboard/ten,
+/obj/item/stack/material/cardboard/ten,
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "cwN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -28833,6 +28451,14 @@
 /obj/effect/paint_stripe/green,
 /turf/simulated/wall/prepainted,
 /area/hallway/aft/third_deck)
+"cXI" = (
+/obj/machinery/door/airlock/glass{
+	name = "Holodeck"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techmaint,
+/area/civilian/holodeck)
 "cZy" = (
 /obj/effect/floor_decal/corner/red/full,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28869,6 +28495,7 @@
 	icon_state = "0-2";
 	pixel_y = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/checkpoint)
 "dkt" = (
@@ -28921,6 +28548,7 @@
 	name = "Brig Lockdown";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "dAL" = (
@@ -28944,17 +28572,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/starboardexternalgun)
 "dFj" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/weapon/storage/backpack/duffel/duffel_norm,
-/obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
 /obj/effect/floor_decal/corner/beige/three_quarters,
-/obj/item/clothing/accessory/armband/cargo,
+/obj/structure/table/rack,
+/obj/item/stack/material/cardboard/ten,
+/obj/item/stack/material/cardboard/ten,
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
+"dKO" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/vending/dinnerware,
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "dOK" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -29051,6 +28683,11 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/rnd/office)
+"elg" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "emJ" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
@@ -29126,6 +28763,19 @@
 /obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
+"erq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/red{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Bridge Port");
+	location = "Security"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/security/entrance)
 "esi" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8;
@@ -29150,6 +28800,11 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
 "eyp" = (
@@ -29157,6 +28812,7 @@
 	name = "Security Office";
 	req_access = list("ACCESS_SECURITY")
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "ezU" = (
@@ -29181,6 +28837,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
+"eEJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 3 Aft Starboard");
+	location = "Mailing Office"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (NORTHWEST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
 "eGp" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -29243,12 +28915,6 @@
 	dir = 1;
 	icon_state = "map-supply"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
@@ -29265,6 +28931,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/command/eva)
+"fnS" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
 "fqm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
@@ -29281,11 +28958,6 @@
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/junction{
@@ -29337,6 +29009,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/checkpoint)
 "fIt" = (
@@ -29373,6 +29046,16 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
+"fJz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fp)
 "fKv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -29408,12 +29091,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
 	icon_state = "pipe-j1"
@@ -29433,6 +29110,14 @@
 /obj/effect/floor_decal/corner/fadeblue,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
+"fXe" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 9;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (NORTHWEST)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/civilian/holodeck)
 "fXH" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -29454,6 +29139,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/checkpoint)
 "grv" = (
@@ -29481,8 +29167,30 @@
 	name = "Brig Lockdown";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
+"gth" = (
+/obj/structure/table/reinforced,
+/obj/item/device/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/device/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/weapon/tape_roll,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 6;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (SOUTHEAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
 "gxQ" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
@@ -29498,32 +29206,58 @@
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "gVr" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 6;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (SOUTHEAST)"
+/obj/machinery/camera/network/cargo{
+	c_tag = "Mailing Office Main";
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Orders";
+	departmentType = 2;
+	name = "Cargo RC";
+	pixel_x = 30;
+	pixel_y = 30
 	},
 /obj/structure/table/reinforced,
-/obj/item/weapon/stamp/cargo,
-/obj/item/weapon/stamp/denied,
+/obj/effect/floor_decal/corner/beige/three_quarters{
+	dir = 1
+	},
+/obj/item/weapon/storage/box,
+/obj/item/weapon/storage/box,
+/obj/item/weapon/storage/box,
+/obj/item/weapon/storage/box,
+/obj/item/weapon/storage/box,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "gZW" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/item/weapon/storage/backpack/duffel/duffel_eng,
-/obj/item/clothing/suit/storage/hooded/wintercoat/miner,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/obj/item/weapon/mining_scanner,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
+"hdh" = (
 /obj/effect/floor_decal/corner/beige{
-	dir = 5;
+	dir = 9;
 	icon_state = "corner_white"
 	},
-/obj/item/clothing/accessory/armband/cargo,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
+"hmt" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Supply Technician"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
 "hpL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -29538,16 +29272,14 @@
 	dir = 1;
 	icon_state = "corner_white_three_quarters"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
 	name = "Port Gun Bay";
 	sortType = "Port Gun Bay"
+	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Bar");
+	location = "Bridge Port"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/commandport)
@@ -29558,6 +29290,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
+"hCe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Hydroponics");
+	location = "Deck 3 Port Central"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/central/third_deck)
 "hCj" = (
 /obj/effect/paint_stripe/blue,
 /obj/structure/cable{
@@ -29568,6 +29324,25 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/bridge)
+"hEA" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fs)
+"hEU" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Kitchen";
+	departmentType = 2;
+	name = "Kitchen RC";
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "hFc" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
@@ -29604,6 +29379,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/third_deck/fp)
+"hZn" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/hallway/central/third_deck)
 "icd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -29632,6 +29412,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/centp)
+"ikq" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/civilian/holodeck)
 "iuc" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -29648,6 +29444,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
+"iBy" = (
+/obj/random/junk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fp)
 "iBE" = (
 /obj/machinery/door/airlock/command{
 	name = "Bridge";
@@ -29668,6 +29473,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
+"iCy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fp)
 "iFY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -29732,6 +29545,20 @@
 /obj/item/clothing/head/hardhat/red,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
+"jgk" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Holodeck"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/civilian/holodeck)
 "joO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29774,6 +29601,7 @@
 	name = "Brig Lockdown";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/brig)
 "jEQ" = (
@@ -29803,16 +29631,13 @@
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "jIp" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/weapon/storage/backpack/duffel/duffel_norm,
-/obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
 /obj/effect/floor_decal/corner/beige/three_quarters{
 	dir = 4
 	},
-/obj/item/clothing/accessory/armband/cargo,
+/obj/structure/closet/crate,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "jJa" = (
 /obj/machinery/door/window/brigdoor/southleft{
 	req_access = list("ACCESS_ROBOTICS")
@@ -29860,6 +29685,7 @@
 	name = "Boarding Armory Blast Door"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
 "jVX" = (
@@ -29873,8 +29699,21 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/plating,
 /area/security/portexternalgun)
+"jWR" = (
+/obj/structure/hygiene/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -11;
+	tag = "icon-sink (WEST)"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/bar)
 "kaf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -29927,12 +29766,53 @@
 	req_access = list("ACCESS_SECURITY")
 	},
 /obj/effect/floor_decal/corner/black/border,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
 "kjn" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/lockers)
+"kjK" = (
+/obj/effect/floor_decal/corner/black{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply";
+	tag = "icon-intact-supply (NORTHWEST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (NORTHWEST)"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
+"kjM" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/hallway/fore/third_deck)
+"koC" = (
+/obj/machinery/computer/HolodeckControl{
+	dir = 4;
+	linkedholodeck = /area/holodeck;
+	linkedholodeck_area = /area/holodeck;
+	programs_list_id = "NervaMainPrograms"
+	},
+/obj/effect/floor_decal/corner/white/three_quarters{
+	dir = 8;
+	icon_state = "corner_white_three_quarters";
+	tag = "icon-corner_white_three_quarters (WEST)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/civilian/holodeck)
 "krd" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -29995,6 +29875,7 @@
 "kBU" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/checkpoint)
 "kFS" = (
@@ -30104,6 +29985,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
+"lkz" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Bridge Maintenance";
+	req_access = list(list("ACCESS_BRIDGE","ACCESS_GUNNERY"))
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/hallway/commandport)
 "lmx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4;
@@ -30129,12 +30023,49 @@
 /obj/item/weapon/folder/white,
 /turf/simulated/floor/tiled/white,
 /area/medical/cmo)
+"ltj" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fs)
+"luj" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "kitchenbar";
+	name = "Kitchen Shutters Control";
+	pixel_x = 26;
+	pixel_y = 5;
+	req_access = list("ACCESS_KITCHEN");
+	tag = "icon-blastctrl (EAST)"
+	},
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "lvk" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
+"lxw" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 8;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
+"lzl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fp)
 "lAn" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -30151,6 +30082,25 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/third_deck/fp)
+"lMA" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/item/modular_computer/console/preset/nervasupply{
+	dir = 1;
+	tag = "icon-console (WEST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
+"lXq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fs)
 "mcq" = (
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 6;
@@ -30165,6 +30115,14 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/boardarmoury)
+"mlv" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fp)
 "mqS" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/black/three_quarters{
@@ -30217,6 +30175,10 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor/plating,
 /area/security/starboardexternalgun)
 "mAz" = (
@@ -30234,6 +30196,16 @@
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/starboardgun)
+"mKx" = (
+/obj/effect/floor_decal/corner/beige/three_quarters{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
 "mNE" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector{
@@ -30290,6 +30262,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/brig)
+"mZx" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/bar)
 "nbG" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 6;
@@ -30420,6 +30399,15 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
+"nFP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fp)
 "nJC" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -30506,20 +30494,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
 "oDe" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/item/weapon/storage/backpack/duffel/duffel_eng,
-/obj/item/clothing/suit/storage/hooded/wintercoat/miner,
+/obj/effect/floor_decal/corner/beige{
+	dir = 6;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (SOUTHEAST)"
+	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/item/weapon/mining_scanner,
-/obj/effect/floor_decal/corner/beige/three_quarters{
-	dir = 1
-	},
-/obj/item/clothing/accessory/armband/cargo,
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "oGG" = (
 /obj/structure/disposaloutlet/unwrap{
 	dir = 4;
@@ -30636,12 +30621,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandstarboard)
 "psT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
 	icon_state = "intact-scrubbers"
@@ -30654,18 +30633,13 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
-"ptN" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/table/standard,
-/obj/machinery/reagentgrinder,
-/turf/simulated/floor/tiled/white,
-/area/civilian/kitchen)
 "puU" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1;
@@ -30725,11 +30699,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
-"qkh" = (
-/obj/machinery/cooker/fryer,
-/obj/effect/floor_decal/corner/green/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/civilian/kitchen)
 "qlE" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/corner/red/half{
@@ -30808,8 +30777,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/portexternalgun)
+"qGN" = (
+/obj/machinery/light/small/red,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fp)
 "qLH" = (
 /turf/simulated/wall/false{
 	density = 1;
@@ -30847,30 +30827,37 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
 "rge" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/weapon/storage/backpack/duffel/duffel_norm,
-/obj/item/clothing/suit/storage/hooded/wintercoat/cargo,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
-	},
-/obj/machinery/camera/network/cargo{
-	c_tag = "Cargo Locker Room";
-	dir = 1;
-	icon_state = "camera"
-	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10;
 	icon_state = "corner_white"
 	},
-/obj/item/clothing/accessory/armband/cargo,
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/structure/closet/crate,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
-/area/logistics/lockers)
+/area/logistics/mailing)
 "rxg" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/third_deck/fs)
+"rNT" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/third_deck)
 "rOs" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
@@ -30952,6 +30939,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
+"soi" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "deliveryentry";
+	name = "Delivery Office Entry Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/logistics/mailing)
 "soA" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
@@ -31007,6 +31007,7 @@
 	name = "Brig Lockdown";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
 "sEc" = (
@@ -31026,6 +31027,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
+"sPK" = (
+/obj/machinery/door/blast/shutters{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/green/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "sRb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable{
@@ -31054,6 +31065,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
+"sXq" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
 "sZY" = (
 /obj/structure/shipweapons/hardpoint/external/nerva,
 /turf/space,
@@ -31192,6 +31209,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/abandonedoffice)
+"ucX" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/third_deck)
 "udn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -31216,6 +31248,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/starboardexternalgun)
+"ujt" = (
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
 "urB" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb{
@@ -31249,6 +31304,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/starboardexternalgun)
+"utO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Holodeck"
+	},
+/turf/simulated/floor/tiled,
+/area/civilian/holodeck)
+"uvu" = (
+/obj/effect/floor_decal/corner/black{
+	dir = 10
+	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 3 Cargo");
+	location = "EVA"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
 "uyU" = (
 /obj/effect/paint_stripe/beige,
 /turf/simulated/wall/prepainted,
@@ -31298,6 +31370,12 @@
 /obj/machinery/recharger{
 	pixel_y = 0
 	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	name = "Security RC";
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
 "uII" = (
@@ -31335,6 +31413,7 @@
 	name = "Robotics";
 	req_access = list("ACCESS_ROBOTICS")
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
 "vfR" = (
@@ -31351,6 +31430,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
+"vgW" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "vkW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -31427,6 +31512,16 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
+"vNs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
 "vTO" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
@@ -31518,6 +31613,16 @@
 /obj/item/clothing/accessory/armband,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/lockers)
+"wyQ" = (
+/obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/third_deck/fs)
 "wGS" = (
 /obj/machinery/door/blast/shutters/open{
 	dir = 2;
@@ -31537,7 +31642,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
 "wPx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/reinforced,
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/folder/yellow,
+/obj/machinery/door/window/northleft,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access = list("ACCESS_SORTING")
+	},
+/obj/effect/floor_decal/corner/beige/full,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "wRe" = (
@@ -31616,6 +31732,7 @@
 	name = "Boarding Armory Blast Door"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/boardarmoury)
 "xfr" = (
@@ -31646,6 +31763,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
+"xiK" = (
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/machinery/door/firedoor,
+/obj/item/weapon/material/ashtray/bronze,
+/turf/simulated/floor/wood/walnut,
+/area/civilian/bar)
 "xjg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
@@ -31670,6 +31793,18 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandoffices)
+"xGO" = (
+/obj/effect/floor_decal/corner/beige/full,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass/mining{
+	name = "Delivery Office";
+	req_access = list("ACCESS_SORTING")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
 "xNL" = (
 /obj/effect/floor_decal/corner/red/full,
 /turf/simulated/floor/tiled/techmaint,
@@ -31682,6 +31817,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/third_deck/fp)
+"xQT" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/security/brig)
 "xUw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -31704,25 +31846,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
-"xYu" = (
-/obj/machinery/smartfridge,
-/turf/simulated/floor/tiled/white,
-/area/civilian/kitchen)
 "ycr" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/portgun)
-"ylk" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/beige/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal";
-	tag = "icon-corner_white_diagonal (EAST)"
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
-/area/civilian/messhall)
 
 (1,1,1) = {"
 aaa
@@ -49604,7 +49731,7 @@ aux
 aux
 aux
 axX
-azf
+aBa
 aAb
 aBa
 aBa
@@ -50017,8 +50144,8 @@ aDI
 aEY
 aGp
 aHp
-aIF
-aIF
+aHp
+aHp
 aKS
 aLY
 aST
@@ -50218,10 +50345,10 @@ auA
 aDJ
 aEZ
 uyU
+aGq
+aGq
+aGq
 aHq
-aGq
-aGq
-aGq
 aGq
 aGq
 aGq
@@ -50419,15 +50546,15 @@ aCd
 auA
 aDK
 aFa
-uyU
+soi
 aHr
-aIG
+hdh
 aJM
-aIG
+bOq
 aKT
 aIG
-aNr
 aIG
+aNr
 aIG
 aQY
 tYN
@@ -50621,17 +50748,17 @@ aCd
 auA
 aDL
 aFa
-uyU
-uyU
+soi
+sXq
 aIH
 aJN
-aJN
-aJN
+xGO
+mKx
 aLZ
 aNs
-aNs
-aNs
-aNs
+aGq
+aGq
+aGq
 wqY
 aSZ
 aTS
@@ -50824,13 +50951,13 @@ auA
 aDM
 aFa
 aGr
-aHs
+sXq
 aII
+aJN
 aJO
-aJO
-aJO
-aMa
-aNs
+fnS
+aIJ
+lxw
 aOA
 aPN
 dFj
@@ -51003,10 +51130,10 @@ adB
 aed
 aeV
 abK
-agC
+agA
 ahx
 aiU
-akt
+aqO
 alC
 amK
 aog
@@ -51024,16 +51151,16 @@ auA
 aCc
 auA
 aDN
-aFa
+rNT
 aGs
 aHt
-aIJ
-aJP
+eEJ
+aJN
 wPx
 aKU
 aMb
-aNt
-aOB
+aMb
+aIJ
 aPO
 cwk
 aSd
@@ -51226,15 +51353,15 @@ aBc
 aCe
 aDb
 aDO
-aFa
-aGt
-aHu
-aIJ
+ucX
+soi
+sXq
 aJQ
-aIJ
+lMA
+aJO
 aKV
 aMc
-aNs
+hmt
 gZW
 aPP
 rge
@@ -51428,15 +51555,15 @@ aBd
 aCf
 aDc
 aDP
-aFa
-aGs
+ucX
+soi
 aHv
 aIK
 aJR
-aKW
+aJO
 gVr
 aMd
-aNs
+gth
 oDe
 aPQ
 jIp
@@ -51612,7 +51739,7 @@ afJ
 agA
 ahA
 aiX
-akt
+aqO
 alF
 amN
 aoj
@@ -51635,13 +51762,13 @@ cTb
 aGu
 aGu
 aGu
-aKX
 aGu
 aGu
-aNs
-aNs
+aGu
+aGq
+aGq
 aPR
-aNs
+aGq
 aSd
 aTd
 aTX
@@ -54240,16 +54367,16 @@ ahM
 ajk
 akG
 akG
-amX
+akI
 aot
 akG
 sEc
-arW
+hCe
 atz
 auF
 atz
 axd
-ayl
+atz
 azp
 atz
 aBq
@@ -54449,13 +54576,13 @@ sEc
 asd
 atA
 auG
-auH
-auL
+hZn
+aDZ
 aym
 auG
-auL
-aBr
-auH
+aDZ
+aym
+hZn
 auG
 aDZ
 aFn
@@ -54652,12 +54779,12 @@ ase
 atB
 auH
 avO
-avQ
-ayn
-azq
-avQ
-avQ
-aCr
+avO
+avO
+avO
+avO
+avO
+avO
 auH
 aEa
 aFo
@@ -54852,18 +54979,18 @@ apK
 aqX
 asf
 atC
-auH
-avP
-avQ
-ayo
-ayo
-ayo
-avQ
-ylk
-auH
+kjM
+avO
+avO
+avO
+avO
+avO
+avO
+avO
+kjM
 atC
 aFp
-aGA
+aLh
 aHJ
 aIY
 aIY
@@ -55054,15 +55181,15 @@ apL
 aqY
 asg
 atD
-auH
-avQ
-avQ
-ayp
-azr
-ayp
-avQ
-avQ
-auH
+kjM
+avO
+avO
+avO
+avO
+avO
+avO
+avO
+kjM
 aEb
 aFq
 ksl
@@ -55256,15 +55383,15 @@ apM
 aqZ
 ash
 atC
-auI
-avQ
-axe
-ayq
-ayq
-ayq
-axe
-avQ
-auI
+kjM
+avO
+avO
+avO
+avO
+avO
+avO
+avO
+kjM
 atC
 aFp
 aGB
@@ -55457,17 +55584,17 @@ akJ
 akJ
 sEc
 asi
-atE
-auJ
-avR
-axf
-ayr
-ayr
-ayr
-axf
-avR
-auJ
-atE
+atC
+kjM
+avO
+avO
+avO
+avO
+avO
+avO
+avO
+kjM
+atC
 aFr
 aGC
 aHM
@@ -55660,15 +55787,15 @@ adj
 ara
 asj
 atC
-auH
-avS
-axg
-ayp
-azs
-ayp
-axg
-aCt
-auH
+kjM
+avO
+avO
+avO
+avO
+avO
+avO
+avO
+kjM
 atC
 aFp
 aGB
@@ -55861,17 +55988,17 @@ suK
 suK
 suK
 ask
-atF
-auK
-avT
-axh
-ays
-ays
-ays
-axh
-aCu
-aDg
-aEc
+atC
+kjM
+avO
+avO
+avO
+avO
+avO
+avO
+avO
+kjM
+atC
 aFs
 ksl
 aGz
@@ -56064,15 +56191,15 @@ apN
 arb
 asl
 atC
-auL
-avU
-axi
-ayo
-ayo
-ayo
-axi
-avQ
-auL
+kjM
+avO
+avO
+avO
+avO
+avO
+avO
+avO
+kjM
 atC
 aFt
 aGD
@@ -56266,17 +56393,17 @@ apO
 arc
 asm
 atC
-auH
-avV
-avQ
+auM
+auM
+auM
+auM
+auM
 ayp
-azr
+cXI
 ayp
-avQ
-avQ
-auH
+brf
 atC
-aFu
+ujt
 aGE
 hNR
 hNR
@@ -56461,22 +56588,22 @@ ahW
 ajv
 vwY
 alW
-alW
+erq
 alW
 aoB
 apP
 ard
 asn
-atC
-auH
+atG
+auM
 avW
-axj
+axo
 ayq
-ayq
-ayq
-avQ
+auM
+koC
+fXe
 aCs
-auH
+utO
 atC
 aFv
 hNR
@@ -56669,18 +56796,18 @@ aoC
 mPt
 mPt
 aso
-atG
-auH
-avX
-avQ
-ayt
-avQ
-avQ
-avQ
-aCv
-auH
 atC
-aFw
+sPK
+axo
+axo
+ayt
+auM
+avQ
+ikq
+aCv
+jgk
+vNs
+kjK
 aGG
 dSr
 qBP
@@ -56873,16 +57000,16 @@ are
 asl
 atH
 auM
+dKO
+axo
+elg
 auM
-axk
 auM
-xYu
-aAk
-aAk
+auM
 auM
 auM
 aEd
-aFw
+uvu
 aGF
 aHS
 aJc
@@ -57077,10 +57204,10 @@ atC
 auM
 avY
 axl
+axo
 ayu
-axo
 aAl
-axo
+hEU
 aCw
 auM
 atC
@@ -57298,9 +57425,9 @@ aMy
 aMy
 aQn
 hNR
-aSz
-aSz
-aSz
+hEA
+aRL
+aRL
 aVh
 aPs
 aPs
@@ -57482,7 +57609,7 @@ auM
 awa
 tWi
 axo
-gMk
+vgW
 aAn
 axo
 aCy
@@ -57503,7 +57630,7 @@ hNR
 aQo
 aQo
 aQo
-aSz
+aRN
 aPs
 aPs
 aPs
@@ -57684,7 +57811,7 @@ auM
 awb
 axn
 ayx
-fRl
+gMk
 aAo
 axo
 uME
@@ -57705,7 +57832,7 @@ aSA
 aTt
 aUi
 aQo
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -57883,12 +58010,12 @@ bFA
 asl
 atK
 auM
-qkh
+fRl
 axo
 ayx
 lai
-ptN
 axo
+luj
 aCz
 auM
 aEf
@@ -57907,7 +58034,7 @@ aSB
 aTu
 aUj
 aUR
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -58089,8 +58216,8 @@ auM
 axk
 auM
 auM
+bdp
 auM
-aBt
 auM
 auM
 aEg
@@ -58291,8 +58418,8 @@ awc
 awh
 ayy
 azv
-aAp
 awh
+jWR
 aCA
 auO
 aEh
@@ -58311,7 +58438,7 @@ aSD
 aTw
 aUl
 aQo
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -58477,7 +58604,7 @@ adO
 adO
 adO
 adO
-bpF
+xQT
 aie
 ajE
 vtZ
@@ -58513,7 +58640,7 @@ aSE
 aTx
 aUm
 aQo
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -58693,9 +58820,9 @@ atC
 auO
 awe
 axq
+xiK
 ayz
-ayz
-ayz
+xiK
 aBv
 aCC
 auO
@@ -58715,7 +58842,7 @@ aQw
 aQw
 aQw
 aQw
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -58874,12 +59001,12 @@ aam
 aaU
 aaT
 aaU
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
+agq
+fJz
+fJz
+fJz
+fJz
+fJz
 agU
 aif
 ajF
@@ -58917,7 +59044,7 @@ aSF
 aTy
 aUn
 aUS
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -59076,7 +59203,7 @@ aam
 aaY
 aam
 aaU
-aaU
+iCy
 aam
 adn
 adn
@@ -59119,7 +59246,7 @@ aSG
 aTz
 aUo
 aQw
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -59278,7 +59405,7 @@ aam
 aam
 aam
 aaU
-aaU
+iCy
 aam
 adP
 aeF
@@ -59321,7 +59448,7 @@ aSH
 aTA
 aUp
 aQw
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -59480,7 +59607,7 @@ aam
 aam
 aam
 aca
-aaU
+iCy
 aam
 adQ
 ogN
@@ -59504,7 +59631,7 @@ axu
 ayD
 azx
 aAs
-ayE
+bZk
 aCF
 auQ
 atC
@@ -59523,7 +59650,7 @@ aSI
 aTB
 aUq
 aQw
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -59682,7 +59809,7 @@ aam
 aam
 aam
 acb
-aaU
+iCy
 aam
 adR
 puU
@@ -59702,11 +59829,11 @@ asv
 atC
 auQ
 awj
+bZk
 axu
-ayE
 awh
 aAt
-axu
+mZx
 aCF
 auQ
 atC
@@ -59725,7 +59852,7 @@ aSJ
 aQw
 aQw
 aQw
-aSO
+wyQ
 aPs
 aPs
 aaa
@@ -59884,7 +60011,7 @@ aam
 aam
 aam
 aam
-aaU
+iCy
 aam
 adS
 puU
@@ -59925,9 +60052,9 @@ vTO
 aQw
 aQw
 aQw
-aSz
-aSz
-aSz
+ltj
+aRL
+lXq
 aPs
 aPs
 aaa
@@ -60086,7 +60213,7 @@ aaa
 aam
 abB
 aam
-abY
+iBy
 aam
 adT
 oPu
@@ -60288,7 +60415,7 @@ aaa
 aam
 aam
 aam
-aaU
+iCy
 aam
 adU
 aeH
@@ -60490,7 +60617,7 @@ aaa
 aaa
 aam
 aam
-aaU
+iCy
 aam
 adn
 adn
@@ -60692,12 +60819,12 @@ aaa
 aaa
 aam
 aam
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
+mlv
+fJz
+fJz
+fJz
+fJz
+lzl
 agZ
 dZX
 ajO
@@ -60899,7 +61026,7 @@ aam
 aam
 aam
 aam
-aaU
+nFP
 agZ
 cBm
 ajP
@@ -61101,7 +61228,7 @@ aam
 adV
 aeI
 aam
-aaU
+nFP
 agZ
 wvQ
 ajQ
@@ -61137,7 +61264,7 @@ aQB
 aRK
 aSN
 aPk
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -61303,7 +61430,7 @@ aam
 adW
 aeJ
 afy
-ago
+qGN
 agZ
 agZ
 kjn
@@ -61339,7 +61466,7 @@ aPk
 aPk
 aPk
 aPk
-aSz
+aRN
 aPs
 aPs
 aaa
@@ -61505,10 +61632,10 @@ aam
 adX
 aeK
 aam
-aaU
-aaU
-agq
-aiq
+mlv
+fJz
+lzl
+amp
 ajR
 ale
 amn
@@ -61536,12 +61663,12 @@ aKw
 aLB
 aMJ
 aOa
-aPm
+aKy
 aQC
 aRL
 aSO
-aSz
-aSz
+aRL
+lXq
 aPs
 aPs
 aaa
@@ -61916,7 +62043,7 @@ air
 ajT
 icd
 air
-amp
+lkz
 air
 air
 emJ
@@ -61942,7 +62069,7 @@ aML
 aOc
 bbM
 aQE
-aRN
+aSz
 aPs
 aTD
 aUu
@@ -62112,8 +62239,8 @@ aam
 waA
 aaU
 aam
-agq
-ahc
+aaU
+ago
 air
 ajU
 jEV
@@ -62144,7 +62271,7 @@ pdI
 aOd
 bbM
 aQF
-aRN
+aSz
 aSP
 aTE
 aUv
@@ -62314,7 +62441,7 @@ aam
 esi
 wrh
 aaT
-agr
+adm
 ahd
 ycr
 ajV
@@ -62346,7 +62473,7 @@ aMM
 aOe
 mBH
 aLD
-aRN
+aSz
 aPs
 aTF
 aUw

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -61,7 +61,7 @@
 "aal" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "solar_tool_outer3";
 	locked = 1;
 	name = "Engineering External Access";
@@ -136,7 +136,7 @@
 "aaw" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "solar_tool_inner3";
 	locked = 1;
 	name = "Engineering External Access";
@@ -3257,7 +3257,7 @@
 /area/maintenance/third_deck/afp)
 "agw" = (
 /obj/machinery/door/airlock/hatch/maintenance{
-	icon_state = "door_closed";
+	icon_state = "closed";
 	id_tag = null;
 	locked = 0;
 	name = "Engine Access"
@@ -7460,15 +7460,10 @@
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
@@ -7477,22 +7472,10 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
 "anz" = (
-/obj/structure/lattice,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "32-8"
-	},
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/hallway/commandport)
 "anA" = (
 /obj/machinery/light/small{
@@ -7503,20 +7486,20 @@
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "anB" = (
-/obj/machinery/door/airlock/command{
-	name = "Bridge";
-	req_access = list("ACCESS_BRIDGE")
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "bridgelock";
-	name = "Bridge Lockdown";
-	tag = "icon-pdoor1"
-	},
 /obj/effect/floor_decal/corner/fadeblue/full,
-/turf/simulated/floor/tiled/dark,
-/area/command/bridge)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/security/portgun)
 "anC" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/bridge)
@@ -7537,7 +7520,7 @@
 "anE" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "robotics_solar_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -7575,7 +7558,7 @@
 "anG" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "robotics_solar_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -8288,8 +8271,15 @@
 	luminosity = 3
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
 /turf/simulated/floor/tiled/dark,
-/area/command/bridge)
+/area/security/portgun)
 "aoY" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/engine_waste)
@@ -11322,6 +11312,13 @@
 "asI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/fadeblue/full,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "asJ" = (
@@ -12107,9 +12104,16 @@
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8";
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
 	tag = ""
 	},
 /turf/simulated/floor/tiled/dark,
@@ -12127,6 +12131,13 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue/full,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "aua" = (
@@ -13096,11 +13107,11 @@
 	icon_state = "corner_white_three_quarters";
 	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/civilian/holodeck)
 "avW" = (
@@ -13959,7 +13970,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch{
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "engine_electrical_maintenance";
 	locked = 1;
 	name = "Engine Electrical Maintenance";
@@ -14260,11 +14271,24 @@
 "ayq" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/cooker/oven,
+/obj/machinery/button/remote/blast_door{
+	id = "kitchenholodeck";
+	name = "Kitchen Holodeck Shutters Control";
+	pixel_x = -5;
+	pixel_y = -26;
+	req_access = list("ACCESS_KITCHEN");
+	tag = "icon-blastctrl (EAST)"
+	},
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "ayt" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/cooker/fryer,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "ayu" = (
@@ -15327,10 +15351,6 @@
 	dir = 4;
 	layer = 2.4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "aAm" = (
@@ -15542,7 +15562,7 @@
 /area/engineering/engine)
 "aAI" = (
 /obj/machinery/door/airlock/hatch{
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "null";
 	locked = 1;
 	name = "Core Access";
@@ -16723,7 +16743,7 @@
 /area/engineering/engine)
 "aCR" = (
 /obj/machinery/door/airlock/hatch{
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "null";
 	locked = 1;
 	name = "Core Access";
@@ -19568,6 +19588,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/vending/whitedragon,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aHw" = (
@@ -20287,6 +20308,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = 22
 	},
+/obj/machinery/computer/merch{
+	icon_state = "computer";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "aIL" = (
@@ -20665,7 +20690,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aJx" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/hallway/commandstarboard)
 "aJy" = (
@@ -20849,6 +20874,11 @@
 "aJR" = (
 /obj/effect/floor_decal/corner/beige/three_quarters{
 	dir = 4
+	},
+/obj/item/modular_computer/console/preset/nervasupply{
+	dir = 8;
+	icon_state = "console";
+	tag = "icon-console (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
@@ -21507,15 +21537,6 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
-"aKV" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/stamp/cargo,
-/obj/item/weapon/stamp/denied,
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
@@ -23037,17 +23058,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/mailing)
-"aNs" = (
-/obj/machinery/conveyor_switch{
-	id = "packageSort1"
-	},
-/obj/effect/floor_decal/corner/beige/three_quarters,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
 "aNu" = (
 /obj/machinery/door/blast/shutters/open{
 	dir = 2;
@@ -23963,16 +23973,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
-"aOA" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 9;
-	icon_state = "corner_white"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
 "aOE" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/corner/beige/three_quarters{
@@ -25236,6 +25236,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aQE" = (
@@ -28288,24 +28289,31 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
+"bEf" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/stamp/denied,
+/obj/item/weapon/stamp/cargo,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
 "bFA" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/evidence)
 "bOq" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "bXZ" = (
 /obj/structure/cable{
@@ -28515,7 +28523,7 @@
 "dpd" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "starboardgun_inner";
 	locked = 1;
 	name = "External Access";
@@ -28807,6 +28815,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/cents)
+"etf" = (
+/obj/structure/lattice,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "32-8"
+	},
+/turf/simulated/open,
+/area/space)
 "eyp" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Office";
@@ -28931,17 +28948,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/command/eva)
-"fnS" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 5
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
 "fqm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
@@ -28970,7 +28976,7 @@
 "fwf" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "port_gun_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -29227,6 +29233,9 @@
 /obj/item/weapon/storage/box,
 /obj/item/weapon/storage/box,
 /obj/item/weapon/storage/box,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
 "gZW" = (
@@ -29362,6 +29371,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/starboardexternalgun)
+"hKg" = (
+/obj/structure/disposaloutlet,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/logistics/mailing)
 "hNR" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
@@ -29520,7 +29541,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/tiled/dark,
-/area/command/bridge)
+/area/security/starboardgun)
 "iME" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/toy/desk/fan,
@@ -29813,6 +29834,28 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/civilian/holodeck)
+"kpv" = (
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	req_access = list("ACCESS_BRIDGE")
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "bridgelock";
+	name = "Bridge Lockdown";
+	tag = "icon-pdoor1"
+	},
+/obj/effect/floor_decal/corner/fadeblue/full,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/bridge)
 "krd" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -29985,19 +30028,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
-"lkz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bridge Maintenance";
-	req_access = list(list("ACCESS_BRIDGE","ACCESS_GUNNERY"))
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/hallway/commandport)
 "lmx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4;
@@ -30050,6 +30080,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
+"lxu" = (
+/obj/machinery/conveyor_switch{
+	id = "packageSort1"
+	},
+/obj/effect/floor_decal/corner/beige/three_quarters,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/logistics/mailing)
 "lxw" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 8;
@@ -30082,17 +30124,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/third_deck/fp)
-"lMA" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 10;
-	icon_state = "corner_white"
-	},
-/obj/item/modular_computer/console/preset/nervasupply{
-	dir = 1;
-	tag = "icon-console (WEST)"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/mailing)
 "lXq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30153,6 +30184,24 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
+"mus" = (
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/portgun)
 "mvm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/red{
@@ -30317,7 +30366,7 @@
 "niC" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "starboardgun_outer";
 	locked = 1;
 	name = "External Access";
@@ -30800,7 +30849,7 @@
 "qRR" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "port_gun_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -31026,7 +31075,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/command/bridge)
+/area/security/starboardgun)
 "sPK" = (
 /obj/machinery/door/blast/shutters{
 	id = "kitchen";
@@ -31107,8 +31156,24 @@
 /area/security/office)
 "tfy" = (
 /obj/effect/floor_decal/corner/fadeblue/full,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/portgun)
+"tkx" = (
+/obj/effect/floor_decal/corner/fadeblue/full,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/starboardgun)
 "toz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	req_access = 1
@@ -31408,6 +31473,17 @@
 /obj/effect/paint_stripe/paleblue,
 /turf/simulated/wall/prepainted,
 /area/medical/examroom)
+"uZS" = (
+/obj/effect/floor_decal/corner/fadeblue/full,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/bridge)
 "vey" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics";
@@ -31780,6 +31856,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
+"xvz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Holodeck"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
 "xyC" = (
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 10;
@@ -31817,6 +31900,22 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/maintenance/third_deck/fp)
+"xOM" = (
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access = list("ACCESS_KITCHEN")
+	},
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
+"xQE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id = "kitchenholodeck";
+	name = "kitchen shutters"
+	},
+/turf/simulated/floor/tiled/white,
+/area/civilian/kitchen)
 "xQT" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -50551,11 +50650,11 @@ aHr
 hdh
 aJM
 bOq
+hKg
 aKT
 aIG
 aIG
 aNr
-aIG
 aQY
 tYN
 aSY
@@ -50752,11 +50851,11 @@ soi
 sXq
 aIH
 aJN
-xGO
+aJO
 mKx
 aLZ
-aNs
-aGq
+aLZ
+lxu
 aGq
 aGq
 wqY
@@ -50954,11 +51053,11 @@ aGr
 sXq
 aII
 aJN
-aJO
-fnS
+xGO
+sXq
+aIJ
 aIJ
 lxw
-aOA
 aPN
 dFj
 wqY
@@ -51156,9 +51255,9 @@ aGs
 aHt
 eEJ
 aJN
-wPx
-aKU
-aMb
+aJO
+bEf
+aIJ
 aMb
 aIJ
 aPO
@@ -51357,9 +51456,9 @@ ucX
 soi
 sXq
 aJQ
-lMA
-aJO
-aKV
+aJN
+wPx
+aKU
 aMc
 hmt
 gZW
@@ -55989,7 +56088,7 @@ suK
 suK
 ask
 atC
-kjM
+xvz
 avO
 avO
 avO
@@ -55997,7 +56096,7 @@ avO
 avO
 avO
 avO
-kjM
+xvz
 atC
 aFs
 ksl
@@ -56395,7 +56494,7 @@ asm
 atC
 auM
 auM
-auM
+xQE
 auM
 auM
 ayp
@@ -57004,7 +57103,7 @@ dKO
 axo
 elg
 auM
-auM
+xOM
 auM
 auM
 auM
@@ -62043,7 +62142,7 @@ air
 ajT
 icd
 air
-lkz
+amp
 air
 air
 emJ
@@ -62667,9 +62766,9 @@ aDm
 aEt
 aFR
 emJ
-emJ
-emJ
-emJ
+mBH
+mBH
+mBH
 mBH
 aMN
 aOf
@@ -62849,12 +62948,12 @@ cOu
 ahd
 ait
 ajX
-ali
+mus
 tfy
 anB
 aoX
-aqk
-aqk
+kpv
+uZS
 asI
 atZ
 auZ
@@ -62868,10 +62967,10 @@ axE
 aDn
 aEu
 aFS
-aqk
+iBE
 iIz
 sPc
-iBE
+tkx
 aLE
 aMO
 aOg
@@ -63053,8 +63152,8 @@ aiu
 ajY
 ali
 amq
-emJ
-emJ
+etf
+ycr
 emJ
 emJ
 asJ
@@ -63254,10 +63353,10 @@ ahd
 aiv
 ajZ
 alj
-ahd
-anC
-anC
-anC
+ycr
+ycr
+ycr
+emJ
 emJ
 emJ
 aub
@@ -63275,8 +63374,8 @@ emJ
 emJ
 aIm
 aGS
-anC
-aLD
+emJ
+mBH
 aMQ
 aOi
 aPq
@@ -63457,7 +63556,7 @@ aiw
 dkt
 pVb
 ahd
-anC
+ahd
 acc
 acc
 emJ

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -66,7 +66,7 @@
 "am" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "solar_tool_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -104,7 +104,7 @@
 "ao" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "solar_tool_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -1521,7 +1521,7 @@
 /obj/machinery/door/firedoor,
 /obj/item/taperoll/engineering/applied,
 /obj/machinery/door/airlock/hatch{
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = null;
 	locked = 1;
 	name = "Observatory";
@@ -1531,7 +1531,7 @@
 /area/hallway/aft/second_deck)
 "dn" = (
 /obj/machinery/door/airlock/hatch{
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = null;
 	locked = 1;
 	name = "Observatory";
@@ -4136,7 +4136,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "iw" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/vending/cola,
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
 "ix" = (
@@ -4547,10 +4547,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
 "js" = (
-/obj/structure/bed/chair/wood/walnut{
-	dir = 8;
-	icon_state = "wooden_chair_preview"
-	},
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/storage/pill_bottle/dice,
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
 "jt" = (
@@ -12046,7 +12044,7 @@
 "xo" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "exti2_inner";
 	locked = 1;
 	name = "External Access";
@@ -12541,7 +12539,7 @@
 "yh" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "exti2_outer";
 	locked = 1;
 	name = "External Access";
@@ -14308,11 +14306,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
-"Gn" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/weapon/storage/pill_bottle/dice,
-/turf/simulated/floor/plating,
-/area/civilian/lounge)
 "Gv" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1;
@@ -15654,6 +15647,10 @@
 /obj/structure/bed/chair/wood/walnut,
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
+"Oi" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/second_deck/afp)
 "Ok" = (
 /obj/random/junk,
 /obj/structure/disposalpipe/segment,
@@ -39219,7 +39216,7 @@ Um
 eG
 Um
 Um
-aX
+Oi
 aX
 fg
 fS
@@ -41447,7 +41444,7 @@ eD
 ga
 gT
 hK
-jq
+iz
 iz
 iz
 ix
@@ -41649,8 +41646,8 @@ fi
 gb
 gU
 hK
-Gn
-kg
+jq
+iz
 iz
 iz
 ix
@@ -41852,7 +41849,7 @@ gc
 gV
 hK
 js
-iz
+kg
 iz
 lk
 RU

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -36,8 +36,8 @@
 "ai" = (
 /obj/structure/catwalk,
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/second_deck/afp)
@@ -82,14 +82,14 @@
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "solar_tool_pump";
-	tag_exterior_door = "solar_tool_outer";
 	frequency = 1379;
 	id_tag = "solar_tool_airlock";
-	tag_interior_door = "solar_tool_inner";
 	pixel_x = 25;
 	req_access = list("ACCESS_EXTERNAL");
-	tag_chamber_sensor = "solar_tool_sensor"
+	tag_airpump = "solar_tool_pump";
+	tag_chamber_sensor = "solar_tool_sensor";
+	tag_exterior_door = "solar_tool_outer";
+	tag_interior_door = "solar_tool_inner"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
@@ -153,8 +153,8 @@
 /area/maintenance/second_deck/afp)
 "av" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -164,42 +164,42 @@
 /area/maintenance/second_deck/afp)
 "aw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "ax" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "ay" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
@@ -294,9 +294,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
@@ -323,35 +323,35 @@
 /area/maintenance/second_deck/afp)
 "aR" = (
 /obj/item/pipe{
-	tag = "icon-simple (EAST)";
+	dir = 4;
 	icon_state = "simple";
-	dir = 4
+	tag = "icon-simple (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "aS" = (
 /obj/item/pipe{
-	tag = "icon-simple (EAST)";
+	dir = 4;
 	icon_state = "simple";
-	dir = 4
+	tag = "icon-simple (EAST)"
 	},
 /obj/item/remains/robot,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "aT" = (
 /obj/item/pipe{
-	tag = "icon-simple (EAST)";
+	dir = 4;
 	icon_state = "simple";
-	dir = 4
+	tag = "icon-simple (EAST)"
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "aU" = (
 /obj/item/pipe{
-	tag = "icon-simple (EAST)";
+	dir = 4;
 	icon_state = "simple";
-	dir = 4
+	tag = "icon-simple (EAST)"
 	},
 /obj/item/stack/material/rods/ten,
 /turf/simulated/floor/plating,
@@ -493,13 +493,13 @@
 /area/maintenance/second_deck/fp)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -519,25 +519,25 @@
 /area/maintenance/second_deck/afp)
 "bu" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/fuel{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/lattice,
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (WEST)";
+	dir = 8;
 	icon_state = "down-supply";
-	dir = 8
+	tag = "icon-down-supply (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "down-scrubbers";
-	dir = 8
+	tag = "icon-down-scrubbers (WEST)"
 	},
 /turf/simulated/open,
 /turf/simulated/open{
@@ -558,8 +558,8 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/item/weapon/circuitboard/borgupload,
 /turf/simulated/floor/plating,
@@ -571,12 +571,12 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -586,8 +586,8 @@
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/item/weapon/circuitboard/helm,
 /obj/item/weapon/circuitboard/combat_computer,
@@ -679,6 +679,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/stech)
 "bK" = (
@@ -702,14 +703,14 @@
 "bO" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/corner/red/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -720,9 +721,9 @@
 /area/security/prison)
 "bP" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -738,10 +739,14 @@
 /area/engineering/fuelbay)
 "bS" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/fuelbay)
 "bT" = (
@@ -785,8 +790,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -799,12 +804,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -818,9 +823,9 @@
 "bY" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -829,17 +834,17 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/techstorage)
 "bZ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -853,9 +858,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/techstorage)
@@ -871,9 +876,9 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/techstorage)
@@ -977,8 +982,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -990,9 +995,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1007,9 +1012,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1018,8 +1023,8 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/fuelbay)
@@ -1034,9 +1039,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1070,8 +1075,8 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -1120,9 +1125,9 @@
 /area/engineering/techstorage)
 "cA" = (
 /obj/structure/cryofeed{
-	tag = "icon-cryo_rear (EAST)";
+	dir = 4;
 	icon_state = "cryo_rear";
-	dir = 4
+	tag = "icon-cryo_rear (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1135,9 +1140,9 @@
 	dir = 1
 	},
 /obj/machinery/cryopod{
-	tag = "icon-body_scanner_0 (EAST)";
+	dir = 4;
 	icon_state = "body_scanner_0";
-	dir = 4
+	tag = "icon-body_scanner_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1150,15 +1155,15 @@
 	name = "JoinLateCryo2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
 "cD" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1231,8 +1236,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -1246,12 +1251,13 @@
 	name = "Prison";
 	req_access = list("ACCESS_BRIG")
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
 "cL" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1263,8 +1269,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
@@ -1276,8 +1282,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -1331,9 +1337,9 @@
 "cT" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
@@ -1351,9 +1357,9 @@
 /area/maintenance/second_deck/fp)
 "cW" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	tag = "icon-air_map (WEST)";
+	dir = 8;
 	icon_state = "air_map";
-	dir = 8
+	tag = "icon-air_map (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
@@ -1381,8 +1387,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/button/ignition{
 	id = "engines";
@@ -1432,9 +1438,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -1478,17 +1484,17 @@
 /area/engineering/techstorage)
 "dh" = (
 /obj/machinery/cryopod{
-	tag = "icon-body_scanner_0 (EAST)";
+	dir = 4;
 	icon_state = "body_scanner_0";
-	dir = 4
+	tag = "icon-body_scanner_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
 "di" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1498,8 +1504,8 @@
 	name = "JoinLateCryo2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1540,8 +1546,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -1640,20 +1646,20 @@
 /area/maintenance/second_deck/fp)
 "dC" = (
 /obj/structure/hygiene/toilet{
-	icon_state = "toilet00";
-	dir = 8
+	dir = 8;
+	icon_state = "toilet00"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 1
+	dir = 1;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
 "dD" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
@@ -1705,8 +1711,8 @@
 "dI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1718,8 +1724,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -1731,9 +1737,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -1761,8 +1767,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1770,8 +1776,8 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1860,8 +1866,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1877,8 +1883,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1892,14 +1898,14 @@
 /area/maintenance/second_deck/afp)
 "en" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1997,9 +2003,9 @@
 "ev" = (
 /obj/structure/closet/walllocker/emerglocker/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -2025,8 +2031,8 @@
 	pixel_y = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -2038,16 +2044,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
 "ez" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -2144,9 +2150,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
@@ -2272,8 +2278,8 @@
 /area/command/captain)
 "ft" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -2299,12 +2305,12 @@
 /area/maintenance/second_deck/afp)
 "fv" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-22";
-	icon_state = "plant-22"
+	icon_state = "plant-22";
+	tag = "icon-plant-22"
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -2313,9 +2319,9 @@
 /obj/item/weapon/storage/backpack/duffel/duffel_eng,
 /obj/item/clothing/glasses/welding/superior,
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -2341,14 +2347,14 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -2363,8 +2369,8 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -2375,9 +2381,9 @@
 /area/command/ce)
 "fA" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2402,9 +2408,9 @@
 /area/engineering/break_room)
 "fB" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -2423,9 +2429,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -2433,13 +2439,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2540,8 +2546,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2559,9 +2565,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2593,9 +2599,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2609,9 +2615,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2626,9 +2632,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/light{
@@ -2652,9 +2658,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
@@ -2687,9 +2693,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2704,13 +2710,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
@@ -2722,8 +2728,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2741,9 +2747,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2761,9 +2767,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2781,9 +2787,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2799,12 +2805,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -2829,8 +2835,8 @@
 	tag = ""
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
@@ -2843,9 +2849,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2863,9 +2869,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/firealarm{
 	dir = 2;
@@ -2887,9 +2893,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2904,9 +2910,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -2916,8 +2922,8 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2932,9 +2938,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck Port Hallway - Fore-Centre"
@@ -2943,8 +2949,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -2959,9 +2965,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2979,9 +2985,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2999,8 +3005,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3018,9 +3024,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3029,9 +3035,9 @@
 	dir = 4
 	},
 /obj/machinery/light/broken{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -3043,13 +3049,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3069,12 +3075,12 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3096,8 +3102,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -3115,8 +3121,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -3128,12 +3134,12 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -3144,14 +3150,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 2 Fore Starboard");
+	location = "Deck 2 Fore Port"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "gn" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3180,8 +3190,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3268,14 +3278,15 @@
 /area/command/captain)
 "gw" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/binary/passive_gate/on{
 	dir = 1;
+	max_pressure_setting = 35000;
 	regulate_mode = 1;
 	target_pressure = 35000;
 	use_power = 1
@@ -3307,8 +3318,8 @@
 /obj/item/weapon/rig/ce/equipped,
 /obj/item/clothing/mask/breath,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/item/weapon/storage/secure/alert_safe{
 	pixel_x = -26
@@ -3332,8 +3343,8 @@
 	name = "Chief Engineer"
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -3360,34 +3371,34 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "gG" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "gH" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -3401,9 +3412,9 @@
 /area/hallway/aft/second_deck)
 "gI" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -3486,25 +3497,25 @@
 /area/hallway/fore/second_deck)
 "gS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "gT" = (
 /obj/machinery/atmospherics/valve/shutoff{
-	tag = "icon-map_vclamp0 (WEST)";
+	dir = 8;
 	icon_state = "map_vclamp0";
-	dir = 8
+	tag = "icon-map_vclamp0 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "gU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -3589,15 +3600,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "hj" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -3608,8 +3619,8 @@
 	pixel_y = 0
 	},
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -3623,6 +3634,7 @@
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/command/captain)
 "hn" = (
@@ -3638,16 +3650,16 @@
 /area/command/captain)
 "hq" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /turf/simulated/floor/carpet,
 /area/command/captain)
 "hr" = (
 /obj/machinery/atmospherics/unary/engine{
-	tag = "icon-nozzle (EAST)";
+	dir = 4;
 	icon_state = "nozzle";
-	dir = 4
+	tag = "icon-nozzle (EAST)"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/fdengine)
@@ -3662,21 +3674,23 @@
 /area/engineering/fdengine)
 "ht" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "hu" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	frequency = 1441;
+	id_tag = "d2_c_chamber_out";
 	internal_pressure_bound = 35000;
 	internal_pressure_bound_default = 35000
 	},
@@ -3709,8 +3723,8 @@
 	pixel_y = -8
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Chief Engineer's Office";
@@ -3737,8 +3751,8 @@
 "hz" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/item/weapon/pen,
 /obj/item/weapon/stamp/ce,
@@ -3763,6 +3777,7 @@
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
 	name = "\improper Central Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "hE" = (
@@ -3776,9 +3791,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -3884,6 +3899,10 @@
 /area/command/teleporter)
 "hU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/carpet,
 /area/command/captain)
 "hV" = (
@@ -3921,8 +3940,8 @@
 /area/engineering/fdengine)
 "hZ" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -3931,12 +3950,14 @@
 	id = "engines";
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
+	frequency = 1441;
+	id_tag = "d2_c_chamber_out";
 	internal_pressure_bound = 35000;
 	internal_pressure_bound_default = 35000
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "ib" = (
@@ -3946,16 +3967,16 @@
 "ic" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -3988,12 +4009,12 @@
 /area/command/ce)
 "if" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
@@ -4015,9 +4036,9 @@
 "ih" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -4035,22 +4056,22 @@
 /area/hallway/aft/second_deck)
 "ik" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "il" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva3 (NORTH)";
+	dir = 1;
 	icon_state = "nerva3";
-	dir = 1
+	tag = "icon-nerva3 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -4185,9 +4206,9 @@
 /area/command/headquarters)
 "iJ" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -4233,8 +4254,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
@@ -4250,8 +4271,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
@@ -4264,8 +4285,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/carpet,
 /area/command/captain)
@@ -4275,12 +4296,12 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/carpet,
 /area/command/captain)
@@ -4289,8 +4310,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -4304,8 +4325,8 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/carpet,
 /area/command/captain)
@@ -4315,8 +4336,8 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Captain's Bedroom";
@@ -4362,9 +4383,9 @@
 "iZ" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -4372,15 +4393,19 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "ja" = (
+/obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1441;
+	id = "d2_c_chamber_in";
 	injecting = 1;
 	use_power = 1
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "jb" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1441;
+	id = "d2_c_chamber_in";
 	injecting = 1;
 	use_power = 1
 	},
@@ -4390,8 +4415,9 @@
 "jc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/air_sensor{
-	id_tag = "cChamber1C";
-	output = 2
+	frequency = 1441;
+	id_tag = "d2_c_chamber_sensor";
+	output = 111
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -4460,22 +4486,22 @@
 /area/hallway/aft/second_deck)
 "jh" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2 (NORTH)";
+	dir = 1;
 	icon_state = "nerva2";
-	dir = 1
+	tag = "icon-nerva2 (NORTH)"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "ji" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -4501,8 +4527,8 @@
 /area/hallway/aft/second_deck)
 "jo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -4515,15 +4541,15 @@
 /area/civilian/lounge)
 "jq" = (
 /obj/structure/bed/chair/wood/walnut{
-	icon_state = "wooden_chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "wooden_chair_preview"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
 "js" = (
 /obj/structure/bed/chair/wood/walnut{
-	icon_state = "wooden_chair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "wooden_chair_preview"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
@@ -4551,8 +4577,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -4608,9 +4634,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -4622,16 +4648,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
 "jC" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/open,
@@ -4655,8 +4681,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -4680,8 +4706,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
@@ -4699,15 +4725,15 @@
 "jJ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "jK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -4724,9 +4750,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -4765,9 +4791,9 @@
 /area/engineering/break_room)
 "jQ" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -4809,9 +4835,9 @@
 /area/engineering/break_room)
 "jT" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4819,16 +4845,16 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "jU" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4841,8 +4867,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -4919,8 +4945,8 @@
 /area/civilian/lounge)
 "kg" = (
 /obj/structure/bed/chair/wood/walnut{
-	icon_state = "wooden_chair_preview";
-	dir = 1
+	dir = 1;
+	icon_state = "wooden_chair_preview"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
@@ -4971,8 +4997,8 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -4983,8 +5009,8 @@
 /area/command/headquarters)
 "kp" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -4997,9 +5023,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHWEST)";
+	dir = 9;
 	icon_state = "warning";
-	dir = 9
+	tag = "icon-warning (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
@@ -5019,6 +5045,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "kt" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/teleporter)
 "ku" = (
@@ -5049,8 +5079,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/item/modular_computer/telescreen/preset/generic{
 	pixel_y = 26
@@ -5111,8 +5141,8 @@
 "kF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -5124,8 +5154,8 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -5150,9 +5180,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5169,13 +5199,13 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5186,8 +5216,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/machinery/computer/general_air_control/large_tank_control{
+	input_tag = "d2_c_chamber_in";
+	name = "Chamber Gas Control";
+	output_tag = "d2_c_chamber_out";
+	sensors = list("d2_c_chamber_sensor" = "Combustion Chamber")
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5202,9 +5235,13 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5219,9 +5256,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
@@ -5270,8 +5307,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -5290,8 +5327,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5311,8 +5348,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5325,7 +5362,6 @@
 	req_access = list("ACCESS_ENGINEERING")
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -5335,8 +5371,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5349,13 +5385,13 @@
 	tag = "icon-direction_eng (WEST)"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -5366,8 +5402,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5388,13 +5424,13 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -5406,12 +5442,12 @@
 /area/civilian/dorms)
 "kZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -5437,9 +5473,9 @@
 /area/civilian/dorms)
 "lb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5451,9 +5487,9 @@
 /area/civilian/dorms)
 "lc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5467,9 +5503,9 @@
 /area/civilian/dorms)
 "ld" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -5480,9 +5516,9 @@
 "le" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5491,14 +5527,14 @@
 /area/civilian/dorms)
 "lf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5512,14 +5548,14 @@
 	name = "Dorms"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5531,12 +5567,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -5564,9 +5600,9 @@
 /area/civilian/lounge)
 "ll" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
@@ -5574,13 +5610,13 @@
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/board,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
 "lo" = (
-/obj/item/stack/material/wood/ten,
+/obj/item/stack/material/wood/walnut/ten,
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
 "lp" = (
@@ -5646,8 +5682,8 @@
 	pixel_x = -25
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled,
@@ -5682,9 +5718,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "TeleporterHub";
@@ -5749,25 +5785,25 @@
 /area/command/captain)
 "lE" = (
 /obj/item/modular_computer/console/preset/nervacommand{
-	tag = "icon-console (WEST)";
+	dir = 8;
 	icon_state = "console";
-	dir = 8
+	tag = "icon-console (WEST)"
 	},
 /obj/item/weapon/card/id/captains_spare,
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
 "lF" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "lG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -5807,8 +5843,8 @@
 /area/engineering/fdengine)
 "lK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -5857,9 +5893,9 @@
 /area/engineering/break_room)
 "lQ" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5907,18 +5943,18 @@
 	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "lW" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -5927,9 +5963,9 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/hallway/aft/second_deck)
@@ -5956,8 +5992,8 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
@@ -6000,8 +6036,8 @@
 /area/civilian/lounge)
 "mi" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-18";
-	icon_state = "plant-18"
+	icon_state = "plant-18";
+	tag = "icon-plant-18"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -6009,9 +6045,9 @@
 	pixel_x = 24
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
@@ -6034,8 +6070,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -6099,13 +6135,13 @@
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
@@ -6120,8 +6156,8 @@
 /area/command/captain)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
@@ -6133,6 +6169,10 @@
 	c_tag = "Captain's Office";
 	dir = 1;
 	icon_state = "camera"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
@@ -6186,6 +6226,11 @@
 	icon_state = "1-4";
 	tag = ""
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "mB" = (
@@ -6234,6 +6279,12 @@
 /obj/machinery/camera/network/engineering{
 	c_tag = "Auxiliary Engine Bay";
 	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "cChamber1pV";
+	name = "combustion chamber vent control";
+	pixel_y = -24
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -6322,9 +6373,9 @@
 /area/maintenance/second_deck/afp)
 "mJ" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/engineering/break_room)
@@ -6398,9 +6449,9 @@
 	icon_state = "camera"
 	},
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /obj/structure/sign/deck/second{
 	dir = 4;
@@ -6409,17 +6460,17 @@
 	tag = "icon-deck-2 (EAST)"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "mS" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/sign/directions/medical{
 	pixel_x = 32
@@ -6440,27 +6491,27 @@
 "mV" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (EAST)";
+	dir = 4;
 	icon_state = "down-supply";
-	dir = 4
+	tag = "icon-down-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "down-scrubbers";
-	dir = 4
+	tag = "icon-down-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
 /area/maintenance/second_deck/central)
 "mW" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6474,20 +6525,20 @@
 /area/maintenance/second_deck/central)
 "mX" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	tag = "icon-up-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "up-scrubbers";
-	dir = 8
+	tag = "icon-up-scrubbers (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	tag = "icon-up-supply (WEST)";
+	dir = 8;
 	icon_state = "up-supply";
-	dir = 8
+	tag = "icon-up-supply (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/central)
@@ -6497,8 +6548,8 @@
 /area/maintenance/second_deck/central)
 "mZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/lapvend,
 /turf/simulated/floor/carpet/blue2,
@@ -6609,9 +6660,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
@@ -6621,21 +6672,21 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/carpet,
 /area/command/headquarters)
 "nq" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/hallway/fore/second_deck)
@@ -6679,8 +6730,8 @@
 /area/command/teleporter)
 "nt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -6728,8 +6779,8 @@
 /area/command/fobedroom)
 "nz" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/reinforced,
@@ -6805,9 +6856,9 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -6867,8 +6918,8 @@
 /area/civilian/dorms)
 "nP" = (
 /obj/structure/bed/chair/wood/walnut{
-	icon_state = "wooden_chair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "wooden_chair_preview"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
@@ -6885,8 +6936,8 @@
 /area/civilian/dorms)
 "nR" = (
 /obj/structure/bed/chair/wood/walnut{
-	icon_state = "wooden_chair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "wooden_chair_preview"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
@@ -6909,8 +6960,8 @@
 "nU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -6955,8 +7006,8 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
@@ -7104,9 +7155,9 @@
 /area/command/fobedroom)
 "ot" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light/small,
@@ -7115,54 +7166,54 @@
 /area/engineering/fdengine)
 "ou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "ov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Maintenance";
@@ -7171,44 +7222,44 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
 "ox" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
 "oy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/meter,
@@ -7216,9 +7267,9 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
@@ -7228,23 +7279,23 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
 "oA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -7255,14 +7306,14 @@
 /area/engineering/atmospherics)
 "oB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/camera/network/engineering{
@@ -7280,14 +7331,14 @@
 "oD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -7300,32 +7351,32 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "oF" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
@@ -7335,9 +7386,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -7348,9 +7399,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7366,9 +7417,9 @@
 /area/engineering/break_room)
 "oJ" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7395,9 +7446,9 @@
 	pixel_y = 0
 	},
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -7490,8 +7541,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -7528,38 +7579,42 @@
 	tag = ""
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "oY" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "oZ" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-22";
-	icon_state = "plant-22"
+	icon_state = "plant-22";
+	tag = "icon-plant-22"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "pa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/carpet/purple,
 /area/command/fobedroom)
 "pb" = (
@@ -7614,8 +7669,8 @@
 /area/engineering/atmospherics)
 "pj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7674,8 +7729,8 @@
 /area/engineering/break_room)
 "pq" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7688,9 +7743,9 @@
 /area/engineering/break_room)
 "ps" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (EAST)";
+	dir = 4;
 	icon_state = "corner_white";
-	dir = 4
+	tag = "icon-corner_white (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -7701,34 +7756,34 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/door/blast/regular{
-	tag = "icon-pdoor0 (WEST)";
-	name = "engineering security door";
-	icon_state = "pdoor0";
-	dir = 8;
-	opacity = 0;
 	density = 0;
-	id = "Engineering Lockdown"
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Engineering Lockdown";
+	name = "engineering security door";
+	opacity = 0;
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "pu" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "pv" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7739,9 +7794,9 @@
 /area/hallway/aft/second_deck)
 "pw" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -7750,18 +7805,18 @@
 /area/hallway/aft/second_deck)
 "px" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "py" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck Aft Hallway - Bathrooms"
@@ -7770,9 +7825,9 @@
 /area/hallway/aft/second_deck)
 "pz" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/device/radio/intercom{
@@ -7842,8 +7897,8 @@
 /area/hallway/fore/second_deck)
 "pJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -7896,12 +7951,12 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -7932,14 +7987,18 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/catwalk,
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 2 Aft Starboard");
+	location = "Deck 2 Fore Starboard"
+	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "pV" = (
@@ -7949,14 +8008,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -7974,19 +8033,19 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/light/broken{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8028,14 +8087,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8047,8 +8106,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8101,8 +8160,8 @@
 /area/command/bridge)
 "qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8115,8 +8174,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -8135,15 +8194,15 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
 "qd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8172,8 +8231,8 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -8187,8 +8246,8 @@
 /area/command/fobedroom)
 "qf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8197,8 +8256,8 @@
 /area/command/fobedroom)
 "qg" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet/purple,
 /area/command/fobedroom)
@@ -8216,17 +8275,17 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmospherics)
 "qk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -8267,18 +8326,18 @@
 "qo" = (
 /obj/machinery/vending/cola,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "qp" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -8286,9 +8345,9 @@
 "qq" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -8298,9 +8357,9 @@
 /area/engineering/break_room)
 "qr" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/industrial/outline/orange,
@@ -8308,9 +8367,9 @@
 /area/engineering/break_room)
 "qs" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -8321,9 +8380,9 @@
 /area/engineering/break_room)
 "qt" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -8377,9 +8436,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8444,25 +8503,25 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "qE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "qF" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8501,16 +8560,16 @@
 /area/hallway/fore/second_deck)
 "qL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
 "qM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8529,15 +8588,15 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
 "qO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8562,8 +8621,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -8603,9 +8662,9 @@
 /area/command/bridge)
 "qY" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "Captain's Office Staircase";
@@ -8613,11 +8672,11 @@
 	icon_state = "camera"
 	},
 /obj/machinery/door/blast/regular/open{
-	tag = "icon-pdoor0 (WEST)";
-	name = "Bridge Lockdown";
-	icon_state = "pdoor0";
 	dir = 8;
-	id = "bridgelock"
+	icon_state = "pdoor0";
+	id = "bridgelock";
+	name = "Bridge Lockdown";
+	tag = "icon-pdoor0 (WEST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -8628,16 +8687,16 @@
 /area/command/bridge)
 "qZ" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/door/blast/regular/open{
-	tag = "icon-pdoor0 (WEST)";
-	name = "Bridge Lockdown";
-	icon_state = "pdoor0";
 	dir = 8;
-	id = "bridgelock"
+	icon_state = "pdoor0";
+	id = "bridgelock";
+	name = "Bridge Lockdown";
+	tag = "icon-pdoor0 (WEST)"
 	},
 /turf/simulated/open,
 /area/command/bridge)
@@ -8653,8 +8712,8 @@
 	dir = 8
 	},
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /turf/simulated/floor/carpet/purple,
 /area/command/fobedroom)
@@ -8673,8 +8732,8 @@
 /area/command/fobedroom)
 "rd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -8686,8 +8745,8 @@
 /area/engineering/atmospherics)
 "re" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -8697,8 +8756,8 @@
 /area/engineering/atmospherics)
 "rf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8712,21 +8771,21 @@
 /area/engineering/atmospherics)
 "rg" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmospherics)
@@ -8739,9 +8798,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Maintenance";
@@ -8759,9 +8818,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -8769,14 +8828,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -8785,9 +8844,9 @@
 	sortType = "Atmospherics"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -8909,6 +8968,7 @@
 /area/logistics/primtool)
 "rA" = (
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/logistics/primtool)
 "rB" = (
@@ -8922,12 +8982,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
 "rC" = (
 /obj/machinery/door/airlock/glass{
 	name = "General Storage"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
 "rD" = (
@@ -8989,8 +9051,8 @@
 /area/engineering/atmospherics)
 "rJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -9009,12 +9071,12 @@
 /area/maintenance/second_deck/afs)
 "rM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
@@ -9033,23 +9095,23 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Second Deck Telecommunications Relay";
@@ -9060,24 +9122,24 @@
 "rO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "down-scrubbers";
-	dir = 8
+	tag = "icon-down-scrubbers (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/fuel{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (WEST)";
+	dir = 8;
 	icon_state = "down-supply";
-	dir = 8
+	tag = "icon-down-supply (WEST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "32-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "32-8"
 	},
 /turf/simulated/open,
 /area/maintenance/second_deck/afs)
@@ -9130,8 +9192,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/bath)
@@ -9148,9 +9210,9 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9202,8 +9264,8 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 28;
@@ -9228,8 +9290,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9245,14 +9307,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9267,20 +9329,20 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9297,14 +9359,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9332,20 +9394,22 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 8;
+	name = "Journalists Office";
+	sortType = "Journalists Office"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -9359,14 +9423,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9381,9 +9445,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9401,9 +9465,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9418,26 +9482,21 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -9448,14 +9507,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -9470,14 +9529,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9603,8 +9662,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -9630,9 +9689,9 @@
 /area/maintenance/second_deck/fs)
 "sF" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -9698,9 +9757,9 @@
 /area/maintenance/second_deck/afs)
 "sP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9710,17 +9769,17 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "sQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9731,17 +9790,17 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "sR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9757,9 +9816,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -9769,27 +9828,27 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "sT" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -9820,8 +9879,8 @@
 /area/civilian/bath)
 "sW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -9835,8 +9894,8 @@
 "sY" = (
 /obj/machinery/vending/urist/coatdispenser,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -9892,9 +9951,9 @@
 /area/maintenance/second_deck/afs)
 "ti" = (
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb1 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb1";
-	dir = 1
+	tag = "icon-cobweb1 (NORTH)"
 	},
 /obj/structure/table/rack,
 /obj/random/maintenance,
@@ -9920,43 +9979,37 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "tl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "tm" = (
 /obj/machinery/atmospherics/valve/shutoff{
-	tag = "icon-map_vclamp0 (WEST)";
+	dir = 8;
 	icon_state = "map_vclamp0";
-	dir = 8
+	tag = "icon-map_vclamp0 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "tn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -9994,8 +10047,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -10009,18 +10062,18 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/primtool)
@@ -10031,14 +10084,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10053,14 +10106,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10081,14 +10134,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10126,17 +10179,17 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/landmark/start{
 	name = "Assistant"
@@ -10150,9 +10203,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10178,9 +10231,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10203,9 +10256,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10223,19 +10276,19 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -10310,9 +10363,9 @@
 /area/engineering/atmospherics)
 "tK" = (
 /obj/structure/cable/yellow{
-	icon_state = "16-0";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "16-0"
 	},
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/cable/yellow{
@@ -10320,19 +10373,19 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	tag = "icon-up-supply (WEST)";
+	dir = 8;
 	icon_state = "up-supply";
-	dir = 8
+	tag = "icon-up-supply (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	tag = "icon-up-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "up-scrubbers";
-	dir = 8
+	tag = "icon-up-scrubbers (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -10345,8 +10398,8 @@
 "tM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/bath)
@@ -10355,8 +10408,8 @@
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -10471,9 +10524,9 @@
 /area/logistics/primtool)
 "ud" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -10486,8 +10539,8 @@
 /area/logistics/primtool)
 "uf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -10527,8 +10580,8 @@
 /area/engineering/atmospherics)
 "um" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/meter,
 /obj/structure/disposalpipe/segment{
@@ -10589,8 +10642,8 @@
 "uq" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
@@ -10635,25 +10688,25 @@
 /area/engineering/atmospherics)
 "uw" = (
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
-	name = "Carbon Dioxide Supply Control";
-	icon_state = "computer";
 	dir = 8;
 	frequency = 1441;
-	sensors = list("co2_sensor" = "Tank");
+	icon_state = "computer";
 	input_tag = "co2_in";
-	output_tag = "co2_out"
+	name = "Carbon Dioxide Supply Control";
+	output_tag = "co2_out";
+	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -10661,8 +10714,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/plating,
@@ -10687,8 +10740,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Bathrooms";
@@ -10703,9 +10756,9 @@
 /area/civilian/bath)
 "uB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10726,9 +10779,9 @@
 	name = "Unisex Restrooms"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10740,9 +10793,9 @@
 /area/civilian/personal)
 "uD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10758,8 +10811,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -10799,8 +10852,8 @@
 "uJ" = (
 /obj/structure/bed/chair/couch/right/black,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/observatory)
@@ -10826,8 +10879,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/observatory)
@@ -10951,8 +11004,8 @@
 /area/maintenance/second_deck/afs)
 "vc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Atmospherics - Entry";
@@ -10967,8 +11020,8 @@
 /area/engineering/atmospherics)
 "vd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -10981,15 +11034,15 @@
 /area/engineering/atmospherics)
 "vf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "vg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled,
@@ -11002,8 +11055,8 @@
 /area/engineering/atmospherics)
 "vi" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11032,12 +11085,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11126,8 +11179,8 @@
 	icon_state = "camera"
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -11162,22 +11215,22 @@
 /area/civilian/observatory)
 "vy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/observatory)
 "vz" = (
 /obj/item/stack/tile/floor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/observatory)
@@ -11189,13 +11242,13 @@
 /area/civilian/observatory)
 "vB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/escape_pod1/station)
@@ -11204,9 +11257,9 @@
 /area/shuttle/escape_pod1/station)
 "vD" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (WEST)";
+	dir = 8;
 	icon_state = "shuttlechair";
-	dir = 8
+	tag = "icon-shuttlechair (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/escape_pod1/station)
@@ -11229,8 +11282,8 @@
 /area/maintenance/second_deck/fs)
 "vI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
@@ -11284,16 +11337,16 @@
 "vQ" = (
 /obj/effect/floor_decal/corner/orange,
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11385,9 +11438,9 @@
 /area/civilian/observatory)
 "wc" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/escape_pod1/station)
@@ -11422,8 +11475,8 @@
 /area/maintenance/second_deck/fs)
 "wj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -11433,8 +11486,8 @@
 /area/maintenance/second_deck/afs)
 "wk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11487,8 +11540,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -11499,16 +11552,16 @@
 /area/engineering/atmospherics)
 "wo" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "wp" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled,
@@ -11536,8 +11589,8 @@
 "wt" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11554,16 +11607,16 @@
 /area/engineering/atmospherics)
 "wv" = (
 /obj/effect/floor_decal/corner/orange{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
@@ -11598,8 +11651,8 @@
 /area/civilian/bath)
 "wy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -11621,9 +11674,9 @@
 	name = "Showers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11641,18 +11694,18 @@
 /area/civilian/bath)
 "wA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -11726,9 +11779,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/civilian/personal)
@@ -11770,9 +11823,9 @@
 /obj/structure/closet,
 /obj/random/maintenance/clean,
 /obj/effect/decal/cleanable/cobweb2{
-	tag = "icon-cobweb2 (NORTH)";
+	dir = 1;
 	icon_state = "cobweb2";
-	dir = 1
+	tag = "icon-cobweb2 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -11833,13 +11886,13 @@
 /area/engineering/atmospherics)
 "wW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /obj/machinery/meter,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -11861,8 +11914,8 @@
 /area/engineering/atmospherics)
 "wZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11885,12 +11938,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11918,8 +11971,8 @@
 /area/engineering/atmospherics)
 "xe" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12017,12 +12070,12 @@
 /area/engineering/atmospherics)
 "xr" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = 28
@@ -12039,8 +12092,8 @@
 /area/engineering/atmospherics)
 "xs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12052,8 +12105,8 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -12078,31 +12131,31 @@
 "xv" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "xw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "xx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "xy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled,
@@ -12122,17 +12175,17 @@
 /area/engineering/atmospherics)
 "xB" = (
 /obj/effect/floor_decal/corner/orange{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/white,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12176,8 +12229,8 @@
 /area/civilian/personal)
 "xF" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper_0";
-	dir = 4
+	dir = 4;
+	icon_state = "sleeper_0"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/escape_pod1/station)
@@ -12240,8 +12293,8 @@
 /area/engineering/atmospherics)
 "xK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/meter,
@@ -12253,8 +12306,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12308,8 +12361,8 @@
 /area/engineering/atmospherics)
 "xS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12340,12 +12393,12 @@
 /area/engineering/atmospherics)
 "xY" = (
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
@@ -12356,8 +12409,8 @@
 	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12399,8 +12452,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -12419,14 +12472,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -12463,17 +12516,17 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -12498,8 +12551,8 @@
 /area/maintenance/second_deck/fs)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/structure/sign/warning/compressed_gas,
 /turf/simulated/wall/r_wall/prepainted,
@@ -12509,8 +12562,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12523,8 +12576,8 @@
 /area/engineering/atmospherics)
 "yl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12563,8 +12616,8 @@
 "yq" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12592,12 +12645,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12649,9 +12702,9 @@
 /area/maintenance/second_deck/afs)
 "yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12670,9 +12723,9 @@
 /area/maintenance/second_deck/afs)
 "yy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12716,14 +12769,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -12739,19 +12792,19 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -12780,27 +12833,27 @@
 "yG" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/second_deck/fs)
 "yH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "yI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12862,8 +12915,8 @@
 /area/engineering/atmospherics)
 "yM" = (
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12885,8 +12938,8 @@
 "yN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12901,8 +12954,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12974,8 +13027,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12987,22 +13040,22 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "yX" = (
 /obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -13043,8 +13096,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/vehicle_part/random,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-stickyweb2";
-	icon_state = "stickyweb2"
+	icon_state = "stickyweb2";
+	tag = "icon-stickyweb2"
 	},
 /obj/random/drinkbottle,
 /obj/random/smokes,
@@ -13080,8 +13133,8 @@
 /area/engineering/atmospherics)
 "zi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -13116,8 +13169,8 @@
 /area/engineering/atmospherics)
 "zl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	icon_state = "intact";
-	dir = 9
+	dir = 9;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -13157,9 +13210,9 @@
 /area/engineering/atmospherics)
 "zr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -13208,9 +13261,9 @@
 /area/maintenance/second_deck/afs)
 "zA" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -13342,9 +13395,9 @@
 "zR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
@@ -13365,9 +13418,9 @@
 "zU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/comfy/brown{
-	tag = "icon-comfychair_preview (WEST)";
+	dir = 8;
 	icon_state = "comfychair_preview";
-	dir = 8
+	tag = "icon-comfychair_preview (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
@@ -13379,16 +13432,16 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
 "Ah" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -13402,8 +13455,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
@@ -13418,9 +13471,9 @@
 	req_access = list("ACCESS_ENGINEERING")
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
@@ -13447,8 +13500,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/black{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -13495,9 +13548,9 @@
 /area/maintenance/second_deck/afp)
 "AV" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -13590,9 +13643,9 @@
 /area/security/prison)
 "BM" = (
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
+	dir = 4;
 	icon_state = "chapel";
-	dir = 4
+	tag = "icon-chapel (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -13616,14 +13669,14 @@
 "BW" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
@@ -13635,15 +13688,17 @@
 /turf/simulated/wall/prepainted,
 /area/civilian/counselor)
 "Ch" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/polarized/full{
+	id = "journalist"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/civilian/exercise)
+/area/civilian/journalist)
 "Cl" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -13663,12 +13718,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 6
+	dir = 6;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/counselor)
@@ -13688,9 +13743,9 @@
 /obj/item/seeds/tomatoseed,
 /obj/item/device/analyzer/plant_analyzer,
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -13744,6 +13799,9 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"Dr" = (
+/turf/simulated/floor/carpet/blue2,
+/area/civilian/journalist)
 "Dw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13751,19 +13809,19 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -13802,14 +13860,14 @@
 /area/maintenance/second_deck/fs)
 "DP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -13829,22 +13887,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "DQ" = (
-/obj/item/weapon/storage/mirror{
-	pixel_x = 28
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/hygiene/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
-	icon_state = "bordercolor";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
 "DR" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -13874,8 +13924,8 @@
 /obj/structure/table/woodentable/walnut,
 /obj/item/weapon/flame/candle,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -13886,9 +13936,9 @@
 /area/chapel)
 "Ed" = (
 /obj/structure/window/reinforced/tinted{
-	tag = "icon-window (EAST)";
+	dir = 4;
 	icon_state = "window";
-	dir = 4
+	tag = "icon-window (EAST)"
 	},
 /obj/item/weapon/stool/padded,
 /obj/item/device/radio/intercom{
@@ -13974,8 +14024,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
@@ -13985,9 +14035,9 @@
 /area/maintenance/second_deck/fp)
 "Ez" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -14000,8 +14050,8 @@
 /area/security/prison)
 "EK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
 "EM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
@@ -14020,6 +14070,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "EP" = (
@@ -14046,8 +14097,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -14059,8 +14110,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
@@ -14069,9 +14120,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Chapel"
@@ -14080,21 +14131,29 @@
 /turf/simulated/floor/carpet,
 /area/chapel)
 "Ff" = (
-/obj/machinery/door/airlock/glass{
-	name = "Fitness Room"
+/obj/machinery/door/airlock{
+	name = "Journalists Office"
 	},
 /obj/effect/floor_decal/corner/black/mono,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/area/civilian/journalist)
 "Fg" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -14106,8 +14165,8 @@
 /obj/structure/table/standard,
 /obj/machinery/microwave,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -14136,22 +14195,27 @@
 /area/maintenance/second_deck/afp)
 "Fz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
 "FD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/cable,
 /obj/machinery/door/blast/regular{
@@ -14175,9 +14239,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -14199,8 +14263,8 @@
 	name = "Auxiliary Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14224,17 +14288,17 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
 "Gk" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/status_display{
 	density = 0;
@@ -14251,8 +14315,8 @@
 /area/civilian/lounge)
 "Gv" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /obj/item/weapon/stool,
 /obj/machinery/light{
@@ -14262,14 +14326,14 @@
 /area/chapel)
 "Gy" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -14297,31 +14361,53 @@
 "GE" = (
 /obj/structure/ladder/updown,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "GF" = (
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
+	dir = 1;
 	icon_state = "corner_white_three_quarters";
-	dir = 1
+	tag = "icon-corner_white_three_quarters (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "GG" = (
-/obj/item/weapon/storage/mirror{
-	pixel_x = 28
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
-	icon_state = "bordercolor";
+/obj/structure/filingcabinet/wallcabinet{
+	pixel_x = 30
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
+"GK" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers";
+	tag = "icon-intact-scrubbers (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 2 Fore Port");
+	location = "Deck 2 Aft Port"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "GO" = (
 /obj/effect/shuttle_landmark/nerva/deck2/hadrian,
 /turf/space,
@@ -14360,9 +14446,9 @@
 /area/security/prison)
 "GX" = (
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
+	dir = 4;
 	icon_state = "chapel";
-	dir = 4
+	tag = "icon-chapel (EAST)"
 	},
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
@@ -14370,9 +14456,9 @@
 "Hh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/camera/network/prison{
 	c_tag = "Prison Dorms";
@@ -14382,8 +14468,8 @@
 /area/security/prison)
 "Hi" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 8
+	dir = 8;
+	icon_state = "chapel"
 	},
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
@@ -14409,28 +14495,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "Hu" = (
-/obj/structure/fitness/punchingbag,
-/obj/effect/floor_decal/corner/black/border,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/machinery/requests_console{
+	department = "Journalist's Desk";
+	departmentType = 5;
+	name = "Journalists RC";
+	pixel_y = -30
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/civilian/journalist)
 "Hy" = (
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
+	dir = 4;
 	icon_state = "chapel";
-	dir = 4
+	tag = "icon-chapel (EAST)"
 	},
 /obj/structure/bed/chair/urist/bench/bench1/right{
-	icon_state = "benchright";
-	dir = 1
+	dir = 1;
+	icon_state = "benchright"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "HA" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -14446,9 +14536,9 @@
 /area/engineering/substation/atmos)
 "HB" = (
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
+	dir = 4;
 	icon_state = "chapel";
-	dir = 4
+	tag = "icon-chapel (EAST)"
 	},
 /obj/item/weapon/stool,
 /obj/machinery/camera/network/second_deck{
@@ -14483,9 +14573,9 @@
 	name = "Boarding Armoury Access"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
@@ -14567,8 +14657,8 @@
 /area/hallway/aft/second_deck)
 "IP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14583,9 +14673,9 @@
 /area/maintenance/second_deck/afs)
 "IT" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (NORTH)";
+	dir = 1;
 	icon_state = "corner_white";
-	dir = 1
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -14609,16 +14699,17 @@
 	pixel_x = 28;
 	tag = "icon-intercom (WEST)"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "IW" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /obj/structure/bed/chair/urist/bench/bench1/left{
-	icon_state = "benchleft";
-	dir = 1
+	dir = 1;
+	icon_state = "benchleft"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -14631,6 +14722,16 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "Jg" = (
@@ -14640,14 +14741,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -14682,27 +14783,22 @@
 /area/security/prison)
 "Jm" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "Jv" = (
-/obj/structure/fitness/weightlifter,
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
-	icon_state = "bordercolor";
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/machinery/photocopier,
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
 "Jy" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 8
+	dir = 8;
+	icon_state = "chapel"
 	},
 /obj/item/weapon/stool,
 /obj/machinery/light,
@@ -14719,17 +14815,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
 "JG" = (
-/obj/structure/fitness/weightlifter,
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
-	icon_state = "bordercolor";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
-	icon_state = "bordercolor";
-	dir = 1
-	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	dir = 2;
@@ -14738,14 +14823,16 @@
 	pixel_y = 28
 	},
 /obj/machinery/camera/network/second_deck{
-	c_tag = "Fitness Room"
+	c_tag = "Journalists Office"
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
 "JL" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 8
+	dir = 8;
+	icon_state = "chapel"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -14782,8 +14869,8 @@
 "Ka" = (
 /obj/machinery/power/terminal,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -14812,9 +14899,9 @@
 "Kg" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -14847,10 +14934,11 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
 "Kz" = (
@@ -14858,8 +14946,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
@@ -14884,8 +14972,8 @@
 /obj/effect/floor_decal/corner/red/three_quarters,
 /obj/machinery/light,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -14901,9 +14989,9 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/space,
 /area/security/prison)
@@ -14945,11 +15033,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
+"La" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/weapon/material/ashtray/wood,
+/obj/item/clothing/mask/smokable/cigarette/cigar,
+/obj/machinery/newscaster{
+	pixel_x = 28
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/civilian/journalist)
 "Lc" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/polarized/full{
+	id = "journalist"
+	},
 /turf/simulated/floor/plating,
-/area/civilian/exercise)
+/area/civilian/journalist)
 "Le" = (
 /obj/item/weapon/tank/emergency/oxygen/double,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -14981,9 +15080,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
@@ -15030,12 +15129,12 @@
 /area/security/prison)
 "LC" = (
 /obj/structure/bed/chair/wood/walnut{
-	icon_state = "wooden_chair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "wooden_chair_preview"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
@@ -15128,8 +15227,8 @@
 /area/maintenance/second_deck/fs)
 "LY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -15152,12 +15251,12 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
@@ -15166,20 +15265,11 @@
 /turf/simulated/floor/airless,
 /area/security/prison)
 "Mi" = (
-/obj/machinery/vending/fitness,
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
-	icon_state = "bordercolor";
-	dir = 4
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/black/border,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/turf/simulated/floor/carpet/blue2,
+/area/civilian/journalist)
 "Mn" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/breakerbox/activated{
@@ -15192,12 +15282,17 @@
 	dir = 1;
 	icon_state = "map_vent_out"
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/structure/table/woodentable/walnut,
+/obj/item/device/camera,
+/obj/item/weapon/pen,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/material/clipboard,
+/turf/simulated/floor/carpet/blue2,
+/area/civilian/journalist)
 "Mq" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/dark,
@@ -15248,21 +15343,25 @@
 /turf/simulated/floor/carpet,
 /area/chapel)
 "MG" = (
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
-	icon_state = "bordercolor";
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
 "MH" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/red,
@@ -15279,8 +15378,8 @@
 /area/maintenance/second_deck/fp)
 "MQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15298,8 +15397,8 @@
 /area/hallway/aft/second_deck)
 "MV" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15380,9 +15479,9 @@
 /area/security/prison)
 "Nu" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/security/prison)
@@ -15401,9 +15500,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/black/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -15434,9 +15533,9 @@
 	req_access = list("ACCESS_ENGINEERING")
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -15452,9 +15551,9 @@
 "NT" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -15471,12 +15570,12 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -15496,12 +15595,13 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
 "NY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15517,12 +15617,13 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
 "Ob" = (
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -15560,12 +15661,12 @@
 /area/logistics/auxtool)
 "Op" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -15653,9 +15754,9 @@
 "Pg" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15690,9 +15791,9 @@
 /area/hallway/aft/second_deck)
 "Ps" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	tag = "icon-corner_white (WEST)";
+	dir = 8;
 	icon_state = "corner_white";
-	dir = 8
+	tag = "icon-corner_white (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -15709,8 +15810,8 @@
 /area/hallway/fore/second_deck)
 "PA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15727,8 +15828,8 @@
 "PC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
@@ -15747,17 +15848,17 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
 "PP" = (
 /obj/structure/window/reinforced/tinted{
-	tag = "icon-window (WEST)";
+	dir = 8;
 	icon_state = "window";
-	dir = 8
+	tag = "icon-window (WEST)"
 	},
 /obj/item/weapon/stool/padded,
 /obj/item/device/radio/intercom{
@@ -15781,9 +15882,9 @@
 /area/civilian/entertainer)
 "PT" = (
 /obj/structure/bed/chair/urist/shuttle{
-	tag = "icon-shuttlechair (EAST)";
+	dir = 4;
 	icon_state = "shuttlechair";
-	dir = 4
+	tag = "icon-shuttlechair (EAST)"
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32;
@@ -15820,14 +15921,14 @@
 /area/hallway/aft/second_deck)
 "Qd" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/civilian/exercise)
+/area/civilian/journalist)
 "Qg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
@@ -15836,9 +15937,9 @@
 	sortType = "Captain"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
@@ -15847,8 +15948,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -15884,31 +15985,36 @@
 /area/engineering/substation/second_deck)
 "Qv" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 8
+	dir = 8;
+	icon_state = "chapel"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "Qw" = (
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (EAST)";
-	icon_state = "bordercolor";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (NORTH)";
-	icon_state = "bordercolor";
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/closet,
+/obj/item/device/camera/tvcamera,
+/obj/item/device/camera_film,
+/obj/item/device/camera_film,
+/obj/item/weapon/storage/briefcase,
+/obj/item/weapon/folder,
+/obj/item/device/taperecorder,
+/obj/item/device/tape,
+/obj/item/clothing/suit/storage/urist/coat/journocoat,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
 "QE" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list("ACCESS_MAINT")
@@ -15920,9 +16026,9 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -15958,12 +16064,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
@@ -15997,13 +16103,9 @@
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
 "QV" = (
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
-	icon_state = "bordercolor";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
 "QW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -16020,8 +16122,8 @@
 /area/civilian/entertainer)
 "Ri" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-stickyweb2";
-	icon_state = "stickyweb2"
+	icon_state = "stickyweb2";
+	tag = "icon-stickyweb2"
 	},
 /obj/structure/closet/crate,
 /obj/random/maintenance,
@@ -16037,8 +16139,8 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-t"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/wood/walnut,
@@ -16066,9 +16168,9 @@
 /area/hallway/aft/second_deck)
 "RC" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/blast/regular{
@@ -16104,8 +16206,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
@@ -16133,16 +16235,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "RT" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
@@ -16160,9 +16262,9 @@
 /area/maintenance/second_deck/fs)
 "Sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16177,15 +16279,15 @@
 /area/hallway/fore/second_deck)
 "Sh" = (
 /obj/item/modular_computer/console/preset/library{
-	icon_state = "console";
-	dir = 1
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
 "Sn" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/bed/chair{
 	dir = 8
@@ -16196,45 +16298,45 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Sz" = (
+/obj/machinery/button/windowtint{
+	id = "journalist";
+	pixel_x = -10
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/maintenance/second_deck/fs)
 "SF" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/reinforced,
 /area/maintenance/second_deck/fp)
 "SS" = (
 /obj/structure/bed/chair/wood/walnut{
-	icon_state = "wooden_chair_preview";
-	dir = 1
+	dir = 1;
+	icon_state = "wooden_chair_preview"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
 "ST" = (
 /obj/structure/hygiene/shower{
-	icon_state = "shower";
 	dir = 8;
+	icon_state = "shower";
 	pixel_x = 0;
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
 "SX" = (
-/obj/structure/fitness/punchingbag,
-/obj/effect/floor_decal/corner/black/border,
-/obj/effect/floor_decal/corner/black/border{
-	tag = "icon-bordercolor (WEST)";
-	icon_state = "bordercolor";
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/old_tile,
-/area/civilian/exercise)
+/turf/simulated/floor/carpet/blue2,
+/area/civilian/journalist)
 "SY" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -16253,13 +16355,13 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -16270,8 +16372,8 @@
 /area/maintenance/second_deck/afp)
 "TA" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -16303,15 +16405,16 @@
 	name = "Teleporter Blast Door Control"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (WEST)";
+	dir = 8;
 	icon_state = "warning";
-	dir = 8
+	tag = "icon-warning (WEST)"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
 "TP" = (
@@ -16366,8 +16469,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
@@ -16400,9 +16503,9 @@
 /obj/item/seeds/cornseed,
 /obj/item/seeds/tobaccoseed,
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -16411,8 +16514,8 @@
 /area/security/prison)
 "UA" = (
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -16424,8 +16527,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
@@ -16464,9 +16567,9 @@
 /area/maintenance/second_deck/fp)
 "UQ" = (
 /obj/machinery/light_construct{
-	tag = "icon-tube-construct-stage1 (EAST)";
+	dir = 4;
 	icon_state = "tube-construct-stage1";
-	dir = 4
+	tag = "icon-tube-construct-stage1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
@@ -16525,9 +16628,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/teleporter)
@@ -16542,8 +16645,8 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light_construct{
-	icon_state = "tube-construct-stage1";
-	dir = 1
+	dir = 1;
+	icon_state = "tube-construct-stage1"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
@@ -16551,23 +16654,35 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/security/prison)
 "Vw" = (
 /obj/structure/inflatable/door,
 /turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
+"VK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 1 Port Docks");
+	location = "Deck 2 Aft Starboard"
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
 "VN" = (
 /obj/effect/decal/cleanable/blood,
@@ -16578,8 +16693,8 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
@@ -16591,12 +16706,13 @@
 /obj/machinery/door/morgue{
 	name = "Confessional Booth"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/lino,
 /area/civilian/counselor)
 "Wd" = (
 /obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -16605,12 +16721,12 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
@@ -16707,9 +16823,9 @@
 /area/civilian/counselor)
 "WN" = (
 /obj/machinery/light_construct{
-	tag = "icon-tube-construct-stage1 (EAST)";
+	dir = 4;
 	icon_state = "tube-construct-stage1";
-	dir = 4
+	tag = "icon-tube-construct-stage1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
@@ -16746,8 +16862,8 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -16770,13 +16886,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
@@ -16809,9 +16925,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -16825,9 +16941,9 @@
 "Xt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -16855,8 +16971,8 @@
 /area/civilian/entertainer)
 "XJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16881,9 +16997,9 @@
 "XM" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /obj/machinery/door/blast/regular{
 	dir = 2;
@@ -16962,8 +17078,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
@@ -16979,8 +17095,8 @@
 "Yl" = (
 /obj/random/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17002,27 +17118,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
-"Yo" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list("ACCESS_MAINT")
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plating,
-/area/civilian/exercise)
 "Yp" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
 "Yt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -17035,9 +17138,9 @@
 	layer = 2.9
 	},
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -17048,8 +17151,8 @@
 "YN" = (
 /obj/item/weapon/caution/cone,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17068,9 +17171,9 @@
 /area/logistics/auxtool)
 "YO" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -17078,9 +17181,9 @@
 "YW" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
@@ -17089,8 +17192,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/newscaster{
 	hitstaken = 1;
@@ -17098,9 +17201,9 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/black{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -17122,8 +17225,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/prison)
@@ -17132,8 +17235,8 @@
 /obj/item/weapon/bedsheet,
 /obj/item/weapon/broken_bottle,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 8
+	dir = 8;
+	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -17154,12 +17257,12 @@
 /area/maintenance/second_deck/fs)
 "ZA" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
@@ -17177,6 +17280,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/entertainer)
+"ZJ" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/aft/second_deck)
 "ZK" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
@@ -35077,7 +35184,7 @@ ep
 fa
 fD
 gG
-jY
+fc
 ih
 jg
 jW
@@ -35481,7 +35588,7 @@ er
 bI
 fF
 gG
-ii
+ZJ
 ij
 FI
 FI
@@ -36691,7 +36798,7 @@ BZ
 hC
 hC
 hC
-fJ
+GK
 Ps
 hF
 ik
@@ -36703,7 +36810,7 @@ mR
 jh
 hF
 IT
-qw
+VK
 rp
 sa
 sX
@@ -41155,7 +41262,7 @@ Qd
 JG
 QV
 MG
-QV
+Dr
 SX
 tV
 uN
@@ -41555,11 +41662,11 @@ qJ
 ru
 sp
 tn
-Yo
+Qd
 Qw
 GG
 DQ
-GG
+La
 Mi
 Ch
 ah
@@ -41762,7 +41869,7 @@ sI
 sI
 sI
 sI
-sI
+Sz
 sI
 sI
 sI

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -249,7 +249,7 @@
 "aI" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "security_inner3";
 	locked = 1;
 	name = "External Access";
@@ -298,7 +298,7 @@
 "aL" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "security_outer3";
 	locked = 1;
 	name = "External Access";
@@ -460,7 +460,7 @@
 "aY" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "security_inner3";
 	locked = 1;
 	name = "External Access";
@@ -1542,7 +1542,7 @@
 "dr" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "security_outer";
 	locked = 1;
 	name = "External Access";
@@ -1594,7 +1594,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "security_inner";
 	locked = 1;
 	name = "External Access";
@@ -3870,7 +3870,7 @@
 "hL" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "security_inner2";
 	locked = 1;
 	name = "External Access";
@@ -3936,7 +3936,7 @@
 "hO" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "security_outer2";
 	locked = 1;
 	name = "External Access";
@@ -8325,7 +8325,7 @@
 "pr" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "aft_solar_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -8383,7 +8383,7 @@
 "pt" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "door_locked";
+	icon_state = "closed";
 	id_tag = "aft_solar_inner";
 	locked = 1;
 	name = "Engineering External Access";

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -49,8 +49,8 @@
 /area/hallway/centralfirst)
 "ak" = (
 /obj/structure/sign/warning/docking_area{
-	icon_state = "securearea";
-	dir = 1
+	dir = 1;
+	icon_state = "securearea"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/centralfirst)
@@ -95,8 +95,8 @@
 	req_access = list("ACCESS_EXTERNAL")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -129,8 +129,8 @@
 /area/hallway/centralfirst)
 "at" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -148,8 +148,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -165,24 +165,24 @@
 /area/hallway/centralfirst)
 "ax" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/centralfirst)
 "ay" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "az" = (
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 4
+	dir = 4;
+	icon_state = "handrail"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -240,9 +240,9 @@
 	req_access = list("ACCESS_EXTERNAL")
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -276,9 +276,9 @@
 	id_tag = "security_pump3"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHWEST)";
+	dir = 9;
 	icon_state = "warning";
-	dir = 9
+	tag = "icon-warning (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -289,9 +289,9 @@
 	id_tag = "security_pump3"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -315,9 +315,9 @@
 /area/maintenance/first_deck/afp)
 "aO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -326,31 +326,35 @@
 /area/hallway/centralfirst)
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 1 Starboard Docks");
+	location = "Deck 1 Port Docks"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "aQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -361,13 +365,13 @@
 /area/hallway/centralfirst)
 "aR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -378,13 +382,13 @@
 /area/hallway/centralfirst)
 "aS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Port Hallway - Docking";
@@ -400,9 +404,9 @@
 "aT" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -435,17 +439,17 @@
 /area/hallway/centralfirst)
 "aW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "aX" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -463,8 +467,8 @@
 	req_access = list("ACCESS_EXTERNAL")
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -481,9 +485,9 @@
 	id_tag = "security_pump3"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHWEST)";
+	dir = 10;
 	icon_state = "warning";
-	dir = 10
+	tag = "icon-warning (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -494,9 +498,9 @@
 	id_tag = "security_pump3"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -557,8 +561,8 @@
 /area/hallway/centralfirst)
 "bk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/centralfirst)
@@ -632,9 +636,9 @@
 	icon_state = "intact"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/item/trash/cigbutt/rand,
 /turf/simulated/floor/plating,
@@ -649,8 +653,8 @@
 /area/maintenance/first_deck/central)
 "bx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -669,9 +673,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afp)
@@ -771,9 +775,9 @@
 /area/maintenance/first_deck/afp)
 "bR" = (
 /obj/structure/bed/chair/office/dark{
-	tag = "icon-officechair_preview (WEST)";
+	dir = 8;
 	icon_state = "officechair_preview";
-	dir = 8
+	tag = "icon-officechair_preview (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afp)
@@ -810,9 +814,9 @@
 /area/maintenance/first_deck/central)
 "bX" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (EAST)";
+	dir = 4;
 	icon_state = "warning";
-	dir = 4
+	tag = "icon-warning (EAST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -1077,8 +1081,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
@@ -1166,8 +1170,8 @@
 	pixel_y = 25
 	},
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-t"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/dockingcheckpoint)
@@ -1176,8 +1180,8 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1252,9 +1256,9 @@
 /obj/random/soap,
 /obj/structure/scrap,
 /obj/machinery/light_construct{
-	tag = "icon-tube-construct-stage1 (EAST)";
+	dir = 4;
 	icon_state = "tube-construct-stage1";
-	dir = 4
+	tag = "icon-tube-construct-stage1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/abandonedwarehouse)
@@ -1343,9 +1347,9 @@
 /area/security/dockingcheckpoint)
 "db" = (
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -1369,8 +1373,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated,
 /obj/structure/cable{
@@ -1432,8 +1436,8 @@
 /area/civilian/abandonedwarehouse)
 "dh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -1464,9 +1468,9 @@
 "dm" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/orange{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/solar/main)
@@ -1548,15 +1552,15 @@
 /area/maintenance/first_deck/fp)
 "ds" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "security_pump";
-	tag_exterior_door = "security_outer";
 	frequency = 1379;
 	id_tag = "security_airlock";
-	tag_interior_door = "security_inner";
 	pixel_x = 0;
 	pixel_y = 25;
 	req_access = list("ACCESS_EXTERNAL");
-	tag_chamber_sensor = "security_sensor"
+	tag_airpump = "security_pump";
+	tag_chamber_sensor = "security_sensor";
+	tag_exterior_door = "security_outer";
+	tag_interior_door = "security_inner"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -1585,8 +1589,8 @@
 /area/maintenance/first_deck/fp)
 "du" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -1617,9 +1621,9 @@
 "dw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (WEST)";
+	dir = 8;
 	icon_state = "cobweb1";
-	dir = 8
+	tag = "icon-cobweb1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fp)
@@ -1655,9 +1659,9 @@
 /area/security/dockingcheckpoint)
 "dB" = (
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -1692,8 +1696,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -1794,9 +1798,9 @@
 "dR" = (
 /obj/structure/ladder,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fp)
@@ -1823,8 +1827,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/civilian/first_emergency_storage)
@@ -1876,9 +1880,9 @@
 /area/security/dockingcheckpoint)
 "dY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -1887,13 +1891,13 @@
 /area/security/dockingcheckpoint)
 "dZ" = (
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1906,12 +1910,13 @@
 	req_access = list("ACCESS_SECURITY")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/dockingcheckpoint)
 "eb" = (
@@ -1923,8 +1928,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -2015,8 +2020,8 @@
 "en" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -2032,9 +2037,9 @@
 /area/civilian/first_emergency_storage)
 "ep" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -2148,8 +2153,8 @@
 /area/command/aicore)
 "eC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fp)
@@ -2197,17 +2202,17 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
 "eG" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -2226,8 +2231,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 4
+	dir = 4;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afp)
@@ -2270,15 +2275,15 @@
 /area/hallway/centralfirst)
 "eM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -2291,9 +2296,9 @@
 /area/maintenance/mainsolar)
 "eR" = (
 /obj/structure/cable/orange{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/orange{
@@ -2357,8 +2362,8 @@
 	pixel_y = 23
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 9
+	dir = 9;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -2369,9 +2374,9 @@
 	id_tag = "nuke_shuttle_dock_pump"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -2481,8 +2486,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2492,8 +2497,8 @@
 /area/hallway/centralfirst)
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2506,8 +2511,8 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2517,8 +2522,8 @@
 "fk" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2528,17 +2533,17 @@
 "fl" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -2561,9 +2566,9 @@
 /area/maintenance/first_deck/central)
 "fp" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -2577,8 +2582,8 @@
 /area/maintenance/first_deck/central)
 "fr" = (
 /obj/structure/sign/warning/airlock{
-	icon_state = "doors";
-	dir = 8
+	dir = 8;
+	icon_state = "doors"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/mainsolar)
@@ -2589,10 +2594,10 @@
 	pixel_y = 0
 	},
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Solar - Main";
 	capacity = 1e+007;
 	charge = 0;
-	cur_coils = 4;
-	RCon_tag = "Solar - Main"
+	cur_coils = 4
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = 23
@@ -2624,14 +2629,14 @@
 /area/maintenance/mainsolar)
 "fv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-supply";
-	dir = 6
+	tag = "icon-intact-supply (SOUTHEAST)"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -2671,12 +2676,12 @@
 /area/command/aicore)
 "fA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -2702,9 +2707,9 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -2718,17 +2723,17 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
 "fF" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHWEST)";
+	dir = 10;
 	icon_state = "warning";
-	dir = 10
+	tag = "icon-warning (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -2739,9 +2744,9 @@
 	id_tag = "nuke_shuttle_dock_pump"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -2783,8 +2788,8 @@
 /area/hallway/centralfirst)
 "fK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	icon_state = "map_scrubber_on";
-	dir = 4
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
@@ -2813,8 +2818,8 @@
 /area/hallway/centralfirst)
 "fM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
@@ -2904,8 +2909,8 @@
 "fV" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -2918,8 +2923,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -2930,17 +2935,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "fY" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2977,13 +2982,13 @@
 "gc" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 1
+	dir = 1;
+	icon_state = "map"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -2997,9 +3002,9 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -3079,8 +3084,8 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/mainsolar)
@@ -3115,8 +3120,8 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/mainsolar)
@@ -3137,8 +3142,8 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/mainsolar)
@@ -3168,9 +3173,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/orange{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/solar/main)
@@ -3222,9 +3227,9 @@
 /area/security/topgun)
 "gu" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -3251,8 +3256,8 @@
 "gw" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -3376,8 +3381,8 @@
 /area/maintenance/first_deck/central)
 "gO" = (
 /obj/structure/sign/warning/high_voltage{
-	icon_state = "shock";
-	dir = 8
+	dir = 8;
+	icon_state = "shock"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/mainsolar)
@@ -3475,9 +3480,9 @@
 "ha" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/first_deck_lobby)
@@ -3521,9 +3526,9 @@
 /area/hallway/centralfirst)
 "hg" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3538,9 +3543,9 @@
 /area/hallway/centralfirst)
 "hh" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva3 (NORTH)";
+	dir = 1;
 	icon_state = "nerva3";
-	dir = 1
+	tag = "icon-nerva3 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -3549,9 +3554,9 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/hallway/centralfirst)
@@ -3621,8 +3626,8 @@
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -3656,25 +3661,25 @@
 /area/command/aicore)
 "hu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
 "hv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -3716,8 +3721,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3736,9 +3741,9 @@
 /area/civilian/first_deck_lobby)
 "hB" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2 (NORTH)";
+	dir = 1;
 	icon_state = "nerva2";
-	dir = 1
+	tag = "icon-nerva2 (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3753,17 +3758,17 @@
 /area/hallway/centralfirst)
 "hC" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "hD" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing/mapped,
 /obj/structure/sign/directions/evac{
@@ -3785,9 +3790,9 @@
 /obj/structure/closet/walllocker/emerglocker/west,
 /obj/structure/closet/firecloset,
 /obj/structure/cable{
+	d2 = 2;
 	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/first_deck_atmos)
@@ -3822,9 +3827,9 @@
 /area/maintenance/first_deck/central)
 "hJ" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3832,13 +3837,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	icon_state = "map";
-	dir = 8
+	dir = 8;
+	icon_state = "map"
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -3964,9 +3969,9 @@
 /area/maintenance/first_deck/central)
 "hQ" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/reinforced/airless,
@@ -4034,9 +4039,9 @@
 /area/command/aicore)
 "hW" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTHEAST)";
+	dir = 5;
 	icon_state = "warning";
-	dir = 5
+	tag = "icon-warning (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/status_display{
@@ -4061,16 +4066,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
 "hZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -4083,12 +4088,12 @@
 /area/security/topgun)
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/topgun)
@@ -4108,8 +4113,8 @@
 	pixel_x = -24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Lobby";
@@ -4162,8 +4167,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated,
@@ -4204,9 +4209,9 @@
 /area/maintenance/first_deck/central)
 "im" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4263,8 +4268,8 @@
 /area/engineering/first_deck_atmos)
 "ir" = (
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
@@ -4289,8 +4294,8 @@
 /area/maintenance/first_deck/central)
 "iu" = (
 /obj/structure/sign/warning/airlock{
-	icon_state = "doors";
-	dir = 8
+	dir = 8;
+	icon_state = "doors"
 	},
 /turf/simulated/wall/prepainted,
 /area/maintenance/first_deck/central)
@@ -4305,9 +4310,9 @@
 /area/maintenance/first_deck/central)
 "iw" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/camera/network/command{
@@ -4318,9 +4323,9 @@
 /area/maintenance/first_deck/fs)
 "ix" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/aicore)
@@ -4330,25 +4335,25 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
 "iz" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 8
+	dir = 8;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - Aft";
@@ -4369,12 +4374,12 @@
 "iB" = (
 /obj/machinery/ai_slipper,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -4465,17 +4470,17 @@
 "iH" = (
 /obj/machinery/status_display,
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/aicore)
 "iI" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/porta_turret{
 	dir = 8
@@ -4490,13 +4495,13 @@
 "iJ" = (
 /obj/machinery/ai_slipper,
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -4532,13 +4537,13 @@
 /area/command/aicore)
 "iM" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/aicore)
@@ -4569,8 +4574,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -4620,8 +4625,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/first_deck_lobby)
@@ -4702,8 +4707,8 @@
 	pixel_y = 1
 	},
 /obj/machinery/atmospherics/portables_connector{
-	icon_state = "map_connector";
-	dir = 1
+	dir = 1;
+	icon_state = "map_connector"
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -4720,26 +4725,26 @@
 /area/maintenance/first_deck/central)
 "jg" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "jh" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/item/trash/cigbutt/rand,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "ji" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -4782,8 +4787,8 @@
 /area/command/aicore)
 "jn" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/table/steel_reinforced,
 /obj/structure/cable/yellow{
@@ -4815,9 +4820,9 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (SOUTHEAST)";
+	dir = 6;
 	icon_state = "warning";
-	dir = 6
+	tag = "icon-warning (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -4862,9 +4867,9 @@
 /area/civilian/first_deck_lobby)
 "ju" = (
 /obj/effect/floor_decal/corner/yellow{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4881,16 +4886,16 @@
 "jv" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/civilian/first_deck_lobby)
 "jw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -4964,9 +4969,9 @@
 /area/command/aicore)
 "jF" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4983,9 +4988,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -5039,9 +5044,9 @@
 /area/maintenance/first_deck/afs)
 "jL" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva1 (NORTH)";
+	dir = 1;
 	icon_state = "nerva1";
-	dir = 1
+	tag = "icon-nerva1 (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5074,8 +5079,8 @@
 "jN" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5091,13 +5096,13 @@
 "jO" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Central Maintenance APC"
@@ -5107,23 +5112,23 @@
 "jP" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (WEST)";
+	dir = 8;
 	icon_state = "down-scrubbers";
-	dir = 8
+	tag = "icon-down-scrubbers (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (WEST)";
+	dir = 8;
 	icon_state = "down-supply";
-	dir = 8
+	tag = "icon-down-supply (WEST)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/central)
 "jQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5145,9 +5150,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-supply";
-	dir = 6
+	tag = "icon-intact-supply (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5163,9 +5168,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5182,9 +5187,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5201,9 +5206,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5216,16 +5221,16 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5245,9 +5250,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5259,17 +5264,17 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5282,8 +5287,8 @@
 "ka" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/modular_computer/console/preset/civilian{
-	icon_state = "console";
-	dir = 1
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/aicore)
@@ -5297,8 +5302,8 @@
 "kc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/modular_computer/console/preset/research{
-	icon_state = "console";
-	dir = 1
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/aicore)
@@ -5354,8 +5359,8 @@
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/reinforced,
 /area/security/topgun)
@@ -5378,8 +5383,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -5401,9 +5406,9 @@
 /area/maintenance/first_deck/afs)
 "km" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva2 (NORTH)";
+	dir = 1;
 	icon_state = "nerva2";
-	dir = 1
+	tag = "icon-nerva2 (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5421,9 +5426,9 @@
 /area/hallway/centralfirst)
 "kn" = (
 /obj/effect/floor_decal/urist/nervalogo{
-	tag = "icon-nerva4 (NORTH)";
+	dir = 1;
 	icon_state = "nerva4";
-	dir = 1
+	tag = "icon-nerva4 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5659,9 +5664,9 @@
 /area/maintenance/first_deck/fs)
 "kL" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/reinforced/airless,
@@ -5673,21 +5678,21 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
 "kN" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5699,13 +5704,13 @@
 /area/command/aicore)
 "kO" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 1
+	dir = 1;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5714,13 +5719,13 @@
 /area/command/aicore)
 "kP" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 1
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5733,9 +5738,9 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5752,13 +5757,13 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/bluegrid,
 /area/command/aicore)
@@ -5775,8 +5780,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -5793,8 +5798,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -5875,8 +5880,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5891,13 +5896,13 @@
 /area/hallway/centralfirst)
 "lb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5913,13 +5918,13 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5932,13 +5937,13 @@
 "ld" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5951,13 +5956,13 @@
 "le" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5966,8 +5971,8 @@
 	tag = ""
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 1
+	dir = 1;
+	icon_state = "firelight1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6002,8 +6007,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6020,8 +6025,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6035,13 +6040,13 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6136,9 +6141,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -6240,14 +6245,14 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6268,9 +6273,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6287,9 +6292,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -6305,9 +6310,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -6323,9 +6328,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
@@ -6338,13 +6343,13 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
+	dir = 10;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -6377,13 +6382,13 @@
 	},
 /obj/machinery/light/small/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -6417,12 +6422,12 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	icon_state = "map-supply";
-	dir = 4
+	dir = 4;
+	icon_state = "map-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
@@ -6444,12 +6449,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -6463,8 +6468,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6489,8 +6494,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6518,8 +6523,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/first_deck_storage)
@@ -6558,8 +6563,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6578,8 +6583,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6607,8 +6612,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -6664,9 +6669,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6811,9 +6816,9 @@
 /area/maintenance/first_deck/central)
 "my" = (
 /obj/structure/bed/chair/office/comfy/black{
-	tag = "icon-comfyofficechair_preview (EAST)";
+	dir = 4;
 	icon_state = "comfyofficechair_preview";
-	dir = 4
+	tag = "icon-comfyofficechair_preview (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -6891,9 +6896,9 @@
 /area/maintenance/first_deck/central)
 "mJ" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/closet,
 /obj/random/junk,
@@ -6912,9 +6917,9 @@
 "mM" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -6932,9 +6937,9 @@
 /area/maintenance/first_deck/fs)
 "mP" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	tag = "icon-air_map (WEST)";
+	dir = 8;
 	icon_state = "air_map";
-	dir = 8
+	tag = "icon-air_map (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -7048,54 +7053,54 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
 "mW" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	tag = "icon-down-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "down-scrubbers";
-	dir = 4
+	tag = "icon-down-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	tag = "icon-down-supply (EAST)";
+	dir = 4;
 	icon_state = "down-supply";
-	dir = 4
+	tag = "icon-down-supply (EAST)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "32-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "32-4"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/afs)
 "mX" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/structure/disposalpipe/segment{
-	icon_state = "pipe-c";
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -7213,9 +7218,9 @@
 /area/maintenance/first_deck/central)
 "nh" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -7225,9 +7230,9 @@
 "ni" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -7237,9 +7242,9 @@
 /area/maintenance/first_deck/central)
 "nj" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -7249,9 +7254,9 @@
 /area/maintenance/first_deck/central)
 "nk" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -7262,9 +7267,9 @@
 /area/maintenance/first_deck/central)
 "nl" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -7275,9 +7280,9 @@
 /area/maintenance/first_deck/central)
 "nm" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -7287,17 +7292,17 @@
 "nn" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "no" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -7315,13 +7320,13 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -7337,9 +7342,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -7356,9 +7361,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/random/tool,
 /turf/simulated/floor/plating,
@@ -7441,12 +7446,12 @@
 	dir = 4
 	},
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -7564,9 +7569,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/orange{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/solar/auxaft)
@@ -7578,8 +7583,8 @@
 	},
 /obj/item/device/radio,
 /obj/machinery/light/small/red{
-	icon_state = "firelight1";
-	dir = 8
+	dir = 8;
+	icon_state = "firelight1"
 	},
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
@@ -7613,8 +7618,8 @@
 /area/engineering/substation/first_deck)
 "nR" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -7646,7 +7651,6 @@
 /area/hallway/centralfirst)
 "nU" = (
 /obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/abandonedcheckpoint)
@@ -7700,8 +7704,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+	dir = 5;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
@@ -7762,9 +7766,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-scrubbers";
-	dir = 9
+	tag = "icon-intact-scrubbers (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -7790,8 +7794,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -7803,9 +7807,9 @@
 /area/security/abandonedcheckpoint)
 "oj" = (
 /obj/structure/bed/chair/office/dark{
-	tag = "icon-officechair_preview (WEST)";
+	dir = 8;
 	icon_state = "officechair_preview";
-	dir = 8
+	tag = "icon-officechair_preview (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/security/abandonedcheckpoint)
@@ -7839,9 +7843,9 @@
 /area/maintenance/first_deck/fs)
 "on" = (
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /obj/structure/closet/crate,
 /obj/random/bomb_supply,
@@ -7912,14 +7916,14 @@
 /area/security/abandonedcheckpoint)
 "ox" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -7948,9 +7952,9 @@
 /area/maintenance/first_deck/central)
 "oB" = (
 /obj/structure/bed/chair/office/comfy/black{
-	tag = "icon-comfyofficechair_preview (EAST)";
+	dir = 4;
 	icon_state = "comfyofficechair_preview";
-	dir = 4
+	tag = "icon-comfyofficechair_preview (EAST)"
 	},
 /obj/effect/landmark/start{
 	name = "Stowaway"
@@ -7982,9 +7986,9 @@
 /area/space)
 "oG" = (
 /obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
+	dir = 1;
 	icon_state = "warning";
-	dir = 1
+	tag = "icon-warning (NORTH)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
@@ -8005,8 +8009,8 @@
 /area/maintenance/first_deck/afs)
 "oJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 8
+	dir = 8;
+	icon_state = "map-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -8015,13 +8019,13 @@
 /area/hallway/centralfirst)
 "oK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -8032,25 +8036,25 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/security/abandonedcheckpoint)
 "oM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (EAST)";
+	dir = 4;
 	icon_state = "intact-supply";
-	dir = 4
+	tag = "icon-intact-supply (EAST)"
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "Abandoned Checkpoint";
@@ -8060,13 +8064,13 @@
 /area/security/abandonedcheckpoint)
 "oN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -8205,9 +8209,9 @@
 "pg" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/central)
@@ -8217,9 +8221,9 @@
 /area/maintenance/first_deck/central)
 "pi" = (
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/open,
@@ -8333,8 +8337,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/plating,
@@ -8371,8 +8375,8 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aftsolar)
@@ -8394,8 +8398,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 1
+	dir = 1;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/plating,
@@ -8417,9 +8421,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/orange{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/catwalk,
@@ -8427,9 +8431,9 @@
 /area/maintenance/aftsolar)
 "pv" = (
 /obj/structure/cable/orange{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
@@ -8465,18 +8469,18 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aftsolar)
 "py" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8496,45 +8500,45 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 9
+	dir = 9;
+	icon_state = "intact-supply"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
 "pA" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/afs)
 "pB" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/afs)
 "pC" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing/mapped{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/maintenance/first_deck/afs)
@@ -8548,9 +8552,9 @@
 /area/hallway/centralfirst)
 "pE" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -8569,8 +8573,8 @@
 /area/maintenance/first_deck/central)
 "pG" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar{
 	id = "portsolar";
@@ -8586,9 +8590,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/orange{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -8653,18 +8657,18 @@
 /area/maintenance/first_deck/afs)
 "pN" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
 "pO" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /obj/random/junk,
@@ -8672,18 +8676,18 @@
 /area/maintenance/first_deck/afs)
 "pP" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
 "pQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated,
@@ -8696,8 +8700,8 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	icon_state = "map_vent_out";
-	dir = 8
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -8709,9 +8713,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -8732,9 +8736,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -8786,18 +8790,18 @@
 	req_access = list("ACCESS_MAINT")
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
 "qc" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -8806,9 +8810,9 @@
 /area/hallway/centralfirst)
 "qd" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -8821,9 +8825,9 @@
 	req_access = list("ACCESS_MAINT")
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
@@ -8873,9 +8877,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/cobweb{
-	tag = "icon-cobweb1 (EAST)";
+	dir = 4;
 	icon_state = "cobweb1";
-	dir = 4
+	tag = "icon-cobweb1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
@@ -8911,16 +8915,16 @@
 	req_access = list("ACCESS_EXTERNAL")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "qp" = (
 /obj/structure/cable/orange{
-	icon_state = "1-8";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -9031,12 +9035,33 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fore)
+"Ct" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/security/topgun)
 "Fd" = (
 /obj/item/weapon/material/shard{
 	icon_state = "small"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
+"GW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/navbeacon{
+	codes = list("patrol" = 1, "next_patrol" = "Deck 4 Escape");
+	location = "Deck 1 Starboard Docks"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/centralfirst)
 "Rn" = (
 /obj/effect/floor_decal/solarpanel,
 /obj/machinery/power/solar{
@@ -9061,9 +9086,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/orange{
-	icon_state = "2-4";
 	d1 = 1;
-	d2 = 4
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/solar/auxaft)
@@ -28586,7 +28611,7 @@ br
 oJ
 bg
 pe
-bS
+GW
 pQ
 pV
 qc
@@ -29355,7 +29380,7 @@ aa
 aa
 aa
 aa
-av
+as
 aD
 aS
 bi
@@ -40484,11 +40509,11 @@ ib
 gr
 gs
 Xf
-gs
+Ct
 iR
 ib
 jI
-gs
+Ct
 gs
 Xf
 gs

--- a/maps/nerva/nerva-5.dmm
+++ b/maps/nerva/nerva-5.dmm
@@ -4976,6 +4976,20 @@
 "ko" = (
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chapel)
+"kp" = (
+/obj/structure/window/reinforced/holowindow{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (SOUTHWEST)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_thunderdomecourt)
 "kq" = (
 /turf/simulated/floor/holofloor/ice,
 /area/holodeck/source_winter)
@@ -5416,7 +5430,7 @@
 /area/holodeck/source_theatre)
 "lG" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/holofloor/desert,
+/turf/simulated/floor/holofloor/path,
 /area/holodeck/source_picnicarea)
 "lH" = (
 /turf/simulated/floor/holofloor/lino,
@@ -5618,6 +5632,14 @@
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/holofloor/snow,
 /area/holodeck/source_winter)
+"mf" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Cockpit";
+	req_access = list("ACCESS_CENT_GENERAL")
+	},
+/turf/space,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/transport1/centcom)
 "mg" = (
 /obj/effect/floor_decal/carpet{
 	dir = 1
@@ -5629,6 +5651,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
+"mm" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "mo" = (
 /obj/item/weapon/tank/nitrogen,
 /turf/unsimulated/floor{
@@ -6206,6 +6234,7 @@
 /area/holodeck/source_theatre)
 "nM" = (
 /obj/effect/floor_decal/carpet,
+/obj/structure/holostool,
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_theatre)
 "nO" = (
@@ -6695,6 +6724,17 @@
 	icon_state = "beach"
 	},
 /area/holodeck/source_beach)
+"oX" = (
+/obj/structure/bed/chair/holochair/wood{
+	icon_state = "wooden_chair_preview";
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "pa" = (
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
@@ -7311,6 +7351,20 @@
 	icon_state = "vault"
 	},
 /area/tdome/tdome1)
+"qG" = (
+/obj/structure/window/reinforced/holowindow{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (SOUTHWEST)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_thunderdomecourt)
 "qI" = (
 /turf/simulated/floor/holofloor/beach/sand{
 	icon_state = "desert_dug"
@@ -7748,51 +7802,23 @@
 /turf/simulated/floor/holofloor/reinforced,
 /area/holodeck/source_battle_arena)
 "rS" = (
-/obj/structure/bed/chair/holochair{
-	dir = 4;
-	icon_state = "chair_preview";
-	tag = "icon-chair_preview (EAST)"
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_surgery)
-"rT" = (
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 8
-	},
-/obj/structure/window/reinforced/holowindow{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
-"rU" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_surgery)
-"rV" = (
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/structure/table/holotable,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
-"rW" = (
-/obj/item/clothing/head/surgery/blue,
-/obj/item/clothing/head/surgery/black,
-/obj/item/clothing/head/surgery/green,
-/obj/item/clothing/head/surgery/navyblue,
-/obj/item/clothing/head/surgery/purple,
-/obj/structure/table/rack/holorack,
-/obj/effect/floor_decal/corner/paleblue{
+/obj/structure/holostool,
+/obj/effect/floor_decal/corner/black/border{
 	dir = 1;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (NORTH)"
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (NORTH)"
 	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (WEST)"
+	},
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
+"rU" = (
+/obj/structure/fitness/punchingbag,
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
 "rY" = (
 /obj/structure/holostool,
 /turf/simulated/floor/holofloor/tiled/dark,
@@ -7805,19 +7831,6 @@
 	dir = 5
 	},
 /obj/structure/window/reinforced/holowindow{
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_boxingcourt)
-"sc" = (
-/obj/structure/window/reinforced/holowindow{
-	dir = 4
-	},
-/obj/structure/window/reinforced/holowindow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/green,
-/obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
 /turf/simulated/floor/holofloor/tiled,
@@ -7870,6 +7883,10 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
+"sl" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/holofloor/desert,
+/area/holodeck/source_desert)
 "sm" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -7946,9 +7963,6 @@
 	icon_state = "dark"
 	},
 /area/tdome)
-"sz" = (
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
 "sB" = (
 /obj/structure/table/holotable,
 /obj/item/clothing/gloves/boxing/hologlove,
@@ -8105,27 +8119,15 @@
 	icon_state = "vault"
 	},
 /area/tdome)
-"ta" = (
-/obj/structure/window/reinforced/holowindow{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
-"tb" = (
-/obj/machinery/optable,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
 "tc" = (
-/obj/item/weapon/scalpel,
-/obj/item/weapon/hemostat,
-/obj/structure/table/holotable,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
-"td" = (
 /obj/structure/holostool,
-/obj/structure/holostool,
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_boxingcourt)
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (EAST)"
+	},
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
 "te" = (
 /obj/effect/floor_decal/corner/blue/three_quarters,
 /turf/simulated/floor/holofloor/tiled,
@@ -8153,6 +8155,12 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_thunderdomecourt)
+"tk" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
 "tm" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8332,24 +8340,14 @@
 	icon_state = "vault"
 	},
 /area/tdome)
-"tL" = (
-/obj/effect/floor_decal/corner/paleblue,
-/obj/item/weapon/retractor,
-/obj/item/weapon/FixOVein,
-/obj/item/weapon/bonegel,
-/obj/item/weapon/bonesetter,
-/obj/structure/table/holotable,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
 "tM" = (
+/obj/effect/floor_decal/corner/green/three_quarters{
+	dir = 4
+	},
 /obj/structure/window/reinforced/holowindow{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/window/reinforced/holowindow,
-/obj/effect/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
 "tN" = (
@@ -8357,18 +8355,6 @@
 	dir = 10
 	},
 /obj/structure/window/reinforced/holowindow,
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_boxingcourt)
-"tO" = (
-/obj/effect/floor_decal/corner/green/three_quarters{
-	dir = 4
-	},
-/obj/structure/window/reinforced/holowindow{
-	dir = 4
-	},
-/obj/machinery/door/window/holowindoor{
-	name = "Green Corner"
-	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
 "tQ" = (
@@ -8501,33 +8487,6 @@
 	icon_state = "lino"
 	},
 /area/tdome/tdomeadmin)
-"uk" = (
-/obj/effect/floor_decal/corner/paleblue/three_quarters,
-/obj/structure/window/reinforced/holowindow{
-	dir = 8
-	},
-/obj/structure/window/reinforced/holowindow,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
-"ul" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8
-	},
-/obj/structure/window/reinforced/holowindow,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
-"um" = (
-/obj/machinery/door/window/holowindoor{
-	base_state = "right";
-	icon_state = "right"
-	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
-"un" = (
-/obj/effect/floor_decal/corner/paleblue,
-/obj/structure/window/reinforced/holowindow,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
 "up" = (
 /obj/structure/table/holotable,
 /obj/item/clothing/gloves/boxing/hologlove{
@@ -8558,15 +8517,6 @@
 	id_tag = "rescue_base_hatch";
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
-/turf/simulated/floor/tiled,
-/area/shuttle/transport1/centcom)
-"uy" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1331;
-	id_tag = "rescue_base_hatch";
-	req_access = list("ACCESS_CENT_SPECOPS")
-	},
-/turf/space,
 /turf/simulated/floor/tiled,
 /area/shuttle/transport1/centcom)
 "uz" = (
@@ -8665,12 +8615,6 @@
 "uO" = (
 /turf/simulated/floor/tiled/dark,
 /area/tdome)
-"uQ" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_surgery)
 "uS" = (
 /obj/structure/table/holotable,
 /obj/item/clothing/head/helmet/thunderdome,
@@ -8779,14 +8723,23 @@
 /turf/simulated/floor/holofloor/reinforced,
 /area/holodeck/source_battle_arena)
 "vh" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-06"
+/obj/structure/holostool,
+/obj/effect/floor_decal/corner/black/border,
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (WEST)"
 	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_surgery)
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
 "vi" = (
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_surgery)
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (NORTH)"
+	},
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
 "vj" = (
 /obj/structure/table/holotable,
 /obj/item/toy/ringbell,
@@ -9134,10 +9087,6 @@
 	tag = "icon-gravsnow_corner (NORTHEAST)"
 	},
 /area/syndicate_mothership)
-"wf" = (
-/turf/space,
-/turf/space,
-/area/space)
 "wg" = (
 /turf/simulated/shuttle/wall{
 	dir = 1;
@@ -9149,14 +9098,6 @@
 	name = "Cockpit";
 	req_access = list("ACCESS_CENT_GENERAL")
 	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/transport1/centcom)
-"wj" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Cockpit";
-	req_access = list("ACCESS_CENT_GENERAL")
-	},
-/turf/space,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/transport1/centcom)
 "wk" = (
@@ -17025,6 +16966,18 @@
 	tag = "icon-gravsnow_corner (SOUTHWEST)"
 	},
 /area/syndicate_mothership)
+"NR" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_plaza)
 "NT" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 8;
@@ -17109,6 +17062,14 @@
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
+"OH" = (
+/obj/structure/bed/chair/holochair/wood{
+	icon_state = "wooden_chair_preview";
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood/cee,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
 "OI" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8;
@@ -17132,6 +17093,15 @@
 	},
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_courtroom)
+"OM" = (
+/turf/simulated/floor/holofloor/space,
+/area/holodeck/source_space)
+"OQ" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-10"
+	},
+/turf/simulated/floor/holofloor/wood,
+/area/holodeck/source_cafe)
 "OR" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
@@ -17139,24 +17109,15 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
+"OU" = (
+/turf/simulated/floor/holofloor/desert,
+/area/holodeck/source_desert)
 "OV" = (
 /turf/simulated/floor/holofloor/beach/water{
 	icon_state = "desert5";
 	tag = "icon-desert5"
 	},
 /area/holodeck/source_beach)
-"OW" = (
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 4;
-	icon_state = "corner_white_three_quarters";
-	tag = "icon-corner_white_three_quarters (EAST)"
-	},
-/obj/item/weapon/circular_saw,
-/obj/item/weapon/cautery,
-/obj/structure/table/holotable,
-/obj/structure/window/reinforced/holowindow,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
 "Pb" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -17180,6 +17141,15 @@
 	icon_state = "swall_c"
 	},
 /area/shuttle/transport1/centcom)
+"Ph" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1331;
+	id_tag = "rescue_base_hatch";
+	req_access = list("ACCESS_CENT_SPECOPS")
+	},
+/turf/space,
+/turf/simulated/floor/tiled,
+/area/shuttle/transport1/centcom)
 "Pk" = (
 /turf/simulated/shuttle/wall{
 	dir = 1;
@@ -17192,6 +17162,34 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
+"Pn" = (
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (WEST)"
+	},
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
+"Pu" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	icon_state = "spline_fancy_cee";
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_plaza)
+"Pz" = (
+/obj/structure/bed/chair/holochair/wood,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1;
+	icon_state = "spline_fancy";
+	tag = "icon-spline_fancy (NORTH)"
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
 "PJ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -17210,6 +17208,16 @@
 	tag = "icon-beach (NORTH)"
 	},
 /area/holodeck/source_beach)
+"PQ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/structure/bed/chair/holochair/wood{
+	icon_state = "wooden_chair_preview";
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "PR" = (
 /obj/effect/floor_decal/corner/red/three_quarters{
 	dir = 4
@@ -17279,6 +17287,13 @@
 	},
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
+"Qo" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "Qu" = (
 /obj/structure/bed/chair/holochair{
 	dir = 4;
@@ -17302,25 +17317,18 @@
 	tag = "icon-desert3"
 	},
 /area/holodeck/source_beach)
-"Qx" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 4;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (EAST)"
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_surgery)
 "Qy" = (
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 8
-	},
-/obj/machinery/door/window/holowindoor{
-	dir = 8;
-	icon_state = "left";
-	tag = "icon-left (WEST)"
-	},
 /obj/structure/window/reinforced/holowindow{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
+/obj/machinery/door/window/holowindoor{
+	dir = 4;
+	icon_state = "left";
+	tag = "icon-left (EAST)"
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
@@ -17331,12 +17339,23 @@
 /obj/structure/holostool,
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_meetinghall)
+"QB" = (
+/obj/structure/fitness/weightlifter/holo,
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
 "QH" = (
 /turf/simulated/shuttle/wall{
 	dir = 4;
 	icon_state = "swall_straight"
 	},
 /area/shuttle/transport1/centcom)
+"Ra" = (
+/obj/structure/bed/chair/holochair/wood{
+	icon_state = "wooden_chair_preview";
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "Rs" = (
 /obj/effect/floor_decal/carpet{
 	dir = 4
@@ -17355,6 +17374,29 @@
 	},
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_meetinghall)
+"Rw" = (
+/obj/structure/bed/chair/holochair/wood{
+	icon_state = "wooden_chair_preview";
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
+"Ry" = (
+/obj/structure/table/holo_woodentable,
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
+"RA" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9;
+	icon_state = "spline_fancy";
+	tag = "icon-spline_fancy (NORTHWEST)"
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
 "RG" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall,
@@ -17366,6 +17408,28 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_theatre)
+"RN" = (
+/obj/structure/table/holo_woodentable,
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
+"RO" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/holofloor/desert,
+/area/holodeck/source_desert)
+"RQ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
+"Sk" = (
+/obj/structure/holostool,
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_thunderdomecourt)
 "Sn" = (
 /obj/structure/bed/chair/holochair{
 	dir = 4;
@@ -17403,6 +17467,14 @@
 	},
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chapel)
+"SG" = (
+/obj/structure/bed/chair/holochair/wood{
+	icon_state = "wooden_chair_preview";
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
 "SH" = (
 /obj/effect/floor_decal/corner/green,
 /obj/effect/floor_decal/corner/red{
@@ -17418,20 +17490,61 @@
 	},
 /turf/simulated/floor/holofloor/concrete,
 /area/holodeck/source_volleyball)
-"Td" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 4;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (EAST)"
+"SS" = (
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 8
 	},
-/obj/structure/table/rack/holorack,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
+/obj/structure/window/reinforced/holowindow{
+	dir = 1
+	},
+/obj/structure/window/reinforced/holowindow{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_boxingcourt)
+"SV" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/structure/table/holo_woodentable,
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
+"SY" = (
+/obj/structure/window/reinforced/holowindow{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/machinery/door/window/holowindoor{
+	name = "Green Corner"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_boxingcourt)
 "Th" = (
 /obj/effect/wallframe_spawn/reinforced/bare,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/merchant_station)
+"Tr" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/obj/structure/bed/chair/holochair/wood{
+	icon_state = "wooden_chair_preview";
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
+"Tv" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/structure/bed/chair/holochair/wood,
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "Ty" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 10;
@@ -17439,6 +17552,9 @@
 	},
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
+"TL" = (
+/turf/simulated/floor/holofloor/wood,
+/area/holodeck/source_cafe)
 "TP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -17454,6 +17570,10 @@
 	},
 /turf/simulated/floor/holofloor/concrete,
 /area/holodeck/source_volleyball)
+"TY" = (
+/obj/structure/bed/chair/holochair/wood,
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "TZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -17476,6 +17596,13 @@
 /obj/structure/holostool,
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_meetinghall)
+"Ug" = (
+/obj/effect/landmark{
+	can_copy = 1;
+	name = "Holocarp Spawn Random"
+	},
+/turf/simulated/floor/holofloor/space,
+/area/holodeck/source_space)
 "Uk" = (
 /obj/effect/floor_decal/carpet{
 	dir = 4
@@ -17497,6 +17624,14 @@
 "Ux" = (
 /turf/simulated/floor/tiled/dark,
 /area/syndicate_mothership)
+"Uy" = (
+/obj/structure/bed/chair/holochair/wood{
+	icon_state = "wooden_chair_preview";
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "UA" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 9;
@@ -17564,6 +17699,17 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
+"Vi" = (
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
+"Vj" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5;
+	icon_state = "spline_fancy";
+	tag = "icon-spline_fancy (NORTHEAST)"
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
 "Vr" = (
 /obj/structure/bed/chair/holochair{
 	dir = 4;
@@ -17575,6 +17721,24 @@
 	},
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_courtroom)
+"VE" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (SOUTHWEST)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_thunderdomecourt)
+"VJ" = (
+/obj/structure/table/holo_woodentable,
+/obj/item/weapon/flame/candle{
+	holographic = 1
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
 "VP" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -17585,13 +17749,26 @@
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
 "VS" = (
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 1;
-	icon_state = "corner_white_three_quarters";
-	tag = "icon-corner_white_three_quarters (NORTH)"
+/obj/structure/holostool,
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (EAST)"
 	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (NORTH)"
+	},
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
+"VW" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 10
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
 "Wt" = (
 /turf/simulated/shuttle/wall{
 	dir = 4;
@@ -17611,6 +17788,11 @@
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
+"WB" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/table/holo_woodentable,
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "WC" = (
 /obj/effect/floor_decal/carpet{
 	dir = 4
@@ -17641,6 +17823,18 @@
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
+"WQ" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/floor_decal/spline/fancy/wood/three_quarters,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_plaza)
+"WT" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "WV" = (
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/holofloor/beach/water{
@@ -17648,17 +17842,6 @@
 	tag = "icon-desert4"
 	},
 /area/holodeck/source_beach)
-"WX" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 1;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (NORTH)"
-	},
-/obj/structure/window/reinforced/holowindow{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
 "Xc" = (
 /obj/effect/floor_decal/carpet{
 	dir = 4
@@ -17678,6 +17861,16 @@
 	icon_state = "swall_c"
 	},
 /area/shuttle/transport1/centcom)
+"Xh" = (
+/obj/structure/holostool,
+/obj/effect/floor_decal/corner/black/border,
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (EAST)"
+	},
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
 "Xj" = (
 /obj/effect/floor_decal/carpet{
 	dir = 4
@@ -17696,6 +17889,16 @@
 	},
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_meetinghall)
+"Xk" = (
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
+"Xm" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	icon_state = "spline_fancy";
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_plaza)
 "Xw" = (
 /obj/effect/floor_decal/carpet,
 /obj/effect/floor_decal/carpet{
@@ -17787,20 +17990,34 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_thunderdomecourt)
+"YL" = (
+/obj/effect/floor_decal/corner/black/border,
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
 "YN" = (
 /turf/simulated/floor/holofloor/beach/sand{
 	dir = 8;
 	icon_state = "beach"
 	},
 /area/holodeck/source_beach)
-"YW" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 4;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (EAST)"
+"YS" = (
+/obj/structure/table/holo_woodentable,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
 	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
+"YW" = (
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (EAST)"
+	},
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
 "YY" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swall_c"
@@ -17849,6 +18066,19 @@
 	},
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
+"Zy" = (
+/obj/structure/table/holo_woodentable,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
+"Zz" = (
+/obj/structure/holostool,
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8;
+	icon_state = "bordercolor";
+	tag = "icon-bordercolor (WEST)"
+	},
+/turf/simulated/floor/holofloor/tiled/old_tile,
+/area/holodeck/source_gym)
 "ZB" = (
 /obj/structure/bed/chair/holochair{
 	dir = 4;
@@ -17866,23 +18096,41 @@
 	},
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_courtroom)
+"ZD" = (
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	icon_state = "spline_fancy_cee";
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/holofloor/grass,
+/area/holodeck/source_plaza)
 "ZF" = (
 /turf/simulated/floor/holofloor/beach/water{
 	icon_state = "desert1";
 	tag = "icon-desert1"
 	},
 /area/holodeck/source_beach)
-"ZT" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8;
-	icon_state = "corner_white";
-	tag = "icon-corner_white (WEST)"
+"ZP" = (
+/obj/structure/bed/chair/holochair/wood,
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	icon_state = "spline_fancy_cee";
+	dir = 1
 	},
-/obj/structure/window/reinforced/holowindow{
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
+"ZW" = (
+/obj/structure/bed/chair/holochair/wood{
+	icon_state = "wooden_chair_preview";
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_cafe)
 
 (1,1,1) = {"
 aa
@@ -37813,7 +38061,7 @@ ig
 ks
 ks
 ks
-ks
+ll
 ks
 ks
 ks
@@ -37827,11 +38075,11 @@ ol
 OV
 ig
 rS
-rS
-rS
-rS
-rS
-rS
+Pn
+Pn
+Zz
+Pn
+Pn
 vh
 ig
 ab
@@ -38018,7 +38266,7 @@ ks
 ks
 ks
 ks
-ks
+me
 ig
 ZF
 WV
@@ -38029,12 +38277,12 @@ ol
 ol
 ig
 vi
-vi
-vi
-vi
-vi
-vi
-vi
+Vi
+Vi
+Vi
+Vi
+Vi
+YL
 ig
 ab
 ab
@@ -38230,13 +38478,13 @@ ol
 Os
 ol
 ig
-rU
-rU
-rU
-rU
-rU
-Qx
 vi
+rU
+Vi
+QB
+Vi
+rU
+YL
 ig
 ab
 ab
@@ -38432,13 +38680,13 @@ qs
 qt
 ol
 ig
-rT
-WX
-ta
-ZT
-uk
-uQ
 vi
+Vi
+Vi
+Vi
+Vi
+Vi
+YL
 ig
 ab
 ab
@@ -38634,13 +38882,13 @@ PM
 ol
 ol
 ig
-rW
-sz
-sz
-sz
-ul
-uQ
 vi
+Vi
+Vi
+Vi
+Vi
+Vi
+YL
 ig
 ab
 ab
@@ -38836,13 +39084,13 @@ PM
 Op
 ol
 ig
-rV
-sz
-tb
-sz
-um
-uQ
 vi
+rU
+Vi
+QB
+Vi
+rU
+YL
 ig
 ab
 ab
@@ -39038,13 +39286,13 @@ PM
 Ub
 ol
 ig
-Td
-sz
-sz
-sz
-un
-uQ
 vi
+Vi
+Vi
+Vi
+Vi
+Vi
+YL
 ig
 ab
 ab
@@ -39243,10 +39491,10 @@ ig
 VS
 YW
 tc
-tL
-OW
-uQ
-vh
+tc
+tc
+YW
+Xh
 ig
 ab
 ab
@@ -39644,11 +39892,11 @@ SQ
 SQ
 SQ
 ig
-rY
-rY
-td
-rY
-rY
+rZ
+rZ
+rZ
+rZ
+rZ
 rZ
 rY
 ig
@@ -39846,13 +40094,13 @@ Ql
 Ql
 Ty
 ig
+SS
+sC
+sC
+SY
 rZ
 rZ
-rZ
-rZ
-rZ
-rZ
-vj
+rY
 ig
 ab
 ab
@@ -40048,13 +40296,13 @@ pa
 qJ
 rj
 ig
+sb
+sD
+te
+tN
+up
 rZ
-rZ
-rZ
-rZ
-rZ
-rZ
-rZ
+rY
 ig
 ab
 ab
@@ -40250,13 +40498,13 @@ pa
 pa
 rk
 ig
+sb
+sE
+tf
+tN
+up
 rZ
-sB
-sB
-rZ
-rZ
-rZ
-rZ
+rY
 ig
 ab
 ab
@@ -40453,12 +40701,12 @@ pa
 rk
 ig
 Qy
-sC
-sC
+sF
+sF
 tM
 rZ
 rZ
-rZ
+rY
 ig
 ab
 ab
@@ -40654,13 +40902,13 @@ qu
 pz
 rk
 ig
-sb
-sD
-te
-tN
-up
 rZ
-rY
+sB
+sB
+rZ
+rZ
+rZ
+rZ
 ig
 ab
 ab
@@ -40840,7 +41088,7 @@ ab
 ab
 ab
 ig
-kt
+ku
 ku
 ku
 ku
@@ -40856,13 +41104,13 @@ Zt
 Zt
 rm
 ig
-sb
-sE
-tf
-tN
-up
 rZ
-rY
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 ig
 ab
 ab
@@ -41048,7 +41296,7 @@ ku
 ku
 ku
 ku
-ku
+kt
 ig
 TW
 TW
@@ -41058,13 +41306,13 @@ TW
 TW
 TW
 ig
-sc
-sF
-sF
-tO
+rY
 rZ
+rY
+rY
+rY
 rZ
-rZ
+vj
 ig
 ab
 ab
@@ -41462,13 +41710,13 @@ Vr
 Vr
 OJ
 ig
-sg
-sg
-sg
-sg
-sg
-sg
-sg
+NZ
+PJ
+Sv
+qG
+Ul
+YD
+UJ
 ig
 ab
 ab
@@ -41664,13 +41912,13 @@ pd
 pd
 rn
 ig
-NZ
-PJ
-Sv
-Ul
-YD
-UJ
-sg
+se
+sH
+th
+VE
+tQ
+sH
+uS
 ig
 ab
 ab
@@ -41869,10 +42117,10 @@ ig
 se
 sH
 th
+VE
 tQ
 sH
 uS
-sg
 ig
 ab
 ab
@@ -42071,10 +42319,10 @@ ig
 se
 sH
 th
+VE
 tQ
 sH
 uS
-sg
 ig
 ab
 ab
@@ -42273,10 +42521,10 @@ ig
 se
 sH
 th
+VE
 tQ
 sH
 uS
-sg
 ig
 ab
 ab
@@ -42472,13 +42720,13 @@ ov
 ov
 ov
 ig
-se
-sH
-th
-tQ
-sH
-uS
-sg
+sf
+Ox
+ti
+kp
+tR
+Ox
+uT
 ig
 ab
 ab
@@ -42674,12 +42922,12 @@ qv
 ov
 ov
 ig
-sf
-Ox
-ti
-tR
-Ox
-uT
+sg
+sg
+sg
+sg
+sg
+sg
 sg
 ig
 ab
@@ -42876,13 +43124,13 @@ ov
 ov
 rp
 ig
+Sk
 sg
+Sk
+Sk
+Sk
 sg
-sg
-sg
-sg
-sg
-sg
+Sk
 ig
 ab
 ab
@@ -45090,21 +45338,21 @@ mP
 mP
 nP
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+WQ
+RQ
+RQ
+RQ
+RQ
+RQ
+WQ
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+TL
+TL
+TL
+TL
+TL
+TL
+TL
 ig
 ab
 ab
@@ -45292,21 +45540,21 @@ lq
 lq
 nQ
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Tr
+Xk
+Xk
+Xk
+Xk
+Xk
+Uy
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+TL
+RA
+ZW
+ZW
+ZW
+VW
+TL
 ig
 ab
 ab
@@ -45494,21 +45742,21 @@ lq
 lq
 nQ
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+RN
+Ra
+Xk
+ZD
+Xk
+TY
+WB
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+TL
+Pz
+Zy
+Zy
+Zy
+SG
+TL
 ig
 ab
 ab
@@ -45696,21 +45944,21 @@ lq
 lq
 nQ
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Xm
+Xk
+Xk
+NR
+Xk
+Xk
+Qo
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+TL
+Pz
+Zy
+VJ
+VJ
+SG
+TL
 ig
 ab
 ab
@@ -45898,21 +46146,21 @@ lq
 lq
 nQ
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+oX
+Xk
+Xk
+NR
+Xk
+Xk
+Uy
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+TL
+Vj
+Rw
+Rw
+Rw
+tk
+TL
 ig
 ab
 ab
@@ -46100,21 +46348,21 @@ lq
 lq
 nQ
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+RN
+Ra
+Xk
+Pu
+Xk
+TY
+Ry
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+TL
+TL
+TL
+TL
+TL
+TL
+TL
 ig
 ab
 ab
@@ -46302,21 +46550,21 @@ lq
 lq
 nQ
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Xm
+Xk
+Xk
+Xk
+Xk
+Xk
+WT
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+TL
+TL
+TL
+TL
+TL
+TL
+TL
 ig
 ab
 ab
@@ -46504,21 +46752,21 @@ mQ
 mQ
 nR
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+WQ
+mm
+Tv
+SV
+PQ
+mm
+WQ
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+OQ
+TL
+ZP
+YS
+OH
+TL
+OQ
 ig
 ab
 ab
@@ -46718,14 +46966,14 @@ ig
 ig
 ig
 ig
-uu
+ig
 ig
 ig
 ig
 ab
 ab
 ab
-wf
+ab
 ab
 ab
 ab
@@ -46883,6 +47131,39 @@ ab
 ab
 ab
 ab
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+ab
+ig
+OU
+RO
+OU
+OU
+OU
+OU
+OU
+ig
+OM
+OM
+OM
+OM
+OM
+OM
+OM
+ig
 ab
 ab
 ab
@@ -46890,6 +47171,7 @@ ab
 ab
 ab
 ab
+ig
 ab
 ab
 ab
@@ -46897,40 +47179,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-wf
 ab
 ab
 ab
@@ -47085,6 +47333,39 @@ ab
 ab
 ab
 ab
+qK
+rq
+rq
+Wt
+uV
+vn
+vN
+vN
+uV
+vn
+Pk
+rq
+rq
+rq
+qK
+ab
+ig
+OU
+OU
+OU
+sl
+OU
+OU
+RO
+ig
+OM
+OM
+OM
+Ug
+OM
+OM
+OM
+ig
 ab
 ab
 ab
@@ -47092,40 +47373,7 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ig
 ab
 ab
 ab
@@ -47283,59 +47531,59 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 qK
 qK
 qK
 qK
 qK
+rq
+tW
+uv
+uW
+vp
+vp
+vp
+vp
+vp
+wg
+vN
+vN
+Xe
 qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
+ab
+ig
+OU
+OU
+OU
+OU
+OU
+OU
+OU
+ig
+OM
+OM
+OM
+OM
+OM
+OM
+OM
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -47485,59 +47733,59 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 qK
-rq
-rq
-Wt
-uV
-vn
-vN
-vN
-uV
-vn
-Pk
 rq
 rq
 rq
 qK
+rq
+TZ
+Ph
+uX
+uX
+uX
+uX
+uX
+uX
+mf
+wp
+wp
+wx
+qK
+ab
+ig
+OU
+OU
+OU
+OU
+OU
+OU
+OU
+ig
+OM
+Ug
+OM
+OM
+OM
+OM
+OM
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -47687,59 +47935,59 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 qK
-qK
-qK
-qK
+rr
+rq
+rq
 qK
 rq
-tW
-uv
-uW
-vp
-vp
-vp
-vp
-vp
-wg
-vN
-vN
-Xe
+TZ
+QH
+uX
+uX
+vO
+vO
+uX
+uX
+Qh
+wq
+UF
+wy
 qK
+ab
+ig
+OU
+OU
+sl
+OU
+OU
+RO
+OU
+ig
+OM
+OM
+OM
+OM
+OM
+Ug
+OM
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -47889,40 +48137,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 qK
 rq
 rq
@@ -47930,18 +48144,52 @@ rq
 qK
 rq
 TZ
-uy
+uw
 uX
 uX
 uX
 uX
 uX
 uX
-wj
+wh
 wp
 wp
-wx
+wz
 qK
+ab
+ig
+OU
+OU
+OU
+sl
+OU
+OU
+OU
+ig
+OM
+OM
+OM
+OM
+OM
+OM
+OM
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -48091,59 +48339,59 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 qK
-rr
-rq
-rq
+qK
+qK
+qK
 qK
 rq
-TZ
-QH
-uX
-uX
-vO
-vO
-uX
-uX
-Qh
-wq
-UF
-wy
+Yr
+uv
+uW
+UK
+UK
+UK
+UK
+UK
+wg
+vN
+vN
+Pe
 qK
+ab
+ig
+OU
+OU
+OU
+OU
+OU
+OU
+OU
+ig
+OM
+OM
+OM
+Ug
+OM
+OM
+OM
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -48297,55 +48545,55 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 qK
+rq
+rq
+YY
+uV
+vn
+vN
+vN
+uV
+vn
+Pe
 rq
 rq
 rq
 qK
-rq
-TZ
-uw
-uX
-uX
-uX
-uX
-uX
-uX
-wh
-wp
-wp
-wz
-qK
+ab
+ig
+RO
+OU
+OU
+OU
+OU
+OU
+sl
+ig
+OM
+OM
+OM
+OM
+OM
+OM
+OM
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -48499,55 +48747,55 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 qK
 qK
 qK
 qK
 qK
-rq
-Yr
-uv
-uW
-UK
-UK
-UK
-UK
-UK
-wg
-vN
-vN
-Pe
 qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+ab
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+uu
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+uu
+ig
+ig
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -48735,21 +48983,21 @@ ab
 ab
 ab
 ab
-qK
-rq
-rq
-YY
-uV
-vn
-vN
-vN
-uV
-vn
-Pe
-rq
-rq
-rq
-qK
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -48937,21 +49185,21 @@ ab
 ab
 ab
 ab
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab

--- a/maps/nerva/nerva-5.dmm
+++ b/maps/nerva/nerva-5.dmm
@@ -151,26 +151,26 @@
 /area/rescue_base/base)
 "av" = (
 /obj/machinery/computer/teleporter{
-	icon_state = "computer";
-	dir = 2
+	dir = 2;
+	icon_state = "computer"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "aw" = (
 /obj/machinery/teleport/station,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ax" = (
 /obj/machinery/teleport/hub,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ay" = (
@@ -226,8 +226,8 @@
 /area/space)
 "aF" = (
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "aG" = (
@@ -237,8 +237,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "aH" = (
@@ -283,18 +283,18 @@
 	pixel_y = 16
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/rescue_base/base)
 "aN" = (
 /obj/structure/hygiene/shower{
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	icon_state = "shower"
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/rescue_base/base)
 "aO" = (
@@ -303,8 +303,8 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/rescue_base/base)
 "aP" = (
@@ -322,7 +322,6 @@
 /area/rescue_base/base)
 "aR" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/weapon/material/twohanded/baseballbat/metal,
 /obj/item/weapon/material/hatchet,
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -330,8 +329,8 @@
 /area/rescue_base/base)
 "aS" = (
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/rescue_base/base)
 "aT" = (
@@ -346,8 +345,8 @@
 /obj/item/weapon/aiModule/solgov,
 /obj/item/weapon/aiModule/solgov_aggressive,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "aU" = (
@@ -362,8 +361,8 @@
 /obj/item/weapon/plastique,
 /obj/item/weapon/plastique,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "aV" = (
@@ -375,8 +374,8 @@
 	pixel_y = 22
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "aW" = (
@@ -390,8 +389,8 @@
 /obj/item/weapon/storage/box/ammo/shotgunshells,
 /obj/item/weapon/storage/box/ammo/shotgunshells,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "aX" = (
@@ -401,8 +400,8 @@
 /obj/item/weapon/gun/energy/gun/nuclear,
 /obj/item/weapon/gun/energy/gun/nuclear,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "aY" = (
@@ -497,8 +496,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/rescue_base/base)
 "bh" = (
@@ -512,8 +511,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/rescue_base/base)
 "bj" = (
@@ -523,8 +522,8 @@
 /obj/item/ammo_magazine/box/a556,
 /obj/item/ammo_magazine/box/a556,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bk" = (
@@ -533,8 +532,8 @@
 	pixel_y = 22
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bl" = (
@@ -545,8 +544,8 @@
 	pixel_y = -3
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bm" = (
@@ -555,8 +554,8 @@
 /obj/item/weapon/gun/projectile/automatic/wt550,
 /obj/item/weapon/gun/projectile/automatic/wt550,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bn" = (
@@ -593,8 +592,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/rescue_base/base)
 "br" = (
@@ -603,16 +602,16 @@
 	pixel_y = 16
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/rescue_base/base)
 "bs" = (
 /obj/structure/table/rack,
 /obj/item/weapon/gun/projectile/automatic/l6_saw,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bt" = (
@@ -630,8 +629,8 @@
 /obj/item/clothing/suit/armor/laserproof,
 /obj/item/clothing/suit/armor/laserproof,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bu" = (
@@ -646,8 +645,8 @@
 /obj/item/ammo_magazine/mc9mmt/rubber,
 /obj/item/ammo_magazine/mc9mmt/rubber,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bv" = (
@@ -708,8 +707,8 @@
 /obj/item/weapon/rig/ert/assetprotection,
 /obj/item/weapon/rig/ert/assetprotection,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bC" = (
@@ -727,8 +726,8 @@
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bD" = (
@@ -744,8 +743,8 @@
 /obj/item/ammo_magazine/mc9mmt,
 /obj/item/ammo_magazine/mc9mmt,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bE" = (
@@ -765,8 +764,8 @@
 /area/rescue_base/base)
 "bG" = (
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 9
+	dir = 9;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bH" = (
@@ -873,8 +872,8 @@
 /obj/item/weapon/gun/projectile/automatic/z8,
 /obj/item/weapon/gun/projectile/automatic/z8,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bS" = (
@@ -890,8 +889,8 @@
 	p_open = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bT" = (
@@ -900,8 +899,8 @@
 /obj/item/weapon/storage/box/smokes,
 /obj/item/weapon/storage/box/flashbangs,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "bU" = (
@@ -950,16 +949,16 @@
 /obj/item/ammo_magazine/a762,
 /obj/item/ammo_magazine/a762,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ca" = (
 /obj/structure/table/rack,
 /obj/item/weapon/gun/launcher/grenade,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cb" = (
@@ -970,8 +969,8 @@
 /obj/item/weapon/storage/box/emps,
 /obj/item/weapon/storage/box/frags,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cc" = (
@@ -983,16 +982,16 @@
 /obj/item/clothing/head/solgov/utility/fleet,
 /obj/item/clothing/accessory/badge/solgov/tags,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cd" = (
 /obj/structure/bed/nice,
 /obj/item/weapon/bedsheet/captain,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ce" = (
@@ -1003,8 +1002,8 @@
 	pixel_y = 22
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cf" = (
@@ -1012,8 +1011,8 @@
 	prices = list()
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cg" = (
@@ -1029,8 +1028,8 @@
 	p_open = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ch" = (
@@ -1058,8 +1057,8 @@
 "cl" = (
 /obj/machinery/acting/changer,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cm" = (
@@ -1067,8 +1066,8 @@
 	name = "Response Team"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cn" = (
@@ -1094,8 +1093,8 @@
 "cp" = (
 /obj/structure/undies_wardrobe,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cq" = (
@@ -1114,8 +1113,8 @@
 	pixel_y = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cs" = (
@@ -1125,8 +1124,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ct" = (
@@ -1152,8 +1151,8 @@
 /obj/item/taperoll/police,
 /obj/item/taperoll/police,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cu" = (
@@ -1165,8 +1164,8 @@
 /obj/item/clothing/glasses/tacgoggles,
 /obj/item/clothing/glasses/tacgoggles,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cv" = (
@@ -1176,8 +1175,8 @@
 /obj/item/weapon/storage/belt/holster/security/tactical,
 /obj/item/weapon/storage/belt/holster/security/tactical,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cw" = (
@@ -1185,8 +1184,8 @@
 /obj/item/weapon/gun/energy/gun/nuclear,
 /obj/item/weapon/gun/energy/gun/nuclear,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cx" = (
@@ -1200,8 +1199,8 @@
 /obj/item/clothing/head/helmet,
 /obj/item/clothing/head/helmet,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cy" = (
@@ -1211,8 +1210,8 @@
 /obj/item/clothing/head/helmet,
 /obj/item/clothing/head/helmet,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cz" = (
@@ -1220,8 +1219,8 @@
 /obj/item/weapon/gun/energy/gun,
 /obj/item/weapon/gun/energy/gun,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cA" = (
@@ -1233,8 +1232,8 @@
 /obj/item/weapon/storage/belt/medical/emt,
 /obj/item/weapon/storage/belt/medical/emt,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cB" = (
@@ -1247,8 +1246,8 @@
 /obj/item/weapon/storage/box/gloves,
 /obj/item/weapon/storage/box/masks,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cC" = (
@@ -1274,8 +1273,8 @@
 /obj/item/weapon/gun/launcher/syringe/rapid,
 /obj/item/weapon/gun/launcher/syringe/rapid,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cD" = (
@@ -1291,8 +1290,8 @@
 /obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
 /obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cE" = (
@@ -1305,8 +1304,8 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cF" = (
@@ -1316,8 +1315,8 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cG" = (
@@ -1339,8 +1338,8 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cH" = (
@@ -1356,15 +1355,15 @@
 	pixel_y = 22
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cI" = (
 /obj/structure/table/rack,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cJ" = (
@@ -1390,8 +1389,8 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cK" = (
@@ -1401,8 +1400,8 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cL" = (
@@ -1415,8 +1414,8 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cM" = (
@@ -1454,8 +1453,8 @@
 	pixel_y = 2
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cN" = (
@@ -1465,16 +1464,16 @@
 /obj/item/weapon/gun/energy/laser,
 /obj/item/weapon/gun/energy/laser,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cO" = (
 /obj/machinery/chemical_dispenser/ert,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cP" = (
@@ -1487,8 +1486,8 @@
 /obj/structure/table/rack,
 /obj/item/weapon/rig/ert/janitor,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cQ" = (
@@ -1519,8 +1518,8 @@
 	name = "Unlocked Autolathe"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cU" = (
@@ -1528,8 +1527,8 @@
 /obj/item/weapon/gun/energy/ionrifle,
 /obj/item/weapon/gun/energy/ionrifle,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cV" = (
@@ -1547,8 +1546,8 @@
 /obj/item/weapon/shield/riot,
 /obj/item/weapon/shield/riot,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cW" = (
@@ -1570,8 +1569,8 @@
 /obj/item/bodybag/cryobag,
 /obj/item/weapon/defibrillator/compact/loaded,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cX" = (
@@ -1583,8 +1582,8 @@
 /obj/item/roller,
 /obj/item/roller,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "cY" = (
@@ -1607,8 +1606,8 @@
 "cZ" = (
 /obj/machinery/chem_master,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "da" = (
@@ -1619,8 +1618,8 @@
 /obj/structure/table/rack,
 /obj/item/weapon/rig/ert/janitor,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "db" = (
@@ -1632,8 +1631,8 @@
 /obj/item/device/paicard,
 /obj/item/device/paicard,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dc" = (
@@ -1643,8 +1642,8 @@
 /obj/item/weapon/gun/energy/gun,
 /obj/item/weapon/gun/energy/gun,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dd" = (
@@ -1654,16 +1653,16 @@
 /obj/item/weapon/shield/riot/metal,
 /obj/item/weapon/shield/riot/metal,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "de" = (
 /obj/machinery/chemical_dispenser/full,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "df" = (
@@ -1690,8 +1689,8 @@
 	pixel_x = 32
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "di" = (
@@ -1708,15 +1707,15 @@
 /obj/item/clothing/head/beret/solgov/fleet/security,
 /obj/item/clothing/head/beret/solgov/fleet/security,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dj" = (
 /obj/structure/iv_drip,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dk" = (
@@ -1731,8 +1730,8 @@
 /obj/item/device/flashlight/pen,
 /obj/item/device/flashlight/pen,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dl" = (
@@ -1747,8 +1746,8 @@
 /obj/item/weapon/storage/firstaid/o2,
 /obj/item/weapon/storage/firstaid/o2,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dm" = (
@@ -1763,15 +1762,15 @@
 /obj/item/weapon/storage/firstaid/combat,
 /obj/item/weapon/storage/firstaid/combat,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dn" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "do" = (
@@ -1782,8 +1781,8 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dp" = (
@@ -1796,8 +1795,8 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dq" = (
@@ -1819,8 +1818,8 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dr" = (
@@ -1828,8 +1827,8 @@
 /obj/structure/table/rack,
 /obj/item/weapon/rig/ert/engineer,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ds" = (
@@ -1840,8 +1839,8 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dt" = (
@@ -1861,8 +1860,8 @@
 "dv" = (
 /obj/structure/table/reinforced,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dw" = (
@@ -1876,8 +1875,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dy" = (
@@ -1887,8 +1886,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dz" = (
@@ -1912,8 +1911,8 @@
 	p_open = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dC" = (
@@ -1923,8 +1922,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dD" = (
@@ -1933,8 +1932,8 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dE" = (
@@ -1944,17 +1943,17 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dF" = (
 /turf/unsimulated/wall{
 	desc = "A secure airlock. Doesn't look like you can get through easily.";
+	dir = 4;
 	icon = 'icons/obj/doors/centcomm/door.dmi';
 	icon_state = "closed";
-	name = "Delta Barracks";
-	dir = 4
+	name = "Delta Barracks"
 	},
 /area/rescue_base/base)
 "dG" = (
@@ -1972,15 +1971,15 @@
 /obj/item/modular_computer/tablet/lease/preset/command,
 /obj/item/modular_computer/tablet/lease/preset/command,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dI" = (
 /obj/machinery/recharge_station,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dJ" = (
@@ -1992,8 +1991,8 @@
 /obj/item/clothing/accessory/storage/white_vest,
 /obj/item/clothing/accessory/storage/white_vest,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dK" = (
@@ -2005,8 +2004,8 @@
 /obj/item/clothing/accessory/storage/black_vest,
 /obj/item/clothing/accessory/storage/black_vest,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dL" = (
@@ -2018,8 +2017,8 @@
 /obj/item/clothing/accessory/storage/brown_vest,
 /obj/item/clothing/accessory/storage/brown_vest,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dM" = (
@@ -2031,8 +2030,8 @@
 /obj/item/clothing/accessory/storage/holster/thigh,
 /obj/item/clothing/accessory/storage/holster/thigh,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dN" = (
@@ -2041,8 +2040,8 @@
 	pixel_y = -22
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dO" = (
@@ -2053,8 +2052,8 @@
 	pixel_y = -25
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dP" = (
@@ -2064,8 +2063,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dQ" = (
@@ -2075,8 +2074,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dR" = (
@@ -2086,8 +2085,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dS" = (
@@ -2102,8 +2101,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dU" = (
@@ -2111,16 +2110,16 @@
 /obj/item/weapon/storage/box/trackimp,
 /obj/item/weapon/storage/box/cdeathalarm_kit,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dV" = (
 /obj/structure/table/reinforced,
 /obj/prefab/hand_teleporter,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dW" = (
@@ -2132,8 +2131,8 @@
 	pixel_y = 22
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dX" = (
@@ -2141,29 +2140,29 @@
 /obj/machinery/cell_charger,
 /obj/item/weapon/cell/hyper,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dY" = (
 /obj/machinery/vending/engivend,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "dZ" = (
 /obj/machinery/vending/tool,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ea" = (
 /obj/machinery/vending/assist,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eb" = (
@@ -2173,15 +2172,15 @@
 	pixel_y = 22
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ec" = (
 /obj/machinery/pipedispenser/disposal/orderable,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ed" = (
@@ -2198,8 +2197,8 @@
 /obj/item/clothing/head/beret/solgov/fleet/engineering,
 /obj/item/clothing/head/beret/solgov/fleet/engineering,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ee" = (
@@ -2211,14 +2210,14 @@
 "ef" = (
 /obj/structure/bed/chair/office/dark,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eg" = (
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eh" = (
@@ -2245,8 +2244,8 @@
 	p_open = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ej" = (
@@ -2284,22 +2283,22 @@
 "en" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eo" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ep" = (
 /obj/machinery/shieldgen,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eq" = (
@@ -2324,8 +2323,8 @@
 	req_access = list("ACCESS_CENT_SPECOPS")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "et" = (
@@ -2334,8 +2333,8 @@
 /obj/item/mecha_parts/mecha_equipment/tool/sleeper,
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eu" = (
@@ -2350,16 +2349,16 @@
 	pixel_y = 22
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ev" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ew" = (
@@ -2367,8 +2366,8 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ex" = (
@@ -2378,8 +2377,8 @@
 /obj/item/weapon/storage/box/handcuffs,
 /obj/item/weapon/melee/baton/loaded,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ey" = (
@@ -2387,8 +2386,8 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/glasses/tacgoggles,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "ez" = (
@@ -2396,16 +2395,16 @@
 /obj/item/weapon/storage/backpack/ert/commander,
 /obj/item/weapon/storage/belt/holster/security/tactical,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eA" = (
 /obj/structure/table/rack,
 /obj/item/weapon/gun/energy/gun,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eB" = (
@@ -2413,22 +2412,22 @@
 /obj/item/clothing/suit/armor/pcarrier/medium/command,
 /obj/item/clothing/head/helmet/solgov/command,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eD" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eE" = (
@@ -2448,8 +2447,8 @@
 	p_open = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eG" = (
@@ -2459,8 +2458,8 @@
 /area/rescue_base/base)
 "eH" = (
 /obj/item/modular_computer/console/preset/command{
-	icon_state = "console";
-	dir = 4
+	dir = 4;
+	icon_state = "console"
 	},
 /obj/item/weapon/card/id/centcom,
 /turf/unsimulated/floor{
@@ -2470,8 +2469,8 @@
 "eI" = (
 /obj/structure/closet/secure_closet/nervacos,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eJ" = (
@@ -2479,15 +2478,15 @@
 /obj/item/weapon/storage/secure/briefcase,
 /obj/item/clothing/head/beret/centcom/captain,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eK" = (
 /obj/machinery/power/emitter,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eL" = (
@@ -2507,8 +2506,8 @@
 	req_access = newlist()
 	},
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/rescue_base/base)
 "eN" = (
@@ -2520,8 +2519,8 @@
 	frequency = 1345
 	},
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/rescue_base/base)
 "eO" = (
@@ -2535,8 +2534,8 @@
 	pixel_y = 4
 	},
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/rescue_base/base)
 "eP" = (
@@ -2550,8 +2549,8 @@
 /obj/item/clothing/gloves/insulated,
 /obj/item/clothing/gloves/insulated,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eQ" = (
@@ -2563,8 +2562,8 @@
 /obj/item/clothing/glasses/welding/superior,
 /obj/item/clothing/glasses/welding/superior,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eR" = (
@@ -2602,8 +2601,8 @@
 	pixel_y = 3
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eS" = (
@@ -2623,8 +2622,8 @@
 /obj/item/weapon/cell/high,
 /obj/item/weapon/cell/high,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eT" = (
@@ -2646,8 +2645,8 @@
 /obj/item/weapon/rcd,
 /obj/item/weapon/rcd,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eU" = (
@@ -2733,8 +2732,8 @@
 	amount = 20
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eV" = (
@@ -2748,15 +2747,15 @@
 /obj/item/weapon/smes_coil/super_io,
 /obj/item/weapon/smes_coil/super_io,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eW" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "eX" = (
@@ -2778,8 +2777,8 @@
 /obj/item/mecha_parts/mecha_equipment/armor_booster/anticcw_armor_booster,
 /obj/item/mecha_parts/mecha_equipment/armor_booster/antiproj_armor_booster,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "fa" = (
@@ -2789,8 +2788,8 @@
 /obj/item/weapon/material/ashtray/bronze,
 /obj/item/trash/cigbutt/cigarbutt,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/rescue_base/base)
 "fb" = (
@@ -2798,8 +2797,8 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/rescue_base/base)
 "fc" = (
@@ -2808,8 +2807,8 @@
 	},
 /obj/item/clothing/head/beret/solgov/marcom,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/rescue_base/base)
 "fd" = (
@@ -2825,8 +2824,8 @@
 	p_open = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "fe" = (
@@ -2848,8 +2847,8 @@
 /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
 /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "fh" = (
@@ -2863,8 +2862,8 @@
 /obj/item/mecha_parts/mecha_equipment/repair_droid,
 /obj/item/mecha_parts/mecha_equipment/repair_droid,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "fi" = (
@@ -2872,8 +2871,8 @@
 /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill,
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "fj" = (
@@ -2881,8 +2880,8 @@
 /obj/item/mecha_parts/mecha_equipment/tool/extinguisher,
 /obj/item/mecha_parts/mecha_equipment/tool/rcd,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "fk" = (
@@ -2890,8 +2889,8 @@
 /obj/item/mecha_parts/mecha_equipment/tool/passenger,
 /obj/item/mecha_parts/mecha_equipment/tool/passenger,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "fl" = (
@@ -2899,8 +2898,8 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion,
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 1
+	dir = 1;
+	icon_state = "vault"
 	},
 /area/rescue_base/base)
 "fm" = (
@@ -3095,8 +3094,8 @@
 /area/rescue_base/start)
 "fJ" = (
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 4
+	dir = 4;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
@@ -3114,15 +3113,15 @@
 	req_access = list("ACCESS_CENT_CREED")
 	},
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
+	dir = 8;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
 "fM" = (
 /obj/item/modular_computer/console/preset/medical{
-	icon_state = "console";
-	dir = 4
+	dir = 4;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
@@ -3131,8 +3130,8 @@
 /area/rescue_base/start)
 "fO" = (
 /obj/item/modular_computer/console/preset/engineering{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
@@ -3143,8 +3142,8 @@
 	pixel_y = 0
 	},
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 8
+	dir = 8;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/plating,
 /area/rescue_base/start)
@@ -3160,8 +3159,8 @@
 /area/rescue_base/start)
 "fR" = (
 /obj/item/modular_computer/console/preset/security{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
@@ -3364,8 +3363,8 @@
 /area/drone_test)
 "gr" = (
 /obj/structure/handrai{
-	icon_state = "handrail";
-	dir = 1
+	dir = 1;
+	icon_state = "handrail"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
@@ -3695,8 +3694,8 @@
 /area/rescue_base/start)
 "hq" = (
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "lava"
+	icon_state = "lava";
+	name = "plating"
 	},
 /area/deity_spawn)
 "hr" = (
@@ -3731,8 +3730,8 @@
 	dir = 1
 	},
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -3880,8 +3879,8 @@
 	name = "DeitySpawn"
 	},
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "lava"
+	icon_state = "lava";
+	name = "plating"
 	},
 /area/deity_spawn)
 "hM" = (
@@ -4122,9 +4121,9 @@
 /area/fightclub)
 "iy" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -4142,9 +4141,9 @@
 /area/fightclub)
 "iB" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (NORTH)";
+	dir = 1;
 	icon_state = "firelight1";
-	dir = 1
+	tag = "icon-firelight1 (NORTH)"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4176,8 +4175,8 @@
 "iF" = (
 /obj/random/junk,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
 /area/fightclub)
@@ -4237,9 +4236,9 @@
 /area/syndicate_mothership/raider_base)
 "iP" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
@@ -4277,22 +4276,22 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
 "iX" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
 "iY" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/plating,
 /area/fightclub)
@@ -4306,8 +4305,8 @@
 	},
 /obj/item/weapon/soap/syndie,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/raider_base)
 "jb" = (
@@ -4315,8 +4314,8 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/raider_base)
 "jc" = (
@@ -4325,8 +4324,8 @@
 	},
 /obj/random/trash,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/raider_base)
 "jd" = (
@@ -4451,15 +4450,15 @@
 /area/syndicate_mothership/raider_base)
 "jq" = (
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/raider_base)
 "jr" = (
 /obj/effect/decal/cleanable/blood,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/raider_base)
 "js" = (
@@ -4534,8 +4533,8 @@
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -4553,9 +4552,9 @@
 	name = "fence"
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHWEST)";
+	dir = 10;
 	icon_state = "corner_white";
-	dir = 10
+	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable{
@@ -4563,8 +4562,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
@@ -4580,8 +4579,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -4601,14 +4600,14 @@
 /area/fightclub)
 "jD" = (
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/space)
 "jE" = (
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -4617,8 +4616,8 @@
 	pixel_y = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/raider_base)
 "jF" = (
@@ -4733,9 +4732,9 @@
 	name = "fence"
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -4750,9 +4749,9 @@
 /area/fightclub)
 "jP" = (
 /obj/effect/decal/cleanable/blood{
-	tag = "icon-bloodsquare (NORTHEAST)";
+	dir = 5;
 	icon_state = "bloodsquare";
-	dir = 5
+	tag = "icon-bloodsquare (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/fightclub)
@@ -4768,8 +4767,8 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -4808,8 +4807,8 @@
 /area/syndicate_mothership/raider_base)
 "jV" = (
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -4819,8 +4818,8 @@
 	pixel_y = 0
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/raider_base)
 "jW" = (
@@ -4837,8 +4836,8 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/raider_base)
 "jY" = (
@@ -4891,8 +4890,8 @@
 /area/syndicate_mothership/raider_base)
 "kd" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 6
+	dir = 6;
+	icon_state = "intact"
 	},
 /turf/unsimulated/floor{
 	icon_state = "plating";
@@ -4947,17 +4946,17 @@
 /area/fightclub)
 "kj" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/fightclub)
 "kk" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
@@ -4971,29 +4970,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
 "kn" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
-	icon_state = "spline_fancy";
-	dir = 4
-	},
+/obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "ko" = (
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_chapel)
-"kp" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (WEST)";
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
 "kq" = (
 /turf/simulated/floor/holofloor/ice,
-/area/holodeck/source_winter)
-"kr" = (
-/turf/simulated/floor/ice,
 /area/holodeck/source_winter)
 "ks" = (
 /turf/simulated/floor/holofloor/snow,
@@ -5028,45 +5012,6 @@
 /area/holodeck/source_meetinghall)
 "kA" = (
 /turf/simulated/floor/holofloor/wood,
-/area/holodeck/source_meetinghall)
-"kB" = (
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet,
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 9
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 10
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_meetinghall)
-"kC" = (
-/obj/effect/floor_decal/carpet,
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_meetinghall)
-"kD" = (
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet,
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 5
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 6
-	},
-/turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_meetinghall)
 "kE" = (
 /obj/effect/floor_decal/corner/red/three_quarters{
@@ -5297,9 +5242,9 @@
 /area/syndicate_mothership/raider_base)
 "lc" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
@@ -5336,14 +5281,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
 "lj" = (
-/obj/structure/table/holo_woodentable,
-/obj/item/weapon/flame/candle{
-	pixel_x = -7
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
 	},
-/obj/item/weapon/flame/candle{
-	pixel_x = 7
+/obj/effect/floor_decal/chapel{
+	dir = 1;
+	icon_state = "chapel";
+	tag = "icon-chapel (NORTH)"
 	},
-/turf/simulated/floor/holofloor/wood,
+/turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "lk" = (
 /obj/structure/flora/tree/dead,
@@ -5413,9 +5361,9 @@
 /area/syndicate_mothership/raider_base)
 "lw" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/fightclub)
@@ -5429,51 +5377,39 @@
 /obj/machinery/vending/boozeomat,
 /turf/simulated/wall/voxshuttle,
 /area/fightclub)
-"lz" = (
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	tag = "icon-spline_fancy_corner (NORTH)";
-	icon_state = "spline_fancy_corner";
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
 "lA" = (
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/obj/effect/floor_decal/chapel{
+	dir = 8;
+	icon_state = "chapel";
+	tag = "icon-chapel (WEST)"
+	},
 /obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (NORTH)";
+	dir = 10;
 	icon_state = "spline_fancy";
-	dir = 1
+	tag = "icon-spline_fancy (SOUTHWEST)"
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "lB" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (NORTHEAST)";
-	icon_state = "spline_fancy";
-	dir = 5
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
 	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
-"lC" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (NORTHWEST)";
-	icon_state = "spline_fancy";
-	dir = 9
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
-"lD" = (
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	tag = "icon-spline_fancy_corner (EAST)";
-	icon_state = "spline_fancy_corner";
-	dir = 4
-	},
+/obj/effect/floor_decal/chapel,
+/obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "lE" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/effect/floor_decal/carpet{
+	dir = 8
 	},
-/turf/simulated/floor/holofloor/tiled,
+/turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_theatre)
 "lF" = (
 /turf/simulated/floor/holofloor/tiled,
@@ -5569,8 +5505,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /obj/structure/grille{
 	desc = "A flimsy fence of metal rods, with screws to secure it to the floor.";
@@ -5622,9 +5558,9 @@
 	name = "fence"
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHEAST)";
+	dir = 6;
 	icon_state = "corner_white";
-	dir = 6
+	tag = "icon-corner_white (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -5667,73 +5603,11 @@
 	req_access = list("ACCESS_CENT_GENERAL")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/space)
 "lY" = (
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
-"lZ" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
-	icon_state = "chair_preview";
-	dir = 1
-	},
-/obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (NORTH)";
-	icon_state = "chapel";
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
-"ma" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
-	icon_state = "chair_preview";
-	dir = 1
-	},
-/obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
-	icon_state = "chapel";
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
-	icon_state = "spline_fancy";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
-"mb" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
-	icon_state = "chair_preview";
-	dir = 1
-	},
-/obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (NORTH)";
-	icon_state = "chapel";
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (WEST)";
-	icon_state = "spline_fancy";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
-"mc" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
-	icon_state = "chair_preview";
-	dir = 1
-	},
-/obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
-	icon_state = "chapel";
-	dir = 4
-	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "md" = (
@@ -5744,35 +5618,9 @@
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/holofloor/snow,
 /area/holodeck/source_winter)
-"mf" = (
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 9
-	},
-/obj/structure/holostool,
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_theatre)
 "mg" = (
 /obj/effect/floor_decal/carpet{
 	dir = 1
-	},
-/obj/structure/holostool,
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_theatre)
-"mh" = (
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 5
 	},
 /obj/structure/holostool,
 /turf/simulated/floor/holofloor/carpet,
@@ -5781,58 +5629,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
-"mj" = (
-/obj/structure/holostool,
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 9
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_meetinghall)
-"mk" = (
-/obj/structure/holostool,
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_meetinghall)
-"ml" = (
-/obj/structure/holostool,
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 5
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_meetinghall)
-"mm" = (
-/obj/effect/floor_decal/corner/green{
-	tag = "icon-corner_white (WEST)";
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_emptycourt)
-"mn" = (
-/obj/effect/floor_decal/corner/green,
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_emptycourt)
 "mo" = (
 /obj/item/weapon/tank/nitrogen,
 /turf/unsimulated/floor{
@@ -5882,8 +5678,8 @@
 /obj/item/clothing/accessory/storage/bandolier,
 /obj/item/clothing/under/assistantformal,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /obj/random/junk,
 /obj/item/weapon/soap/syndie,
@@ -5912,8 +5708,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
@@ -5927,21 +5723,21 @@
 	name = "fence"
 	},
 /obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
@@ -5957,9 +5753,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	tag = "icon-warningcorner (NORTH)";
+	dir = 1;
 	icon_state = "warningcorner";
-	dir = 1
+	tag = "icon-warningcorner (NORTH)"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -5973,8 +5769,8 @@
 /area/tdome)
 "mA" = (
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "mB" = (
@@ -5984,84 +5780,60 @@
 	req_access = list("ACCESS_CENT_GENERAL")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "mC" = (
 /obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "chair_preview";
-	dir = 1
+	tag = "icon-chair_preview (EAST)"
 	},
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (WEST)";
+	dir = 1;
 	icon_state = "chapel";
-	dir = 8
+	tag = "icon-chapel (NORTH)"
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9;
+	icon_state = "spline_fancy";
+	tag = "icon-spline_fancy (NORTHWEST)"
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "mD" = (
 /obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "chair_preview";
-	dir = 1
-	},
-/obj/effect/floor_decal/chapel,
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (EAST)";
-	icon_state = "spline_fancy";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
-"mE" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
-	icon_state = "chair_preview";
-	dir = 1
+	tag = "icon-chair_preview (EAST)"
 	},
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (WEST)";
+	dir = 4;
 	icon_state = "chapel";
-	dir = 8
+	tag = "icon-chapel (EAST)"
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (WEST)";
+	dir = 1;
 	icon_state = "spline_fancy";
-	dir = 8
+	tag = "icon-spline_fancy (NORTH)"
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "mF" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
-	icon_state = "chair_preview";
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5;
+	icon_state = "spline_fancy";
+	tag = "icon-spline_fancy (NORTHEAST)"
 	},
-/obj/effect/floor_decal/chapel,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "mG" = (
 /obj/structure/flora/tree/pine,
 /turf/simulated/floor/holofloor/snow,
 /area/holodeck/source_winter)
-"mH" = (
-/obj/structure/holostool,
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_theatre)
 "mI" = (
 /obj/structure/holostool,
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_theatre)
-"mJ" = (
-/obj/structure/holostool,
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_theatre)
 "mK" = (
@@ -6072,22 +5844,8 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/holofloor/grass,
 /area/holodeck/source_picnicarea)
-"mM" = (
-/obj/structure/holostool,
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_meetinghall)
 "mN" = (
 /obj/structure/holostool,
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_meetinghall)
-"mO" = (
-/obj/structure/holostool,
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_meetinghall)
 "mP" = (
@@ -6162,50 +5920,50 @@
 /area/syndicate_mothership/raider_base)
 "mX" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (WEST)";
+	dir = 8;
 	icon_state = "firelight1";
-	dir = 8
+	tag = "icon-firelight1 (WEST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
 "mY" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /obj/effect/decal/cleanable/blood{
-	tag = "icon-bloodsquare (NORTHWEST)";
+	dir = 9;
 	icon_state = "bloodsquare";
-	dir = 9
+	tag = "icon-bloodsquare (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
 "mZ" = (
 /obj/effect/floor_decal/corner/fadeblue/three_quarters{
-	tag = "icon-corner_white_three_quarters (WEST)";
+	dir = 8;
 	icon_state = "corner_white_three_quarters";
-	dir = 8
+	tag = "icon-corner_white_three_quarters (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/fightclub)
 "na" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/fightclub)
 "nb" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHEAST)";
+	dir = 5;
 	icon_state = "corner_white";
-	dir = 5
+	tag = "icon-corner_white (NORTHEAST)"
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,
@@ -6250,99 +6008,46 @@
 /area/holodeck/source_chapel)
 "ni" = (
 /obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "chair_preview";
-	dir = 1
+	tag = "icon-chair_preview (EAST)"
 	},
 /obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (NORTH)";
+	dir = 8;
 	icon_state = "chapel";
-	dir = 1
+	tag = "icon-chapel (WEST)"
 	},
-/obj/effect/floor_decal/spline/fancy/wood,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "nj" = (
 /obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "chair_preview";
-	dir = 1
-	},
-/obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
-	icon_state = "chapel";
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 6
+	tag = "icon-chair_preview (EAST)"
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
 "nk" = (
 /obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
+	dir = 4;
 	icon_state = "chair_preview";
-	dir = 1
+	tag = "icon-chair_preview (EAST)"
 	},
-/obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (NORTH)";
-	icon_state = "chapel";
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	tag = "icon-spline_fancy (SOUTHWEST)";
-	icon_state = "spline_fancy";
-	dir = 10
-	},
+/obj/effect/floor_decal/chapel,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_chapel)
-"nl" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (NORTH)";
-	icon_state = "chair_preview";
-	dir = 1
-	},
-/obj/effect/floor_decal/chapel{
-	tag = "icon-chapel (EAST)";
-	icon_state = "chapel";
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
-"nm" = (
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	tag = "icon-spline_fancy_corner (WEST)";
-	icon_state = "spline_fancy_corner";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
-"nn" = (
-/obj/structure/holostool,
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet,
-/obj/effect/floor_decal/carpet{
-	dir = 10
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_meetinghall)
-"no" = (
-/obj/structure/holostool,
-/obj/effect/floor_decal/carpet,
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_meetinghall)
 "np" = (
-/obj/structure/holostool,
 /obj/effect/floor_decal/carpet,
 /obj/effect/floor_decal/carpet{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/floor_decal/carpet{
-	dir = 6
+	dir = 10
 	},
+/obj/structure/holostool,
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_meetinghall)
 "nq" = (
@@ -6399,18 +6104,18 @@
 /area/syndicate_mothership/raider_base)
 "nw" = (
 /obj/machinery/light/small/red{
-	tag = "icon-firelight1 (EAST)";
+	dir = 4;
 	icon_state = "firelight1";
-	dir = 4
+	tag = "icon-firelight1 (EAST)"
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
 "nx" = (
 /obj/effect/decal/cleanable/blood{
-	tag = "icon-bloodsquare (NORTHWEST)";
+	dir = 9;
 	icon_state = "bloodsquare";
-	dir = 9
+	tag = "icon-bloodsquare (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fightclub)
@@ -6429,9 +6134,9 @@
 /area/fightclub)
 "nB" = (
 /obj/effect/floor_decal/corner/fadeblue{
-	tag = "icon-corner_white (NORTHWEST)";
+	dir = 9;
 	icon_state = "corner_white";
-	dir = 9
+	tag = "icon-corner_white (NORTHWEST)"
 	},
 /obj/random/junk,
 /turf/simulated/floor/tiled/white,
@@ -6489,12 +6194,6 @@
 	icon_state = "lino"
 	},
 /area/tdome/tdomeobserve)
-"nK" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_chapel)
 "nL" = (
 /obj/effect/floor_decal/carpet{
 	dir = 8
@@ -6507,16 +6206,6 @@
 /area/holodeck/source_theatre)
 "nM" = (
 /obj/effect/floor_decal/carpet,
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_theatre)
-"nN" = (
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet,
-/obj/effect/floor_decal/carpet{
-	dir = 6
-	},
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_theatre)
 "nO" = (
@@ -6650,86 +6339,40 @@
 	icon_state = "desert3"
 	},
 /area/holodeck/source_beach)
-"oi" = (
-/turf/simulated/floor/holofloor/beach/sand{
-	icon_state = "beach";
-	dir = 4
-	},
-/area/holodeck/source_beach)
 "oj" = (
 /turf/simulated/floor/holofloor/beach/water,
 /area/holodeck/source_beach)
 "ok" = (
 /turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-beach (WEST)";
+	dir = 4;
 	icon_state = "beach";
-	dir = 8
+	tag = "icon-beach (NORTH)"
 	},
 /area/holodeck/source_beach)
 "ol" = (
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_beach)
-"om" = (
-/turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-desert1";
-	icon_state = "desert1"
-	},
-/area/holodeck/source_beach)
-"on" = (
-/obj/effect/floor_decal/beach{
-	icon_state = "beachborder";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/concrete,
-/area/holodeck/source_volleyball)
-"oo" = (
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 9
-	},
-/turf/simulated/floor/holofloor/beach/sand{
-	icon_state = "desert2"
-	},
-/area/holodeck/source_volleyball)
 "op" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
-"oq" = (
+"or" = (
+/obj/structure/holonet,
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "desert4"
+	},
+/area/holodeck/source_volleyball)
+"os" = (
 /obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 5
+	dir = 5;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/holofloor/beach/sand{
 	icon_state = "desert4"
 	},
 /area/holodeck/source_volleyball)
-"or" = (
-/obj/effect/floor_decal/beach{
-	icon_state = "beachborder";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/concrete,
-/area/holodeck/source_volleyball)
-"os" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (EAST)";
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 9
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_courtroom)
 "ot" = (
 /obj/effect/floor_decal/carpet{
 	dir = 1
@@ -6751,12 +6394,6 @@
 "ov" = (
 /turf/simulated/floor/holofloor/wood,
 /area/holodeck/source_courtroom)
-"ow" = (
-/obj/effect/landmark{
-	name = "Holocarp Spawn"
-	},
-/turf/simulated/floor/holofloor/reinforced,
-/area/holodeck/source_wildlife)
 "ox" = (
 /turf/simulated/floor/holofloor/reinforced,
 /area/holodeck/source_wildlife)
@@ -7058,58 +6695,19 @@
 	icon_state = "beach"
 	},
 /area/holodeck/source_beach)
-"oX" = (
-/turf/simulated/floor/holofloor/beach/sand{
-	icon_state = "beach";
-	dir = 6
-	},
-/area/holodeck/source_beach)
-"oY" = (
-/obj/item/weapon/beach_ball,
-/turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-desert1";
-	icon_state = "desert1"
-	},
-/area/holodeck/source_beach)
-"oZ" = (
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/beach/sand,
-/area/holodeck/source_volleyball)
 "pa" = (
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
-"pb" = (
+"pc" = (
 /obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 4
+	dir = 4;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/holofloor/beach/sand{
 	icon_state = "desert2"
 	},
 /area/holodeck/source_volleyball)
-"pc" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (EAST)";
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_courtroom)
 "pd" = (
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_courtroom)
-"pe" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (EAST)";
-	icon_state = "chair_preview";
-	dir = 4
-	},
 /turf/simulated/floor/holofloor/carpet,
 /area/holodeck/source_courtroom)
 "pf" = (
@@ -7216,8 +6814,8 @@
 	dir = 9
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "pt" = (
@@ -7226,8 +6824,8 @@
 /obj/item/clothing/shoes/brown,
 /obj/item/weapon/melee/energy/axe,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "pu" = (
@@ -7259,8 +6857,8 @@
 /obj/item/clothing/shoes/brown,
 /obj/item/weapon/melee/energy/axe,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "px" = (
@@ -7268,27 +6866,14 @@
 	dir = 6
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
-"py" = (
-/turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-desert3";
-	icon_state = "desert3"
-	},
-/area/holodeck/source_beach)
 "pz" = (
 /turf/simulated/floor/holofloor/beach/sand{
 	icon_state = "desert3"
 	},
-/area/holodeck/source_volleyball)
-"pA" = (
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
 "pB" = (
 /obj/structure/table/holo_woodentable,
@@ -7373,8 +6958,8 @@
 	name = "Axe Supply"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "pN" = (
@@ -7394,27 +6979,8 @@
 	icon_state = "dark"
 	},
 /area/tdome)
-"pQ" = (
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 8
-	},
-/obj/structure/holonet/end,
-/turf/simulated/floor/holofloor/beach/sand,
-/area/holodeck/source_volleyball)
 "pR" = (
 /obj/structure/holonet,
-/turf/simulated/floor/holofloor/beach/sand,
-/area/holodeck/source_volleyball)
-"pS" = (
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 4
-	},
-/obj/structure/holonet/end{
-	icon_state = "volleynet_end";
-	dir = 8
-	},
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
 "pT" = (
@@ -7445,14 +7011,14 @@
 /area/skipjack_station/start)
 "pX" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	tag_airpump = "vox_west_vent";
-	tag_exterior_door = "vox_northwest_lock";
 	frequency = 1331;
 	id_tag = "vox_west_control";
-	tag_interior_door = "vox_southwest_lock";
 	pixel_x = 24;
 	req_access = list("ACCESS_SYNDICATE");
-	tag_chamber_sensor = "vox_west_sensor"
+	tag_airpump = "vox_west_vent";
+	tag_chamber_sensor = "vox_west_sensor";
+	tag_exterior_door = "vox_northwest_lock";
+	tag_interior_door = "vox_southwest_lock"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -7467,16 +7033,16 @@
 	dir = 8
 	},
 /obj/machinery/computer/station_alert/all{
-	icon_state = "computer";
-	dir = 4
+	dir = 4;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/shuttle/red,
 /area/skipjack_station/start)
 "pZ" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 8;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (WEST)"
 	},
 /turf/simulated/floor/shuttle/red,
 /area/skipjack_station/start)
@@ -7512,8 +7078,8 @@
 "qc" = (
 /obj/structure/computerframe,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/shuttle/red,
 /area/skipjack_station/start)
@@ -7552,9 +7118,9 @@
 /area/acting/stage)
 "qh" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/acting/stage)
@@ -7574,8 +7140,8 @@
 /obj/item/weapon/melee/baton/loaded,
 /obj/item/weapon/melee/energy/sword/red,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "qk" = (
@@ -7584,8 +7150,8 @@
 	name = "General Supply"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "ql" = (
@@ -7593,8 +7159,8 @@
 	name = "tdome2"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome/tdome2)
 "qm" = (
@@ -7603,8 +7169,8 @@
 	name = "Thunderdome Blast Door"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "qn" = (
@@ -7628,8 +7194,8 @@
 	name = "tdome1"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome/tdome1)
 "qq" = (
@@ -7641,22 +7207,15 @@
 /obj/item/weapon/melee/baton/loaded,
 /obj/item/weapon/melee/energy/sword/green,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
-"qr" = (
-/turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-beach (NORTH)";
-	icon_state = "beach";
-	dir = 1
-	},
-/area/holodeck/source_beach)
 "qs" = (
 /turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-beachcorner (EAST)";
+	dir = 8;
 	icon_state = "beachcorner";
-	dir = 4
+	tag = "icon-beachcorner (EAST)"
 	},
 /area/holodeck/source_beach)
 "qt" = (
@@ -7736,8 +7295,8 @@
 	name = "tdome2"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome/tdome2)
 "qF" = (
@@ -7748,24 +7307,10 @@
 	name = "tdome1"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome/tdome1)
-"qG" = (
-/obj/item/clothing/glasses/sunglasses,
-/turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-desert4";
-	icon_state = "desert4"
-	},
-/area/holodeck/source_beach)
-"qH" = (
-/obj/item/weapon/inflatable_duck,
-/turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-desert3";
-	icon_state = "desert3"
-	},
-/area/holodeck/source_beach)
 "qI" = (
 /turf/simulated/floor/holofloor/beach/sand{
 	icon_state = "desert_dug"
@@ -7847,8 +7392,8 @@
 /obj/random/voidhelmet,
 /obj/random/maintenance,
 /obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/shuttle/red,
 /area/skipjack_station/start)
@@ -7943,14 +7488,14 @@
 	invisibility = 101
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome/tdome2)
 "rc" = (
 /turf/unsimulated/floor{
-	tag = "icon-bcircuit";
-	icon_state = "bcircuit"
+	icon_state = "bcircuit";
+	tag = "icon-bcircuit"
 	},
 /area/tdome)
 "rd" = (
@@ -7959,8 +7504,8 @@
 	name = "Thunderdome Flash"
 	},
 /turf/unsimulated/floor{
-	tag = "icon-bcircuit";
-	icon_state = "bcircuit"
+	icon_state = "bcircuit";
+	tag = "icon-bcircuit"
 	},
 /area/tdome)
 "re" = (
@@ -7972,33 +7517,14 @@
 	invisibility = 101
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome/tdome1)
 "rf" = (
 /obj/effect/overlay/palmtree_l,
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_beach)
-"rg" = (
-/turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-desert2";
-	icon_state = "desert2"
-	},
-/area/holodeck/source_beach)
-"rh" = (
-/turf/simulated/floor/holofloor/beach/water{
-	tag = "icon-desert5";
-	icon_state = "desert5"
-	},
-/area/holodeck/source_beach)
-"ri" = (
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 10
-	},
-/turf/simulated/floor/holofloor/beach/sand,
-/area/holodeck/source_volleyball)
 "rj" = (
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/holofloor/beach/sand{
@@ -8009,28 +7535,13 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
-"rl" = (
+"rm" = (
 /obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 6
+	dir = 6;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/holofloor/beach/sand,
 /area/holodeck/source_volleyball)
-"rm" = (
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet,
-/obj/effect/floor_decal/carpet{
-	dir = 10
-	},
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (EAST)";
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/carpet,
-/area/holodeck/source_courtroom)
 "rn" = (
 /obj/effect/floor_decal/carpet,
 /turf/simulated/floor/holofloor/carpet,
@@ -8129,8 +7640,8 @@
 "rC" = (
 /obj/machinery/atmospherics/pipe/vent,
 /turf/unsimulated/floor{
-	tag = "icon-bcircuit";
-	icon_state = "bcircuit"
+	icon_state = "bcircuit";
+	tag = "icon-bcircuit"
 	},
 /area/tdome)
 "rD" = (
@@ -8139,8 +7650,8 @@
 	invisibility = 101
 	},
 /turf/unsimulated/floor{
-	tag = "icon-bcircuit";
-	icon_state = "bcircuit"
+	icon_state = "bcircuit";
+	tag = "icon-bcircuit"
 	},
 /area/tdome)
 "rE" = (
@@ -8207,9 +7718,9 @@
 /area/acting/backstage)
 "rN" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -8225,9 +7736,9 @@
 /area/tdome)
 "rP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -8236,18 +7747,11 @@
 "rQ" = (
 /turf/simulated/floor/holofloor/reinforced,
 /area/holodeck/source_battle_arena)
-"rR" = (
-/obj/structure/bed/chair/holochair{
-	tag = "icon-chair_preview (EAST)";
-	icon_state = "chair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_surgery)
 "rS" = (
-/obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 6
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_surgery)
@@ -8261,18 +7765,11 @@
 /turf/simulated/floor/holofloor/tiled/white,
 /area/holodeck/source_surgery)
 "rU" = (
-/obj/item/clothing/head/surgery/blue,
-/obj/item/clothing/head/surgery/black,
-/obj/item/clothing/head/surgery/green,
-/obj/item/clothing/head/surgery/navyblue,
-/obj/item/clothing/head/surgery/purple,
-/obj/structure/table/rack/holorack,
 /obj/effect/floor_decal/corner/paleblue{
-	tag = "icon-corner_white (NORTH)";
-	icon_state = "corner_white";
-	dir = 1
+	dir = 6;
+	icon_state = "corner_white"
 	},
-/turf/simulated/floor/holofloor/tiled/white,
+/turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_surgery)
 "rV" = (
 /obj/item/clothing/mask/surgical,
@@ -8283,19 +7780,16 @@
 /turf/simulated/floor/holofloor/tiled/white,
 /area/holodeck/source_surgery)
 "rW" = (
-/obj/effect/floor_decal/corner/paleblue{
-	tag = "icon-corner_white (EAST)";
-	icon_state = "corner_white";
-	dir = 4
-	},
+/obj/item/clothing/head/surgery/blue,
+/obj/item/clothing/head/surgery/black,
+/obj/item/clothing/head/surgery/green,
+/obj/item/clothing/head/surgery/navyblue,
+/obj/item/clothing/head/surgery/purple,
 /obj/structure/table/rack/holorack,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
-"rX" = (
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	tag = "icon-corner_white_three_quarters (NORTH)";
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (NORTH)"
 	},
 /turf/simulated/floor/holofloor/tiled/white,
 /area/holodeck/source_surgery)
@@ -8305,20 +7799,6 @@
 /area/holodeck/source_boxingcourt)
 "rZ" = (
 /turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_boxingcourt)
-"sa" = (
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 8
-	},
-/obj/machinery/door/window/holowindoor{
-	tag = "icon-left (WEST)";
-	icon_state = "left";
-	dir = 8
-	},
-/obj/structure/window/reinforced/holowindow{
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
 "sb" = (
 /obj/effect/floor_decal/corner/red{
@@ -8342,19 +7822,6 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
-"sd" = (
-/obj/structure/table/holotable,
-/obj/machinery/readybutton{
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 8
-	},
-/obj/structure/window/reinforced/holowindow{
-	dir = 1
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_thunderdomecourt)
 "se" = (
 /obj/structure/table/holotable,
 /obj/item/clothing/head/helmet/thunderdome,
@@ -8392,13 +7859,6 @@
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
 "si" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_basketball)
-"sj" = (
-/obj/structure/holohoop,
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
@@ -8486,26 +7946,7 @@
 	icon_state = "dark"
 	},
 /area/tdome)
-"sy" = (
-/obj/effect/floor_decal/corner/paleblue{
-	tag = "icon-corner_white (NORTH)";
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/structure/window/reinforced/holowindow{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
 "sz" = (
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
-"sA" = (
-/obj/effect/floor_decal/corner/paleblue{
-	tag = "icon-corner_white (EAST)";
-	icon_state = "corner_white";
-	dir = 4
-	},
 /turf/simulated/floor/holofloor/tiled/white,
 /area/holodeck/source_surgery)
 "sB" = (
@@ -8543,29 +7984,9 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
-"sG" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_thunderdomecourt)
 "sH" = (
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_thunderdomecourt)
-"sI" = (
-/obj/machinery/door/window/holowindoor{
-	tag = "icon-left (EAST)";
-	icon_state = "left";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_thunderdomecourt)
-"sJ" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_basketball)
 "sK" = (
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
@@ -8575,6 +7996,18 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
+"sM" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/structure/bed/chair/holochair{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/wood,
+/area/holodeck/source_meetinghall)
 "sN" = (
 /obj/random/loot,
 /obj/vehicle/bike/thermal,
@@ -8625,8 +8058,8 @@
 /area/skipjack_station/start)
 "sT" = (
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -8658,8 +8091,8 @@
 	req_access = list("ACCESS_CENT_THUNDERDOME")
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "sZ" = (
@@ -8668,8 +8101,8 @@
 	name = "Heavy Supply"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "ta" = (
@@ -8703,11 +8136,6 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
-"tg" = (
-/obj/structure/window/reinforced/holowindow/disappearing,
-/obj/effect/floor_decal/corner/red/three_quarters,
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_thunderdomecourt)
 "th" = (
 /obj/structure/window/reinforced/holowindow/disappearing,
 /obj/effect/floor_decal/corner/red{
@@ -8725,28 +8153,6 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_thunderdomecourt)
-"tj" = (
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_basketball)
-"tk" = (
-/obj/item/weapon/beach_ball/holoball,
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_basketball)
-"tl" = (
-/obj/effect/floor_decal/corner/red{
-	tag = "icon-corner_white (SOUTHEAST)";
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_basketball)
 "tm" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8852,8 +8258,8 @@
 "tC" = (
 /obj/effect/floor_decal/corner/red/three_quarters,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "tD" = (
@@ -8861,8 +8267,8 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "tE" = (
@@ -8873,8 +8279,8 @@
 /obj/item/clothing/head/helmet/swat,
 /obj/item/weapon/gun/energy/laser,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "tF" = (
@@ -8906,15 +8312,15 @@
 /obj/item/clothing/head/helmet/swat,
 /obj/item/weapon/gun/energy/laser,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "tI" = (
 /obj/effect/floor_decal/corner/green,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
 "tJ" = (
@@ -8922,21 +8328,10 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 5
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/tdome)
-"tK" = (
-/obj/effect/floor_decal/corner/paleblue{
-	tag = "icon-corner_white (WEST)";
-	icon_state = "corner_white";
-	dir = 8
-	},
-/obj/structure/window/reinforced/holowindow{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
 "tL" = (
 /obj/effect/floor_decal/corner/paleblue,
 /obj/item/weapon/retractor,
@@ -8976,15 +8371,6 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_boxingcourt)
-"tP" = (
-/obj/structure/window/reinforced/holowindow/disappearing{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/green/three_quarters{
-	dir = 8
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_thunderdomecourt)
 "tQ" = (
 /obj/structure/window/reinforced/holowindow/disappearing{
 	dir = 1
@@ -9007,41 +8393,20 @@
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_thunderdomecourt)
 "tS" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
 /obj/effect/floor_decal/corner/green{
-	dir = 10
+	dir = 9
+	},
+/obj/structure/holohoop{
+	dir = 4
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
-"tU" = (
-/obj/structure/shuttle/engine/propulsion/burst/right{
-	tag = "icon-burst_r (NORTH)";
-	name = "propulsion";
-	icon_state = "burst_r";
-	dir = 1
-	},
-/turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall";
-	tag = "icon-swall2"
-	},
-/area/shuttle/transport1/centcom)
-"tV" = (
-/obj/effect/floor_decal/industrial/warning{
-	tag = "icon-warning (NORTH)";
-	icon_state = "warning";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/centcom)
 "tW" = (
-/obj/structure/shuttle/engine/propulsion/burst/left{
-	tag = "icon-burst_l (NORTH)";
+/obj/structure/shuttle/engine/propulsion/burst/right{
+	dir = 1;
+	icon_state = "burst_r";
 	name = "propulsion";
-	icon_state = "burst_l";
-	dir = 1
+	tag = "icon-burst_r (NORTH)"
 	},
 /turf/simulated/shuttle/wall{
 	dir = 2;
@@ -9163,18 +8528,6 @@
 /obj/structure/window/reinforced/holowindow,
 /turf/simulated/floor/holofloor/tiled/white,
 /area/holodeck/source_surgery)
-"uo" = (
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
-	icon_state = "corner_white_three_quarters";
-	dir = 4
-	},
-/obj/item/weapon/circular_saw,
-/obj/item/weapon/cautery,
-/obj/structure/table/holotable,
-/obj/structure/window/reinforced/holowindow,
-/turf/simulated/floor/holofloor/tiled/white,
-/area/holodeck/source_surgery)
 "up" = (
 /obj/structure/table/holotable,
 /obj/item/clothing/gloves/boxing/hologlove{
@@ -9183,42 +8536,20 @@
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_boxingcourt)
-"uq" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 9
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_thunderdomecourt)
 "ur" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
-"us" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_basketball)
-"ut" = (
-/obj/effect/floor_decal/corner/green{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_basketball)
 "uu" = (
-/turf/unsimulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "swall_c"
-	},
-/area/shuttle/transport1/centcom)
+/turf/space,
+/turf/unsimulated/wall,
+/area/space)
 "uv" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_t";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_t"
 	},
 /area/shuttle/transport1/centcom)
 "uw" = (
@@ -9229,17 +8560,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/transport1/centcom)
-"ux" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_straight";
-	dir = 4
-	},
-/area/shuttle/transport1/centcom)
 "uy" = (
-/turf/unsimulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_c"
+/obj/machinery/door/airlock/external{
+	frequency = 1331;
+	id_tag = "rescue_base_hatch";
+	req_access = list("ACCESS_CENT_SPECOPS")
 	},
+/turf/space,
+/turf/simulated/floor/tiled,
 /area/shuttle/transport1/centcom)
 "uz" = (
 /turf/simulated/mineral,
@@ -9337,26 +8665,12 @@
 "uO" = (
 /turf/simulated/floor/tiled/dark,
 /area/tdome)
-"uP" = (
-/obj/effect/floor_decal/corner/paleblue{
-	tag = "icon-corner_white (EAST)";
-	icon_state = "corner_white";
-	dir = 4
-	},
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/holodeck/source_surgery)
 "uQ" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_surgery)
-"uR" = (
-/obj/structure/table/holotable,
-/obj/effect/floor_decal/corner/green/three_quarters,
-/obj/structure/window/reinforced/holowindow,
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_thunderdomecourt)
 "uS" = (
 /obj/structure/table/holotable,
 /obj/item/clothing/head/helmet/thunderdome,
@@ -9383,12 +8697,6 @@
 /obj/structure/window/reinforced/holowindow,
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_thunderdomecourt)
-"uU" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 6
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_basketball)
 "uV" = (
 /obj/structure/window/shuttle{
 	icon_state = "window2"
@@ -9489,15 +8797,6 @@
 /obj/effect/floor_decal/corner/green/three_quarters,
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_basketball)
-"vl" = (
-/obj/structure/holohoop{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/green{
-	dir = 10
-	},
-/turf/simulated/floor/holofloor/tiled,
-/area/holodeck/source_basketball)
 "vm" = (
 /obj/effect/floor_decal/corner/green/three_quarters{
 	dir = 4
@@ -9511,19 +8810,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/transport1/centcom)
-"vo" = (
-/obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (EAST)";
-	icon_state = "shuttle_chair_preview";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/shuttle/transport1/centcom)
 "vp" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair_preview (WEST)";
+	dir = 4;
 	icon_state = "shuttle_chair_preview";
-	dir = 8
+	tag = "icon-shuttle_chair_preview (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/transport1/centcom)
@@ -9814,9 +9105,9 @@
 "wa" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (NORTHWEST)";
+	dir = 9;
 	icon_state = "gravsnow_corner";
-	dir = 9
+	tag = "icon-gravsnow_corner (NORTHWEST)"
 	},
 /area/syndicate_mothership)
 "wb" = (
@@ -9838,22 +9129,19 @@
 "we" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (NORTHEAST)";
+	dir = 5;
 	icon_state = "gravsnow_corner";
-	dir = 5
+	tag = "icon-gravsnow_corner (NORTHEAST)"
 	},
 /area/syndicate_mothership)
 "wf" = (
-/turf/unsimulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	dir = 1;
-	icon_state = "swall_c"
-	},
-/area/shuttle/transport1/centcom)
+/turf/space,
+/turf/space,
+/area/space)
 "wg" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_t";
-	dir = 1
+	dir = 1;
+	icon_state = "swall_t"
 	},
 /area/shuttle/transport1/centcom)
 "wh" = (
@@ -9863,19 +9151,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/transport1/centcom)
-"wi" = (
-/obj/effect/shuttle_landmark/ferry/start,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_straight";
-	dir = 4
-	},
-/area/shuttle/transport1/centcom)
 "wj" = (
-/turf/unsimulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "swall_c"
+/obj/machinery/door/airlock/hatch{
+	name = "Cockpit";
+	req_access = list("ACCESS_CENT_GENERAL")
 	},
+/turf/space,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/transport1/centcom)
 "wk" = (
 /turf/unsimulated/floor{
@@ -9891,9 +9173,9 @@
 "wm" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (WEST)";
+	dir = 8;
 	icon_state = "gravsnow_corner";
-	dir = 8
+	tag = "icon-gravsnow_corner (WEST)"
 	},
 /area/syndicate_mothership)
 "wn" = (
@@ -9924,14 +9206,6 @@
 	icon_state = "snow"
 	},
 /area/ninja_dojo/dojo)
-"ws" = (
-/obj/machinery/computer/shuttle_control/transport_shuttle{
-	tag = "icon-computer (NORTH)";
-	icon_state = "computer";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/transport1/centcom)
 "wt" = (
 /turf/unsimulated/floor{
 	icon_state = "reinforced"
@@ -9954,9 +9228,9 @@
 /obj/structure/flora/grass/both,
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (SOUTHEAST)";
+	dir = 6;
 	icon_state = "gravsnow_corner";
-	dir = 6
+	tag = "icon-gravsnow_corner (SOUTHEAST)"
 	},
 /area/syndicate_mothership)
 "wx" = (
@@ -9998,9 +9272,9 @@
 /area/space)
 "wC" = (
 /obj/machinery/door/blast/shutters/open{
-	tag = "icon-shutter1";
+	dir = 2;
 	icon_state = "shutter1";
-	dir = 2
+	tag = "icon-shutter1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/space)
@@ -10033,9 +9307,9 @@
 "wH" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (SOUTHEAST)";
+	dir = 6;
 	icon_state = "gravsnow_corner";
-	dir = 6
+	tag = "icon-gravsnow_corner (SOUTHEAST)"
 	},
 /area/syndicate_mothership)
 "wI" = (
@@ -10050,9 +9324,9 @@
 /area/space)
 "wJ" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
+	dir = 1;
 	icon_state = "tube1";
-	dir = 1
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/space)
@@ -10061,9 +9335,9 @@
 /area/space)
 "wL" = (
 /obj/structure/shuttle/engine/propulsion{
-	tag = "icon-propulsion (EAST)";
+	dir = 4;
 	icon_state = "propulsion";
-	dir = 4
+	tag = "icon-propulsion (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10073,9 +9347,9 @@
 "wM" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /area/syndicate_mothership)
 "wN" = (
@@ -10182,8 +9456,8 @@
 /area/wizard_station)
 "xb" = (
 /turf/unsimulated/wall/fakeglass{
-	icon_state = "fakewindows";
-	dir = 8
+	dir = 8;
+	icon_state = "fakewindows"
 	},
 /area/wizard_station)
 "xc" = (
@@ -10207,8 +9481,8 @@
 /area/syndicate_mothership)
 "xg" = (
 /turf/unsimulated/wall/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 1
+	dir = 1;
+	icon_state = "fakewindows2"
 	},
 /area/syndicate_mothership)
 "xh" = (
@@ -10531,31 +9805,31 @@
 /obj/structure/flora/tree/pine,
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner";
-	icon_state = "gravsnow_corner"
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner"
 	},
 /area/syndicate_mothership)
 "xT" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner";
-	icon_state = "gravsnow_corner"
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner"
 	},
 /area/syndicate_mothership)
 "xU" = (
 /obj/structure/flora/grass/both,
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner";
-	icon_state = "gravsnow_corner"
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner"
 	},
 /area/syndicate_mothership)
 "xV" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_surround (EAST)";
+	dir = 4;
 	icon_state = "gravsnow_surround";
-	dir = 4
+	tag = "icon-gravsnow_surround (EAST)"
 	},
 /area/syndicate_mothership)
 "xW" = (
@@ -10707,14 +9981,14 @@
 /area/syndicate_mothership)
 "ym" = (
 /turf/unsimulated/wall/fakeglass{
-	icon_state = "fakewindows";
-	dir = 9
+	dir = 9;
+	icon_state = "fakewindows"
 	},
 /area/syndicate_mothership)
 "yn" = (
 /turf/unsimulated/wall/fakeglass{
-	icon_state = "fakewindows";
-	dir = 4
+	dir = 4;
+	icon_state = "fakewindows"
 	},
 /area/syndicate_mothership)
 "yo" = (
@@ -10793,8 +10067,8 @@
 /area/ninja_dojo/dojo)
 "yz" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -10803,8 +10077,8 @@
 /area/ninja_dojo/dojo)
 "yA" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 4
+	dir = 4;
+	icon_state = "chapel"
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -10822,9 +10096,9 @@
 /area/ninja_dojo/dojo)
 "yC" = (
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "yD" = (
@@ -10832,9 +10106,9 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "yE" = (
@@ -10842,17 +10116,17 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "yF" = (
 /obj/machinery/vending/snack,
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "yG" = (
@@ -10901,8 +10175,8 @@
 /area/merchant_station)
 "yN" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/supply/dock)
@@ -10992,8 +10266,8 @@
 /area/ninja_dojo/dojo)
 "yY" = (
 /obj/effect/floor_decal/chapel{
-	icon_state = "chapel";
-	dir = 8
+	dir = 8;
+	icon_state = "chapel"
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -11010,9 +10284,9 @@
 "za" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "zb" = (
@@ -11060,9 +10334,9 @@
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /turf/simulated/floor/carpet,
 /area/merchant_station)
@@ -11088,8 +10362,8 @@
 /area/supply/dock)
 "zi" = (
 /obj/effect/floor_decal/corner/paleblue{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/supply/dock)
@@ -11219,9 +10493,9 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "zw" = (
@@ -11230,9 +10504,9 @@
 	pixel_y = 2
 	},
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "zx" = (
@@ -11245,9 +10519,9 @@
 	pixel_y = 4
 	},
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "zy" = (
@@ -11255,9 +10529,9 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "zz" = (
@@ -11265,9 +10539,9 @@
 	prices = list()
 	},
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "zA" = (
@@ -11286,17 +10560,17 @@
 	},
 /obj/structure/undies_wardrobe,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	tag = "icon-map_vent_out (EAST)";
+	dir = 4;
 	icon_state = "map_vent_out";
-	dir = 4
+	tag = "icon-map_vent_out (EAST)"
 	},
 /turf/simulated/floor/carpet,
 /area/merchant_station)
 "zC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact-supply";
-	dir = 10
+	tag = "icon-intact-supply (SOUTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
@@ -11322,9 +10596,9 @@
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/merchant_station)
@@ -11403,8 +10677,8 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "zR" = (
@@ -11412,8 +10686,8 @@
 	pixel_y = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "zS" = (
@@ -11430,8 +10704,8 @@
 /area/wizard_station)
 "zT" = (
 /obj/structure/bed/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
-	dir = 4
+	dir = 4;
+	icon_state = "wooden_chair_wings"
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -11448,8 +10722,8 @@
 /area/wizard_station)
 "zV" = (
 /obj/structure/bed/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
-	dir = 8
+	dir = 8;
+	icon_state = "wooden_chair_wings"
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -11590,17 +10864,17 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "An" = (
 /obj/machinery/vending/cola,
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "Ao" = (
@@ -11699,8 +10973,8 @@
 /area/merchant_station)
 "AC" = (
 /turf/unsimulated/wall/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 1
+	dir = 1;
+	icon_state = "fakewindows2"
 	},
 /area/wizard_station)
 "AD" = (
@@ -11708,21 +10982,21 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "AE" = (
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "AF" = (
 /obj/machinery/door/unpowered/simple/iron,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "AG" = (
@@ -11806,9 +11080,9 @@
 "AR" = (
 /obj/machinery/vending/cigarette,
 /turf/unsimulated/floor{
-	tag = "icon-cult";
+	icon_state = "cult";
 	name = "plating";
-	icon_state = "cult"
+	tag = "icon-cult"
 	},
 /area/syndicate_mothership)
 "AS" = (
@@ -11886,9 +11160,9 @@
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-supply";
-	dir = 6
+	tag = "icon-intact-supply (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
@@ -11902,8 +11176,8 @@
 /area/merchant_station)
 "Ba" = (
 /obj/structure/hygiene/shower{
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	icon_state = "shower"
 	},
 /obj/structure/curtain/open/shower,
 /obj/structure/window/reinforced,
@@ -11961,9 +11235,9 @@
 /area/supply/dock)
 "Bi" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -11991,8 +11265,8 @@
 	pixel_y = -22
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "Bm" = (
@@ -12006,8 +11280,8 @@
 	pixel_x = 32
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "Bn" = (
@@ -12123,15 +11397,15 @@
 /area/syndicate_station/start)
 "By" = (
 /turf/unsimulated/wall/fakeglass{
-	tag = "icon-fakewindows (SOUTHWEST)";
+	dir = 10;
 	icon_state = "fakewindows";
-	dir = 10
+	tag = "icon-fakewindows (SOUTHWEST)"
 	},
 /area/syndicate_mothership)
 "Bz" = (
 /turf/unsimulated/wall/fakeglass{
-	icon_state = "fakewindows2";
-	dir = 8
+	dir = 8;
+	icon_state = "fakewindows2"
 	},
 /area/syndicate_mothership)
 "BA" = (
@@ -12145,8 +11419,8 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "BC" = (
@@ -12157,8 +11431,8 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "BD" = (
@@ -12167,8 +11441,8 @@
 	},
 /obj/item/weapon/soap/syndie,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "BE" = (
@@ -12237,14 +11511,14 @@
 /area/merchant_station)
 "BN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-scrubbers";
-	dir = 5
+	tag = "icon-intact-scrubbers (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact-supply";
-	dir = 5
+	tag = "icon-intact-supply (NORTHEAST)"
 	},
 /turf/simulated/floor/wood,
 /area/merchant_station)
@@ -12273,9 +11547,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "intact-scrubbers";
-	dir = 4
+	tag = "icon-intact-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12287,9 +11561,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/merchant_station)
@@ -12312,9 +11586,9 @@
 /area/merchant_station)
 "BU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	tag = "icon-intact-scrubbers (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact-scrubbers";
-	dir = 6
+	tag = "icon-intact-scrubbers (SOUTHEAST)"
 	},
 /mob/living/simple_animal/tindalos{
 	name = "Eddy"
@@ -12469,9 +11743,9 @@
 "Co" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (NORTH)";
+	dir = 1;
 	icon_state = "gravsnow_corner";
-	dir = 1
+	tag = "icon-gravsnow_corner (NORTH)"
 	},
 /area/syndicate_mothership)
 "Cp" = (
@@ -12480,14 +11754,14 @@
 	opacity = 1
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "Cq" = (
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "Cr" = (
@@ -12495,8 +11769,8 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "Cs" = (
@@ -12711,15 +11985,15 @@
 /area/ninja_dojo/dojo)
 "CQ" = (
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/ninja_dojo/dojo)
 "CR" = (
 /obj/effect/floor_decal/snow,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/ninja_dojo/dojo)
 "CS" = (
@@ -12763,14 +12037,14 @@
 	pixel_y = 0
 	},
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "CX" = (
@@ -12791,8 +12065,8 @@
 "Da" = (
 /obj/machinery/papershredder,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -12822,8 +12096,8 @@
 /obj/structure/table/woodentable,
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/merchant_station)
@@ -12879,10 +12153,10 @@
 "Dp" = (
 /turf/unsimulated/wall{
 	desc = "A secure airlock. Doesn't look like you can get through easily.";
+	dir = 4;
 	icon = 'icons/obj/doors/centcomm/door.dmi';
 	icon_state = "closed";
-	name = "Outer Gate";
-	dir = 4
+	name = "Outer Gate"
 	},
 /area/ninja_dojo/dojo)
 "Dq" = (
@@ -12980,8 +12254,8 @@
 /obj/item/weapon/storage/belt/medical,
 /obj/item/weapon/storage/belt/medical,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/syndicate_mothership)
 "DB" = (
@@ -12993,8 +12267,8 @@
 /obj/item/weapon/storage/belt/holster/security/tactical,
 /obj/item/weapon/storage/belt/holster/security/tactical,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/syndicate_mothership)
 "DC" = (
@@ -13123,14 +12397,14 @@
 /area/merchant_station)
 "DR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	tag = "icon-map-scrubbers (EAST)";
+	dir = 4;
 	icon_state = "map-scrubbers";
-	dir = 4
+	tag = "icon-map-scrubbers (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	tag = "icon-map-supply (EAST)";
+	dir = 4;
 	icon_state = "map-supply";
-	dir = 4
+	tag = "icon-map-supply (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/merchant_station)
@@ -13221,9 +12495,9 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	tag = "icon-map_scrubber_on (EAST)";
+	dir = 4;
 	icon_state = "map_scrubber_on";
-	dir = 4
+	tag = "icon-map_scrubber_on (EAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/merchant_station)
@@ -13271,14 +12545,14 @@
 "Eg" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (WEST)";
+	dir = 8;
 	icon_state = "gravsnow_corner";
-	dir = 8
+	tag = "icon-gravsnow_corner (WEST)"
 	},
 /area/syndicate_mothership)
 "Eh" = (
@@ -13546,8 +12820,8 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/merchant_station)
@@ -13609,9 +12883,9 @@
 /area/supply/dock)
 "ET" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
-	tag = "icon-corner_white_three_quarters (EAST)";
+	dir = 4;
 	icon_state = "corner_white_three_quarters";
-	dir = 4
+	tag = "icon-corner_white_three_quarters (EAST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -13703,8 +12977,8 @@
 "Fc" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_surround";
-	icon_state = "gravsnow_surround"
+	icon_state = "gravsnow_surround";
+	tag = "icon-gravsnow_surround"
 	},
 /area/syndicate_mothership)
 "Fd" = (
@@ -13717,8 +12991,8 @@
 /area/syndicate_mothership)
 "Fe" = (
 /turf/unsimulated/wall/fakeglass{
-	icon_state = "fakewindows";
-	dir = 8
+	dir = 8;
+	icon_state = "fakewindows"
 	},
 /area/syndicate_mothership)
 "Ff" = (
@@ -13770,14 +13044,14 @@
 /area/syndicate_mothership)
 "Fj" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_s";
-	dir = 4
+	dir = 4;
+	icon_state = "swall_s"
 	},
 /area/shuttle/merchant/home)
 "Fk" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 4
+	dir = 4;
+	icon_state = "heater"
 	},
 /turf/simulated/shuttle/wall,
 /area/shuttle/merchant/home)
@@ -13859,9 +13133,9 @@
 /area/merchant_station)
 "Fs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	tag = "icon-intact-supply (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact-supply";
-	dir = 9
+	tag = "icon-intact-supply (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -13889,8 +13163,8 @@
 	name = "Bath"
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/ninja_dojo/dojo)
 "Fv" = (
@@ -13969,26 +13243,26 @@
 /area/syndicate_mothership)
 "FB" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_s";
-	dir = 8
+	dir = 8;
+	icon_state = "swall_s"
 	},
 /area/shuttle/merchant/home)
 "FC" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_straight";
-	dir = 4
+	dir = 4;
+	icon_state = "swall_straight"
 	},
 /area/shuttle/merchant/home)
 "FD" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_t";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_t"
 	},
 /area/shuttle/merchant/home)
 "FE" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_t";
-	dir = 1
+	dir = 1;
+	icon_state = "swall_t"
 	},
 /area/shuttle/merchant/home)
 "FF" = (
@@ -14005,8 +13279,8 @@
 /area/shuttle/merchant/home)
 "FH" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_s";
-	dir = 2
+	dir = 2;
+	icon_state = "swall_s"
 	},
 /area/shuttle/merchant/home)
 "FI" = (
@@ -14024,9 +13298,9 @@
 /area/merchant_station)
 "FK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	tag = "icon-map_vent_out (NORTH)";
+	dir = 1;
 	icon_state = "map_vent_out";
-	dir = 1
+	tag = "icon-map_vent_out (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/merchant_station)
@@ -14039,14 +13313,14 @@
 "FM" = (
 /obj/structure/closet/coffin,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "FN" = (
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "FO" = (
@@ -14054,8 +13328,8 @@
 	pixel_y = 22
 	},
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "FP" = (
@@ -14073,15 +13347,15 @@
 	pixel_x = -22
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/ninja_dojo/dojo)
 "FR" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/ninja_dojo/dojo)
 "FS" = (
@@ -14090,8 +13364,8 @@
 	pixel_y = 8
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/ninja_dojo/dojo)
 "FT" = (
@@ -14286,20 +13560,20 @@
 /obj/item/clothing/head/helmet/merc,
 /obj/item/clothing/head/helmet/merc,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/syndicate_mothership)
 "Gm" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_t";
-	dir = 8
+	dir = 8;
+	icon_state = "swall_t"
 	},
 /area/shuttle/merchant/home)
 "Go" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_t";
-	dir = 4
+	dir = 4;
+	icon_state = "swall_t"
 	},
 /area/shuttle/merchant/home)
 "Gp" = (
@@ -14314,8 +13588,8 @@
 /area/shuttle/merchant/home)
 "Gq" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall";
-	dir = 1
+	dir = 1;
+	icon_state = "swall"
 	},
 /area/shuttle/merchant/home)
 "Gr" = (
@@ -14339,15 +13613,15 @@
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/door/window/brigdoor/southright{
 	req_access = list("ACCESS_MERCHANT")
 	},
 /obj/structure/window/phoronreinforced{
-	icon_state = "rwindow";
-	dir = 8
+	dir = 8;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/merchant/home)
@@ -14384,15 +13658,15 @@
 "GA" = (
 /obj/structure/cult/pylon,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "GB" = (
 /obj/structure/kitchenspike,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "GC" = (
@@ -14444,8 +13718,8 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/ninja_dojo/dojo)
 "GG" = (
@@ -14664,8 +13938,8 @@
 /area/shuttle/merchant/home)
 "Hg" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_straight";
-	dir = 1
+	dir = 1;
+	icon_state = "swall_straight"
 	},
 /area/shuttle/merchant/home)
 "Hi" = (
@@ -14721,14 +13995,14 @@
 "Hp" = (
 /obj/item/remains/human,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "lava"
+	icon_state = "lava";
+	name = "plating"
 	},
 /area/wizard_station)
 "Hq" = (
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "lava"
+	icon_state = "lava";
+	name = "plating"
 	},
 /area/wizard_station)
 "Hr" = (
@@ -14749,8 +14023,8 @@
 	dir = 4
 	},
 /obj/structure/hygiene/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -14758,8 +14032,8 @@
 	pixel_x = -32
 	},
 /turf/unsimulated/floor{
-	icon_state = "freezerfloor";
-	dir = 2
+	dir = 2;
+	icon_state = "freezerfloor"
 	},
 /area/ninja_dojo/dojo)
 "Hu" = (
@@ -14891,20 +14165,20 @@
 	},
 /obj/item/weapon/pen,
 /obj/structure/window/phoronreinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/merchant/home)
 "HJ" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/phoronreinforced{
-	icon_state = "rwindow";
-	dir = 4
+	dir = 4;
+	icon_state = "rwindow"
 	},
 /obj/structure/window/phoronreinforced{
-	icon_state = "rwindow";
-	dir = 1
+	dir = 1;
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/merchant/home)
@@ -14932,9 +14206,9 @@
 /area/shuttle/merchant/home)
 "HN" = (
 /obj/effect/floor_decal/industrial/loading{
-	tag = "icon-loadingarea (WEST)";
+	dir = 8;
 	icon_state = "loadingarea";
-	dir = 8
+	tag = "icon-loadingarea (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
@@ -15014,31 +14288,31 @@
 	name = "Experiment 35b"
 	},
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "lava"
+	icon_state = "lava";
+	name = "plating"
 	},
 /area/wizard_station)
 "HW" = (
 /obj/structure/cult/talisman,
 /obj/item/weapon/material/knife/ritual,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "HX" = (
 /obj/effect/gateway/active/cult,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "HY" = (
 /obj/structure/table/marble,
 /obj/item/device/flashlight/slime,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "HZ" = (
@@ -15116,9 +14390,9 @@
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/shuttle/darkred,
 /area/syndicate_station/start)
@@ -15480,13 +14754,6 @@
 /obj/item/weapon/material/clipboard,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/merchant/home)
-"Jb" = (
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall2";
-	icon_state = "swall";
-	dir = 2
-	},
-/area/shuttle/merchant/home)
 "Jc" = (
 /obj/machinery/door/window/brigdoor/northleft{
 	req_access = list("ACCESS_MERCHANT")
@@ -15591,8 +14858,8 @@
 /area/merchant_station)
 "Jp" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/vending/urist/shoedispenser,
 /turf/simulated/floor/tiled,
@@ -15683,8 +14950,8 @@
 /area/syndicate_mothership)
 "JA" = (
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_s";
-	dir = 1
+	dir = 1;
+	icon_state = "swall_s"
 	},
 /area/shuttle/merchant/home)
 "JB" = (
@@ -15711,8 +14978,8 @@
 /area/merchant_station)
 "JE" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/conveyor_switch{
 	id = "merchantbelt1"
@@ -15729,16 +14996,16 @@
 "JG" = (
 /obj/structure/flora/pottedplant/unusual,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "JH" = (
 /obj/structure/table/woodentable,
 /obj/item/xenos_claw,
 /turf/unsimulated/floor{
-	name = "plating";
-	icon_state = "cult"
+	icon_state = "cult";
+	name = "plating"
 	},
 /area/wizard_station)
 "JI" = (
@@ -15800,8 +15067,8 @@
 	amount = 50
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/syndicate_mothership)
 "JO" = (
@@ -15811,8 +15078,8 @@
 	name = "Unlocked Autolathe"
 	},
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/syndicate_mothership)
 "JP" = (
@@ -15824,8 +15091,8 @@
 /obj/item/weapon/storage/belt/utility/full,
 /obj/item/weapon/storage/belt/utility/full,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/syndicate_mothership)
 "JQ" = (
@@ -15980,8 +15247,8 @@
 /area/merchant_station)
 "Kd" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion"
 	},
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -16290,8 +15557,8 @@
 /area/wizard_station)
 "KJ" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 4
+	dir = 4;
+	icon_state = "warning"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -16304,8 +15571,8 @@
 /area/ninja_dojo/start)
 "KK" = (
 /obj/machinery/computer/teleporter{
-	icon_state = "computer";
-	dir = 2
+	dir = 2;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/plating,
 /area/ninja_dojo/start)
@@ -16326,8 +15593,8 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/unsimulated/floor{
 	dir = 2;
@@ -16530,8 +15797,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/unsimulated/floor{
@@ -16547,8 +15814,8 @@
 /area/ninja_dojo/start)
 "Lm" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /turf/unsimulated/floor{
 	dir = 2;
@@ -16583,8 +15850,8 @@
 	req_access = list("ACCESS_SYNDICATE")
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ninja_dojo/start)
@@ -16643,8 +15910,8 @@
 /area/syndicate_station/start)
 "Lx" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/solarpanel,
@@ -16899,13 +16166,13 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/buildable{
+	RCon_tag = null;
 	charge = 2.5e+006;
 	input_attempt = 1;
 	input_level = 250000;
 	inputting = 0;
 	output_attempt = 1;
-	output_level = 250000;
-	RCon_tag = null
+	output_level = 250000
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
@@ -16977,8 +16244,8 @@
 "Mh" = (
 /obj/structure/closet,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/unsimulated/floor{
@@ -17043,8 +16310,8 @@
 /area/syndicate_station/start)
 "Mp" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/tracker,
 /turf/simulated/floor/airless,
@@ -17082,9 +16349,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/airless,
 /area/merchant_station)
@@ -17118,8 +16385,8 @@
 /area/merchant_station)
 "Mv" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -17179,9 +16446,9 @@
 "MB" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
@@ -17203,8 +16470,8 @@
 "ME" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/device/radio/intercom/syndicate{
 	dir = 4;
@@ -17246,8 +16513,8 @@
 /obj/machinery/recharger,
 /obj/item/weapon/wrench,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/unsimulated/floor{
@@ -17338,8 +16605,8 @@
 /obj/item/weapon/rig/merc/empty,
 /obj/item/weapon/rig/merc/heavy/empty,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/syndicate_mothership)
 "MS" = (
@@ -17373,9 +16640,9 @@
 /area/merchant_station)
 "MW" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
@@ -17392,9 +16659,9 @@
 /area/merchant_station)
 "MY" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
@@ -17418,8 +16685,8 @@
 "Nc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/station_alert/all{
-	icon_state = "computer";
-	dir = 1
+	dir = 1;
+	icon_state = "computer"
 	},
 /turf/unsimulated/floor{
 	dir = 2;
@@ -17429,8 +16696,8 @@
 "Nd" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/shuttle_control/multi/ninja{
-	icon_state = "computer";
-	dir = 1
+	dir = 1;
+	icon_state = "computer"
 	},
 /turf/unsimulated/floor{
 	dir = 2;
@@ -17440,8 +16707,8 @@
 "Ne" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/modular_computer/console/preset/security{
-	icon_state = "console";
-	dir = 1
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/unsimulated/floor{
 	dir = 2;
@@ -17488,8 +16755,8 @@
 /obj/structure/table/rack,
 /obj/item/device/suit_cooling_unit,
 /turf/unsimulated/floor{
-	icon_state = "vault";
-	dir = 8
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/syndicate_mothership)
 "Nk" = (
@@ -17518,17 +16785,17 @@
 /area/merchant_station)
 "No" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/merchant_station)
 "Np" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
@@ -17618,9 +16885,9 @@
 "Nx" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_surround (NORTH)";
+	dir = 1;
 	icon_state = "gravsnow_surround";
-	dir = 1
+	tag = "icon-gravsnow_surround (NORTH)"
 	},
 /area/syndicate_mothership)
 "Ny" = (
@@ -17655,9 +16922,9 @@
 /area/merchant_station)
 "ND" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/item/weapon/tank/nitrogen,
@@ -17666,20 +16933,20 @@
 /area/merchant_station)
 "NE" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	tag = "icon-air_map (NORTH)";
-	icon_state = "air_map";
 	dir = 1;
-	start_pressure = 740.5
+	icon_state = "air_map";
+	start_pressure = 740.5;
+	tag = "icon-air_map (NORTH)"
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/merchant_station)
 "NF" = (
 /obj/machinery/atmospherics/pipe/tank/air{
-	tag = "icon-air_map (NORTH)";
-	icon_state = "air_map";
 	dir = 1;
-	start_pressure = 740.5
+	icon_state = "air_map";
+	start_pressure = 740.5;
+	tag = "icon-air_map (NORTH)"
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
@@ -17718,30 +16985,30 @@
 /area/space)
 "NM" = (
 /turf/unsimulated/floor/snow{
-	tag = "icon-permafrost";
-	icon_state = "permafrost"
+	icon_state = "permafrost";
+	tag = "icon-permafrost"
 	},
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (WEST)";
+	dir = 8;
 	icon_state = "gravsnow_corner";
-	dir = 8
+	tag = "icon-gravsnow_corner (WEST)"
 	},
 /area/syndicate_mothership)
 "NN" = (
 /turf/unsimulated/floor/snow{
-	tag = "icon-permafrost";
-	icon_state = "permafrost"
+	icon_state = "permafrost";
+	tag = "icon-permafrost"
 	},
 /area/syndicate_mothership)
 "NO" = (
 /turf/unsimulated/floor/snow{
-	tag = "icon-permafrost";
-	icon_state = "permafrost"
+	icon_state = "permafrost";
+	tag = "icon-permafrost"
 	},
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (EAST)";
+	dir = 4;
 	icon_state = "gravsnow_corner";
-	dir = 4
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /area/syndicate_mothership)
 "NP" = (
@@ -17753,11 +17020,68 @@
 "NQ" = (
 /turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	tag = "icon-gravsnow_corner (SOUTHWEST)";
+	dir = 10;
 	icon_state = "gravsnow_corner";
-	dir = 10
+	tag = "icon-gravsnow_corner (SOUTHWEST)"
 	},
 /area/syndicate_mothership)
+"NT" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 8;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (WEST)"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_emptycourt)
+"NZ" = (
+/obj/structure/table/holotable,
+/obj/machinery/readybutton{
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 8
+	},
+/obj/structure/window/reinforced/holowindow{
+	dir = 1
+	},
+/obj/structure/window/reinforced/holowindow{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_thunderdomecourt)
+"Of" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "desert2"
+	},
+/area/holodeck/source_volleyball)
+"Op" = (
+/turf/simulated/floor/holofloor/beach/water{
+	icon_state = "desert3";
+	tag = "icon-desert3"
+	},
+/area/holodeck/source_beach)
+"Os" = (
+/turf/simulated/floor/holofloor/beach/water{
+	icon_state = "desert2";
+	tag = "icon-desert2"
+	},
+/area/holodeck/source_beach)
+"Ow" = (
+/obj/effect/floor_decal/carpet,
+/obj/structure/holostool,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_meetinghall)
+"Ox" = (
+/obj/machinery/door/window/holowindoor{
+	dir = 4;
+	icon_state = "left";
+	tag = "icon-left (EAST)"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_thunderdomecourt)
 "OE" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1331;
@@ -17771,15 +17095,350 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/syndicate_mothership)
+"OF" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"OG" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1;
+	icon_state = "spline_fancy";
+	tag = "icon-spline_fancy (NORTH)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"OI" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 8;
+	icon_state = "spline_plain"
+	},
+/obj/structure/holonet/end,
+/turf/simulated/floor/holofloor/beach/sand,
+/area/holodeck/source_volleyball)
+"OJ" = (
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 10
+	},
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_courtroom)
+"OR" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"OV" = (
+/turf/simulated/floor/holofloor/beach/water{
+	icon_state = "desert5";
+	tag = "icon-desert5"
+	},
+/area/holodeck/source_beach)
+"OW" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 4;
+	icon_state = "corner_white_three_quarters";
+	tag = "icon-corner_white_three_quarters (EAST)"
+	},
+/obj/item/weapon/circular_saw,
+/obj/item/weapon/cautery,
+/obj/structure/table/holotable,
+/obj/structure/window/reinforced/holowindow,
+/turf/simulated/floor/holofloor/tiled/white,
+/area/holodeck/source_surgery)
+"Pb" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"Pd" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4;
+	icon_state = "spline_plain"
+	},
+/obj/structure/holonet/end{
+	dir = 8;
+	icon_state = "volleynet_end"
+	},
+/turf/simulated/floor/holofloor/beach/sand,
+/area/holodeck/source_volleyball)
+"Pe" = (
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "swall_c"
+	},
+/area/shuttle/transport1/centcom)
+"Pk" = (
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "swall_c"
+	},
+/area/shuttle/transport1/centcom)
+"Pl" = (
+/obj/effect/floor_decal/corner/green/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"PJ" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/machinery/door/window/holowindoor{
+	dir = 8;
+	icon_state = "left";
+	tag = "icon-left (WEST)"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_thunderdomecourt)
+"PM" = (
+/turf/simulated/floor/holofloor/beach/water{
+	dir = 1;
+	icon_state = "beach";
+	tag = "icon-beach (NORTH)"
+	},
+/area/holodeck/source_beach)
+"PR" = (
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"PV" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/item/weapon/beach_ball/holoball,
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"PW" = (
+/obj/effect/floor_decal/corner/red/three_quarters,
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"PY" = (
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
+/obj/structure/holostool,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_meetinghall)
+"Qd" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	dir = 10;
+	icon_state = "beach"
+	},
+/area/holodeck/source_beach)
+"Qh" = (
+/obj/effect/shuttle_landmark/ferry/start,
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "swall_straight"
+	},
+/area/shuttle/transport1/centcom)
+"Qi" = (
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/obj/effect/floor_decal/chapel{
+	dir = 1;
+	icon_state = "chapel";
+	tag = "icon-chapel (NORTH)"
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1;
+	icon_state = "spline_fancy";
+	tag = "icon-spline_fancy (NORTH)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"Ql" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 8;
+	icon_state = "spline_plain"
+	},
+/turf/simulated/floor/holofloor/beach/sand,
+/area/holodeck/source_volleyball)
+"Qu" = (
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/obj/effect/floor_decal/chapel{
+	dir = 1;
+	icon_state = "chapel";
+	tag = "icon-chapel (NORTH)"
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"Qw" = (
+/obj/item/weapon/inflatable_duck,
+/turf/simulated/floor/holofloor/beach/water{
+	icon_state = "desert3";
+	tag = "icon-desert3"
+	},
+/area/holodeck/source_beach)
+"Qx" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (EAST)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_surgery)
+"Qy" = (
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 8
+	},
+/obj/machinery/door/window/holowindoor{
+	dir = 8;
+	icon_state = "left";
+	tag = "icon-left (WEST)"
+	},
+/obj/structure/window/reinforced/holowindow{
+	dir = 1
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_boxingcourt)
+"Qz" = (
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/structure/holostool,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_meetinghall)
+"QH" = (
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "swall_straight"
+	},
+/area/shuttle/transport1/centcom)
+"Rs" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 10
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 6
+	},
+/obj/structure/bed/chair/holochair{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/wood,
+/area/holodeck/source_meetinghall)
 "RG" = (
 /obj/effect/paint/hull,
 /turf/simulated/wall,
 /area/merchant_station)
+"RL" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4;
+	icon_state = "spline_plain"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_theatre)
+"Sn" = (
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/obj/effect/floor_decal/chapel{
+	dir = 4;
+	icon_state = "chapel";
+	tag = "icon-chapel (EAST)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"Su" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 4;
+	icon_state = "spline_fancy_corner";
+	tag = "icon-spline_fancy_corner (EAST)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"Sv" = (
+/obj/structure/window/reinforced/holowindow/disappearing,
+/obj/effect/floor_decal/corner/red/three_quarters,
+/obj/structure/window/reinforced/holowindow{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_thunderdomecourt)
+"SB" = (
+/obj/structure/table/holo_woodentable,
+/obj/item/weapon/flame/candle,
+/obj/item/weapon/flame/candle{
+	pixel_y = 11
+	},
+/turf/simulated/floor/holofloor/wood,
+/area/holodeck/source_chapel)
+"SH" = (
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/red{
+	dir = 4;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_emptycourt)
+"SQ" = (
+/obj/effect/floor_decal/beach{
+	dir = 8;
+	icon_state = "beachborder"
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_volleyball)
+"Td" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (EAST)"
+	},
+/obj/structure/table/rack/holorack,
+/turf/simulated/floor/holofloor/tiled/white,
+/area/holodeck/source_surgery)
 "Th" = (
 /obj/effect/wallframe_spawn/reinforced/bare,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/merchant_station)
+"Ty" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 10;
+	icon_state = "spline_plain"
+	},
+/turf/simulated/floor/holofloor/beach/sand,
+/area/holodeck/source_volleyball)
 "TP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -17788,9 +17447,265 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/syndicate_mothership)
+"TW" = (
+/obj/effect/floor_decal/beach{
+	dir = 4;
+	icon_state = "beachborder"
+	},
+/turf/simulated/floor/holofloor/concrete,
+/area/holodeck/source_volleyball)
+"TZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning";
+	tag = "icon-warning (NORTH)"
+	},
+/turf/simulated/floor/plating,
+/area/centcom)
+"Ub" = (
+/obj/item/weapon/beach_ball,
+/turf/simulated/floor/holofloor/beach/water{
+	icon_state = "desert1";
+	tag = "icon-desert1"
+	},
+/area/holodeck/source_beach)
+"Ue" = (
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/structure/holostool,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_meetinghall)
+"Uk" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_theatre)
+"Ul" = (
+/obj/structure/window/reinforced/holowindow/disappearing{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/three_quarters{
+	dir = 8
+	},
+/obj/structure/window/reinforced/holowindow{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_thunderdomecourt)
 "Ux" = (
 /turf/simulated/floor/tiled/dark,
 /area/syndicate_mothership)
+"UA" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 9;
+	icon_state = "spline_plain"
+	},
+/turf/simulated/floor/holofloor/beach/sand{
+	icon_state = "desert2"
+	},
+/area/holodeck/source_volleyball)
+"UF" = (
+/obj/machinery/computer/shuttle_control/transport_shuttle{
+	dir = 1;
+	icon_state = "computer";
+	tag = "icon-computer (NORTH)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/transport1/centcom)
+"UG" = (
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/obj/effect/floor_decal/chapel{
+	dir = 8;
+	icon_state = "chapel";
+	tag = "icon-chapel (WEST)"
+	},
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"UJ" = (
+/obj/structure/table/holotable,
+/obj/effect/floor_decal/corner/green/three_quarters,
+/obj/structure/window/reinforced/holowindow,
+/obj/structure/window/reinforced/holowindow{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_thunderdomecourt)
+"UK" = (
+/obj/structure/bed/chair/shuttle{
+	dir = 8;
+	icon_state = "shuttle_chair_preview";
+	tag = "icon-shuttle_chair_preview (WEST)"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/transport1/centcom)
+"Va" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/obj/structure/holostool,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_meetinghall)
+"Vg" = (
+/obj/effect/floor_decal/corner/green/three_quarters{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"Vr" = (
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_courtroom)
+"VP" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/structure/holohoop{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"VS" = (
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 1;
+	icon_state = "corner_white_three_quarters";
+	tag = "icon-corner_white_three_quarters (NORTH)"
+	},
+/turf/simulated/floor/holofloor/tiled/white,
+/area/holodeck/source_surgery)
+"Wt" = (
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "swall_c"
+	},
+/area/shuttle/transport1/centcom)
+"Wz" = (
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/obj/effect/floor_decal/chapel{
+	dir = 8;
+	icon_state = "chapel";
+	tag = "icon-chapel (WEST)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"WC" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/structure/holostool,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_meetinghall)
+"WF" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4;
+	icon_state = "spline_fancy";
+	tag = "icon-spline_fancy (EAST)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"WI" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"WM" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 8;
+	icon_state = "spline_fancy_corner";
+	tag = "icon-spline_fancy_corner (WEST)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
+"WV" = (
+/obj/item/clothing/glasses/sunglasses,
+/turf/simulated/floor/holofloor/beach/water{
+	icon_state = "desert4";
+	tag = "icon-desert4"
+	},
+/area/holodeck/source_beach)
+"WX" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (NORTH)"
+	},
+/obj/structure/window/reinforced/holowindow{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled/white,
+/area/holodeck/source_surgery)
+"Xc" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_theatre)
+"Xe" = (
+/turf/space,
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "swall_c"
+	},
+/area/shuttle/transport1/centcom)
+"Xj" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/obj/structure/bed/chair/holochair{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/wood,
+/area/holodeck/source_meetinghall)
+"Xw" = (
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 6
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_theatre)
 "XF" = (
 /obj/effect/wallframe_spawn/reinforced/bare,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17801,9 +17716,104 @@
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
+"XI" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"XN" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (SOUTHWEST)"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_basketball)
+"XP" = (
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_theatre)
+"XW" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 6
+	},
+/obj/structure/holostool,
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_meetinghall)
+"Yr" = (
+/obj/structure/shuttle/engine/propulsion/burst/left{
+	dir = 1;
+	icon_state = "burst_l";
+	name = "propulsion";
+	tag = "icon-burst_l (NORTH)"
+	},
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall";
+	tag = "icon-swall2"
+	},
+/area/shuttle/transport1/centcom)
 "Yz" = (
 /turf/space/transit/east,
 /area/space)
+"YA" = (
+/obj/effect/landmark{
+	can_copy = 1;
+	name = "Holocarp Spawn"
+	},
+/turf/simulated/floor/holofloor/reinforced,
+/area/holodeck/source_wildlife)
+"YD" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/machinery/door/window/holowindoor{
+	dir = 8;
+	icon_state = "left";
+	tag = "icon-left (WEST)"
+	},
+/turf/simulated/floor/holofloor/tiled,
+/area/holodeck/source_thunderdomecourt)
+"YN" = (
+/turf/simulated/floor/holofloor/beach/sand{
+	dir = 8;
+	icon_state = "beach"
+	},
+/area/holodeck/source_beach)
+"YW" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (EAST)"
+	},
+/turf/simulated/floor/holofloor/tiled/white,
+/area/holodeck/source_surgery)
+"YY" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_c"
+	},
+/area/shuttle/transport1/centcom)
+"YZ" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1;
+	icon_state = "spline_fancy_corner";
+	tag = "icon-spline_fancy_corner (NORTH)"
+	},
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/holodeck/source_chapel)
 "Zf" = (
 /obj/effect/shuttle_landmark/nerva/transit/hadrian,
 /turf/space/transit/east,
@@ -17815,15 +17825,64 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	icon_state = "intact";
-	dir = 4
+	dir = 4;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/syndicate_mothership)
+"Zi" = (
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_courtroom)
 "Zn" = (
 /obj/effect/wallframe_spawn/reinforced/bare,
 /turf/simulated/floor/plating,
 /area/merchant_station)
+"Zt" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4;
+	icon_state = "spline_plain"
+	},
+/turf/simulated/floor/holofloor/beach/sand,
+/area/holodeck/source_volleyball)
+"ZB" = (
+/obj/structure/bed/chair/holochair{
+	dir = 4;
+	icon_state = "chair_preview";
+	tag = "icon-chair_preview (EAST)"
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
+/turf/simulated/floor/holofloor/carpet,
+/area/holodeck/source_courtroom)
+"ZF" = (
+/turf/simulated/floor/holofloor/beach/water{
+	icon_state = "desert1";
+	tag = "icon-desert1"
+	},
+/area/holodeck/source_beach)
+"ZT" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (WEST)"
+	},
+/obj/structure/window/reinforced/holowindow{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/tiled/white,
+/area/holodeck/source_surgery)
 
 (1,1,1) = {"
 aa
@@ -35934,12 +35993,12 @@ ab
 ab
 ig
 kn
-kn
-lz
-lY
-lY
-nh
-kn
+ko
+ko
+ko
+ko
+ko
+OG
 ig
 og
 og
@@ -35949,7 +36008,7 @@ og
 og
 og
 ig
-rQ
+vg
 rQ
 rQ
 rQ
@@ -36135,13 +36194,13 @@ ab
 ab
 ab
 ig
-ko
-ko
+WM
+Qu
 lA
-lZ
+ko
 mC
 ni
-ko
+Su
 ig
 og
 og
@@ -36337,13 +36396,13 @@ ab
 ab
 ab
 ig
-ko
-ko
+lY
+Sn
 lB
-ma
+ko
 mD
 nj
-ko
+lY
 ig
 og
 og
@@ -36539,13 +36598,13 @@ ab
 ab
 ab
 ig
-ko
+lY
 lj
+UG
 ko
-ko
-ko
-ko
-ko
+Qi
+Wz
+lY
 ig
 og
 og
@@ -36741,13 +36800,13 @@ ab
 ab
 ab
 ig
+lY
+Sn
+lB
 ko
-ko
-lC
-mb
-mE
+mD
 nk
-ko
+lY
 ig
 og
 og
@@ -36943,13 +37002,13 @@ ab
 ab
 ab
 ig
+nh
+WF
+OF
 ko
-ko
-lA
-mc
 mF
-nl
-ko
+WF
+YZ
 ig
 og
 og
@@ -37145,13 +37204,13 @@ ab
 ab
 ab
 ig
-kp
-kp
-lD
-lY
-lY
-nm
-nK
+kn
+ko
+ko
+SB
+ko
+ko
+OG
 ig
 og
 og
@@ -37167,7 +37226,7 @@ rQ
 rQ
 rQ
 rQ
-vg
+rQ
 ig
 ab
 ab
@@ -37347,29 +37406,29 @@ ab
 ab
 ab
 ig
+kn
+ko
+ko
+ko
+ko
+ko
+OG
 ig
+og
+og
+og
+og
+og
+og
+og
 ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
+rQ
 ig
 ab
 ab
@@ -37549,29 +37608,29 @@ ab
 ab
 ab
 ig
-kq
-kq
-kq
-md
-ks
-ks
-ks
 ig
-oh
-oW
-oj
-oj
-qr
-om
-rf
 ig
-rR
-rR
-rR
-rR
-rR
-rR
-vh
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
 ig
 ab
 ab
@@ -37751,29 +37810,29 @@ ab
 ab
 ab
 ig
-kq
-kq
-kq
 ks
 ks
-me
+ks
+ks
+ks
+ks
 ks
 ig
-oi
-oX
-oj
-oj
-qr
-qG
+rf
 ol
+Os
+ol
+ol
+ol
+OV
 ig
 rS
 rS
 rS
 rS
 rS
-uP
-vi
+rS
+vh
 ig
 ab
 ab
@@ -37953,28 +38012,28 @@ ab
 ab
 ab
 ig
-kq
-kq
-ll
 ks
-lk
+ks
+ks
+ks
+ks
 ks
 ks
 ig
-oj
-oj
-oj
-oj
-qr
+ZF
+WV
 ol
-rg
+Qw
+qI
+ol
+ol
 ig
-rT
-sy
-ta
-tK
-uk
-uQ
+vi
+vi
+vi
+vi
+vi
+vi
 vi
 ig
 ab
@@ -38155,28 +38214,28 @@ ab
 ab
 ab
 ig
-kr
-lk
+ks
+me
 ks
 ks
-ks
+md
 ks
 ks
 ig
-oj
-oj
-oj
-oj
-qr
-qH
+ol
+Os
+ol
+ol
+ol
+Os
 ol
 ig
 rU
-sz
-sz
-sz
-ul
-uQ
+rU
+rU
+rU
+rU
+Qx
 vi
 ig
 ab
@@ -38359,10 +38418,10 @@ ab
 ig
 ks
 ks
+lk
 ks
-me
 ks
-md
+mG
 ks
 ig
 ok
@@ -38370,14 +38429,14 @@ ok
 ok
 ok
 qs
-qI
+qt
 ol
 ig
-rV
-sz
-tb
-sz
-um
+rT
+WX
+ta
+ZT
+uk
 uQ
 vi
 ig
@@ -38559,19 +38618,19 @@ ab
 ab
 ab
 ig
+md
 ks
-ll
 ks
 ks
-mG
+me
 ks
 ks
 ig
-ol
-oY
-py
-ol
-qt
+oj
+oj
+oj
+oj
+PM
 ol
 ol
 ig
@@ -38579,7 +38638,7 @@ rW
 sz
 sz
 sz
-un
+ul
 uQ
 vi
 ig
@@ -38761,29 +38820,29 @@ ab
 ab
 ab
 ig
-ks
-ks
-ks
+kq
+kq
+ll
 ks
 ks
 ks
 ks
 ig
-om
+oj
+oj
+oj
+oj
+PM
+Op
 ol
-ol
-ol
-ol
-ol
-rh
 ig
-rX
-sA
-tc
-tL
-uo
+rV
+sz
+tb
+sz
+um
 uQ
-vh
+vi
 ig
 ab
 ab
@@ -38963,29 +39022,29 @@ ab
 ab
 ab
 ig
+kq
+kq
+kq
+lk
+ks
+ll
+ks
 ig
+YN
+Qd
+oj
+oj
+PM
+Ub
+ol
 ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
+Td
+sz
+sz
+sz
+un
+uQ
+vi
 ig
 ab
 ab
@@ -39165,29 +39224,29 @@ ab
 ab
 ab
 ig
-kt
-kt
-lE
-lF
-lF
-lF
-lF
+kq
+kq
+kq
+kq
+ks
+ks
+ks
 ig
-on
-on
-on
-on
-on
-on
-on
+oh
+oW
+oj
+oj
+PM
+ol
+ZF
 ig
-rY
-rY
-td
-rY
-rY
-rZ
-rY
+VS
+YW
+tc
+tL
+OW
+uQ
+vh
 ig
 ab
 ab
@@ -39367,29 +39426,29 @@ ab
 ab
 ab
 ig
-ku
-ku
-lE
-mf
-mH
-mH
-nL
 ig
-oo
-oZ
-oZ
-pQ
-oZ
-oZ
-ri
 ig
-rZ
-rZ
-rZ
-rZ
-rZ
-rZ
-vj
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
 ig
 ab
 ab
@@ -39569,29 +39628,29 @@ ab
 ab
 ab
 ig
-ku
-ku
+lF
+XP
 lE
-mg
-mI
-mI
-nM
+lE
+lE
+nL
+lF
 ig
-op
-pa
-pz
-pR
-pa
-qJ
-rj
+SQ
+SQ
+SQ
+SQ
+SQ
+SQ
+SQ
 ig
+rY
+rY
+td
+rY
+rY
 rZ
-sB
-sB
-rZ
-rZ
-rZ
-rZ
+rY
 ig
 ab
 ab
@@ -39771,29 +39830,29 @@ ab
 ab
 ab
 ig
-ku
-ku
-lE
+lF
 mg
 mI
 mI
+mI
 nM
+lF
 ig
-op
-pa
-pa
-pR
-pa
-pa
-rk
+UA
+Ql
+Ql
+OI
+Ql
+Ql
+Ty
 ig
-sa
-sC
-sC
-tM
 rZ
 rZ
 rZ
+rZ
+rZ
+rZ
+vj
 ig
 ab
 ab
@@ -39973,27 +40032,27 @@ ab
 ab
 ab
 ig
-ku
-ku
-lE
+lF
 mg
 mI
 mI
+mI
 nM
+lF
 ig
 op
 pa
-pa
-pR
-qu
 pz
-rk
+pR
+pa
+qJ
+rj
 ig
-sb
-sD
-te
-tN
-up
+rZ
+rZ
+rZ
+rZ
+rZ
 rZ
 rZ
 ig
@@ -40175,29 +40234,29 @@ ab
 ab
 ab
 ig
-ku
-ku
-lE
-mh
-mJ
-mJ
-nN
+lF
+mg
+mI
+mI
+mI
+nM
+lF
 ig
-oq
-pb
-pA
-pS
-pA
-pA
-rl
+op
+pa
+pa
+pR
+pa
+pa
+rk
 ig
-sb
-sE
-tf
-tN
-up
 rZ
-rY
+sB
+sB
+rZ
+rZ
+rZ
+rZ
 ig
 ab
 ab
@@ -40377,29 +40436,29 @@ ab
 ab
 ab
 ig
-ku
-ku
 lF
-lF
-lF
-lF
+Xc
+Uk
+Uk
+Uk
+Xw
 lF
 ig
+op
+pa
+pa
 or
-or
-or
-or
-or
-or
-or
+Of
+pa
+rk
 ig
-sc
-sF
-sF
-tO
+Qy
+sC
+sC
+tM
 rZ
 rZ
-rY
+rZ
 ig
 ab
 ab
@@ -40579,29 +40638,29 @@ ab
 ab
 ab
 ig
+RL
+RL
+RL
+RL
+RL
+RL
+lF
 ig
+op
+pa
+pa
+pR
+qu
+pz
+rk
 ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
+sb
+sD
+te
+tN
+up
+rZ
+rY
 ig
 ab
 ab
@@ -40781,29 +40840,29 @@ ab
 ab
 ab
 ig
-kv
-lm
-lm
-ky
-mi
-mi
-mi
+kt
+ku
+ku
+ku
+ku
+ku
+ku
 ig
 os
 pc
-pc
-pc
-pc
-pc
+Zt
+Pd
+Zt
+Zt
 rm
 ig
-sd
-sG
-tg
-tP
-uq
-uR
-sg
+sb
+sE
+tf
+tN
+up
+rZ
+rY
 ig
 ab
 ab
@@ -40983,29 +41042,29 @@ ab
 ab
 ab
 ig
-kw
-lm
-kx
-mi
-mK
-mi
-mi
+kt
+ku
+ku
+ku
+ku
+ku
+ku
 ig
-ot
-pd
-pd
-pd
-pd
-pd
-rn
+TW
+TW
+TW
+TW
+TW
+TW
+TW
 ig
-se
-sH
-th
-tQ
-sH
-uS
-sg
+sc
+sF
+sF
+tO
+rZ
+rZ
+rZ
 ig
 ab
 ab
@@ -41185,29 +41244,29 @@ ab
 ab
 ab
 ig
-kv
-kx
-kv
-kw
-kv
-lG
-lG
 ig
-ot
-pe
-pe
-pd
-pe
-pe
-rn
 ig
-se
-sH
-th
-tQ
-sH
-uS
-sg
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
 ig
 ab
 ab
@@ -41387,28 +41446,28 @@ ab
 ab
 ab
 ig
-kx
-ky
-ky
-lG
-lG
 kv
-kx
+lm
+lm
+ky
+mi
+mi
+mi
 ig
-ou
-pf
-pf
-pT
-pf
-pf
-ro
+ZB
+Vr
+Vr
+Vr
+Vr
+Vr
+OJ
 ig
-se
-sH
-th
-tQ
-sH
-uS
+sg
+sg
+sg
+sg
+sg
+sg
 sg
 ig
 ab
@@ -41589,28 +41648,28 @@ ab
 ab
 ab
 ig
-ky
+kw
+lm
 kx
-lG
-lG
-kx
-kv
-ky
+mi
+mK
+mi
+mi
 ig
-ov
-ov
-ov
-ov
-ov
-ov
-ov
+ot
+pd
+pd
+pd
+pd
+pd
+rn
 ig
-se
-sH
-th
-tQ
-sH
-uS
+NZ
+PJ
+Sv
+Ul
+YD
+UJ
 sg
 ig
 ab
@@ -41792,27 +41851,27 @@ ab
 ab
 ig
 kv
-ln
+kx
+kv
+kw
+kv
 lG
 lG
-kv
-ky
-kv
 ig
-ov
-pg
-pB
-pU
-qv
-ov
-ov
+ot
+Zi
+Zi
+pd
+Zi
+Zi
+rn
 ig
-sf
-sI
-ti
-tR
-sI
-uT
+se
+sH
+th
+tQ
+sH
+uS
 sg
 ig
 ab
@@ -41993,28 +42052,28 @@ ab
 ab
 ab
 ig
-kw
-kv
-ky
 kx
-mL
+ky
+ky
 lG
-nO
+lG
+kv
+kx
 ig
-ov
-ov
-ov
-pV
-ov
-ov
-rp
+ou
+pf
+pf
+pT
+pf
+pf
+ro
 ig
-sg
-sg
-sg
-sg
-sg
-sg
+se
+sH
+th
+tQ
+sH
+uS
 sg
 ig
 ab
@@ -42195,29 +42254,29 @@ ab
 ab
 ab
 ig
+ky
+kx
+lG
+lG
+kx
+kv
+ky
 ig
+ov
+ov
+ov
+ov
+ov
+ov
+ov
 ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
+se
+sH
+th
+tQ
+sH
+uS
+sg
 ig
 ab
 ab
@@ -42397,29 +42456,29 @@ ab
 ab
 ab
 ig
-kz
-kA
-lH
-lH
-lH
-lH
-lH
+kv
+ln
+lG
+lG
+kv
+ky
+kv
 ig
-ow
-ox
-ox
-ox
-ox
-ox
-ow
+ov
+ov
+ov
+ov
+ov
+ov
+ov
 ig
-sh
-sJ
-tj
-tS
-ur
-ur
-vk
+se
+sH
+th
+tQ
+sH
+uS
+sg
 ig
 ab
 ab
@@ -42599,29 +42658,29 @@ ab
 ab
 ab
 ig
-kA
-kA
-lH
-mj
-mM
-nn
-lH
+kw
+kv
+ky
+kx
+mL
+lG
+nO
 ig
-ox
-ox
-ox
-ox
-ox
-ox
-ox
+ov
+pg
+pB
+pU
+qv
+ov
+ov
 ig
-si
-sK
-sK
-tS
-sK
-sK
-us
+sf
+Ox
+ti
+tR
+Ox
+uT
+sg
 ig
 ab
 ab
@@ -42801,29 +42860,29 @@ ab
 ab
 ab
 ig
-kB
-lo
-lH
-mk
-mN
-no
-lH
+mi
+lG
+lG
+mi
+kw
+kv
+mL
 ig
-ox
-ox
-ow
-ox
-ow
-ox
-ox
+ov
+ov
+ov
+pV
+ov
+ov
+rp
 ig
-sh
-sJ
-si
-tS
-us
-ur
-vk
+sg
+sg
+sg
+sg
+sg
+sg
+sg
 ig
 ab
 ab
@@ -43003,29 +43062,29 @@ ab
 ab
 ab
 ig
-kC
-lo
-lH
-mk
-mN
-no
-lH
 ig
-ox
-ox
-ox
-ox
-ox
-ox
-ox
 ig
-sj
-sK
-tk
-tS
-us
-sK
-vl
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
 ig
 ab
 ab
@@ -43205,29 +43264,29 @@ ab
 ab
 ab
 ig
-kD
-lo
 lH
-mk
-mN
-no
+lH
+lH
+lH
+lH
+lH
 lH
 ig
+YA
 ox
 ox
-ow
-ox
-ow
 ox
 ox
+ox
+YA
 ig
-sk
-sL
-si
+Vg
+ur
+Vg
 tS
-us
-uU
-vm
+vk
+ur
+vk
 ig
 ab
 ab
@@ -43407,11 +43466,11 @@ ab
 ab
 ab
 ig
-kA
-kA
 lH
-ml
-mO
+PY
+Qz
+Qz
+Qz
 np
 lH
 ig
@@ -43423,13 +43482,13 @@ ox
 ox
 ox
 ig
-si
+Pb
 sK
+Pb
 sK
-tS
+XN
 sK
-sK
-us
+XN
 ig
 ab
 ab
@@ -43609,29 +43668,29 @@ ab
 ab
 ab
 ig
-kz
-kA
 lH
-lH
-lH
-lH
+Ue
+mN
+mN
+mN
+Ow
 lH
 ig
-ow
 ox
 ox
+YA
+ox
+YA
 ox
 ox
-ox
-ow
 ig
-sk
-sL
-tl
-tS
-ut
-uU
-vm
+Pb
+sK
+ur
+ur
+ur
+sK
+XN
 ig
 ab
 ab
@@ -43811,29 +43870,29 @@ ab
 ab
 ab
 ig
+lH
+Ue
+mN
+mN
+mN
+Ow
+lH
 ig
+ox
+ox
+ox
+ox
+ox
+ox
+ox
 ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
+Pl
+WI
+WI
+WI
+WI
+WI
+vm
 ig
 ab
 ab
@@ -44013,29 +44072,29 @@ ab
 ab
 ab
 ig
-kE
-lp
-lp
-mm
-mP
-mP
-nP
+lH
+Va
+WC
+WC
+WC
+XW
+lH
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ox
+ox
+ox
+ox
+ox
+ox
+ox
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+sh
+OR
+OR
+PV
+OR
+OR
+PW
 ig
 ab
 ab
@@ -44215,29 +44274,29 @@ ab
 ab
 ab
 ig
-kF
-lq
-lq
-lq
-lq
-lq
-nQ
+lH
+lH
+lH
+lH
+lH
+lH
+lH
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ox
+ox
+YA
+ox
+YA
+ox
+ox
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+si
+sK
+sL
+sL
+sL
+sK
+XI
 ig
 ab
 ab
@@ -44417,29 +44476,29 @@ ab
 ab
 ab
 ig
-kF
-lq
-lq
-lq
-lq
-lq
-nQ
+kA
+kA
+lo
+lo
+lo
+kA
+kA
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ox
+ox
+ox
+ox
+ox
+ox
+ox
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+si
+sK
+si
+sK
+XI
+sK
+XI
 ig
 ab
 ab
@@ -44619,29 +44678,29 @@ ab
 ab
 ab
 ig
-kF
-lq
-lq
-lq
-lq
-lq
-nQ
+kz
+kA
+Xj
+sM
+Rs
+kA
+kz
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+YA
+ox
+ox
+ox
+ox
+ox
+YA
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+sk
+sL
+sk
+VP
+PR
+sL
+PR
 ig
 ab
 ab
@@ -44821,29 +44880,29 @@ ab
 ab
 ab
 ig
-kF
-lq
-lq
-lq
-lq
-lq
-nQ
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ig
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
 ig
 ab
 ab
@@ -45023,13 +45082,13 @@ ab
 ab
 ab
 ig
-kF
-lq
-lq
-lq
-lq
-lq
-nQ
+kE
+lp
+lp
+NT
+mP
+mP
+nP
 ig
 ab
 ab
@@ -45225,13 +45284,13 @@ ab
 ab
 ab
 ig
-kG
-lr
-lr
-mn
-mQ
-mQ
-nR
+kF
+lq
+lq
+lq
+lq
+lq
+nQ
 ig
 ab
 ab
@@ -45427,29 +45486,29 @@ ab
 ab
 ab
 ig
+kF
+lq
+lq
+lq
+lq
+lq
+nQ
 ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
-ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ig
 ab
 ab
@@ -45628,6 +45687,15 @@ ab
 ab
 ab
 ab
+ig
+kF
+lq
+lq
+lq
+lq
+lq
+nQ
+ig
 ab
 ab
 ab
@@ -45635,6 +45703,7 @@ ab
 ab
 ab
 ab
+ig
 ab
 ab
 ab
@@ -45642,17 +45711,7 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ig
 ab
 ab
 ab
@@ -45830,6 +45889,15 @@ ab
 ab
 ab
 ab
+ig
+kF
+lq
+lq
+lq
+lq
+lq
+nQ
+ig
 ab
 ab
 ab
@@ -45837,6 +45905,7 @@ ab
 ab
 ab
 ab
+ig
 ab
 ab
 ab
@@ -45844,17 +45913,7 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ig
 ab
 ab
 ab
@@ -46032,6 +46091,15 @@ ab
 ab
 ab
 ab
+ig
+kF
+lq
+lq
+lq
+lq
+lq
+nQ
+ig
 ab
 ab
 ab
@@ -46039,6 +46107,7 @@ ab
 ab
 ab
 ab
+ig
 ab
 ab
 ab
@@ -46046,17 +46115,7 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ig
 ab
 ab
 ab
@@ -46234,6 +46293,15 @@ ab
 ab
 ab
 ab
+ig
+kF
+lq
+lq
+lq
+lq
+lq
+nQ
+ig
 ab
 ab
 ab
@@ -46241,6 +46309,7 @@ ab
 ab
 ab
 ab
+ig
 ab
 ab
 ab
@@ -46248,17 +46317,7 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ig
 ab
 ab
 ab
@@ -46436,6 +46495,31 @@ ab
 ab
 ab
 ab
+ig
+kG
+lr
+lr
+SH
+mQ
+mQ
+nR
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ig
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ig
 ab
 ab
 ab
@@ -46444,31 +46528,6 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
 ab
 ab
 ab
@@ -46638,39 +46697,39 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-qK
-rq
-rq
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+ig
 uu
-uV
-vn
-vN
-vN
-uV
-vn
+ig
+ig
+ig
+ab
+ab
+ab
 wf
-rq
-rq
-rq
-qK
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -46854,25 +46913,25 @@ ab
 ab
 ab
 ab
-qK
-qK
-qK
-qK
-qK
-rq
-tU
-uv
-uW
-vo
-vo
-vo
-vo
-vo
-wg
-vN
-vN
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 wf
-qK
+ab
 ab
 ab
 ab
@@ -47056,25 +47115,25 @@ ab
 ab
 ab
 ab
-qK
-rq
-rq
-rq
-qK
-rq
-tV
-uw
-uX
-uX
-uX
-uX
-uX
-uX
-wh
-wp
-wp
-wx
-qK
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -47258,24 +47317,24 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
 qK
-rr
-rq
-rq
 qK
-rq
-tV
-ux
-uX
-uX
-vO
-vO
-uX
-uX
-wi
-wq
-ws
-wy
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
 qK
 ab
 ab
@@ -47460,24 +47519,24 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
 qK
 rq
 rq
+Wt
+uV
+vn
+vN
+vN
+uV
+vn
+Pk
 rq
-qK
 rq
-tV
-uw
-uX
-uX
-uX
-uX
-uX
-uX
-wh
-wp
-wp
-wz
+rq
 qK
 ab
 ab
@@ -47679,7 +47738,7 @@ vp
 wg
 vN
 vN
-wj
+Xe
 qK
 ab
 ab
@@ -47864,24 +47923,24 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
 qK
 rq
 rq
+rq
+qK
+rq
+TZ
 uy
-uV
-vn
-vN
-vN
-uV
-vn
+uX
+uX
+uX
+uX
+uX
+uX
 wj
-rq
-rq
-rq
+wp
+wp
+wx
 qK
 ab
 ab
@@ -48066,24 +48125,24 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
 qK
+rr
+rq
+rq
 qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
-qK
+rq
+TZ
+QH
+uX
+uX
+vO
+vO
+uX
+uX
+Qh
+wq
+UF
+wy
 qK
 ab
 ab
@@ -48268,25 +48327,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+qK
+rq
+rq
+rq
+qK
+rq
+TZ
+uw
+uX
+uX
+uX
+uX
+uX
+uX
+wh
+wp
+wp
+wz
+qK
 ab
 ab
 ab
@@ -48470,25 +48529,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+qK
+qK
+qK
+qK
+qK
+rq
+Yr
+uv
+uW
+UK
+UK
+UK
+UK
+UK
+wg
+vN
+vN
+Pe
+qK
 ab
 ab
 ab
@@ -48676,21 +48735,21 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+qK
+rq
+rq
+YY
+uV
+vn
+vN
+vN
+uV
+vn
+Pe
+rq
+rq
+rq
+qK
 ab
 ab
 ab
@@ -48878,21 +48937,21 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
+qK
 ab
 ab
 ab
@@ -52755,7 +52814,7 @@ Gq
 GZ
 HJ
 Ix
-Jb
+Iu
 FD
 JR
 ab

--- a/maps/nerva/nerva_areas.dm
+++ b/maps/nerva/nerva_areas.dm
@@ -106,6 +106,11 @@
 	name = "\improper Safe Room"
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
 
+/area/command/weapons_command
+	name = "\improper Weapons Command"
+	sound_env = SMALL_ENCLOSED
+	area_flags = AREA_FLAG_ION_SHIELDED
+
 //////////////////////////////////////
 //			CIVILIAN				//
 //////////////////////////////////////
@@ -193,6 +198,10 @@
 
 /area/civilian/exercise
 	name = "\improper Exercise Room"
+	sound_env = SMALL_ENCLOSED
+
+/area/civilian/journalist
+	name = "\improper Journalist's Office"
 	sound_env = SMALL_ENCLOSED
 
 //////////////////////////////////////
@@ -436,6 +445,9 @@
 
 /area/engineering/substation/atmos
 	name = "\improper Atmospherics Substation"
+
+/area/engineering/substation/command
+	name ="\improper Command Substation"
 
 //solars
 
@@ -784,6 +796,7 @@
 	name = "\improper Holodeck"
 	icon_state = "Holodeck"
 	dynamic_lighting = 0
+	requires_power = 0
 	sound_env = LARGE_ENCLOSED
 
 /area/holodeck/source_battle_arena

--- a/maps/nerva/nerva_areas.dm
+++ b/maps/nerva/nerva_areas.dm
@@ -792,6 +792,8 @@
 /area/centcom
 	name = "Admin Area"
 
+//holodeck
+
 /area/holodeck
 	name = "\improper Holodeck"
 	icon_state = "Holodeck"
@@ -803,10 +805,6 @@
 	name = "\improper Holodeck - Battle Arena"
 	sound_env = ARENA
 
-/area/holodeck/source_surgery
-	name = "\improper Holodeck - Surgery Simulation"
-	requires_power = 0
-
 /area/holodeck/source_beach
 	name = "\improper Holodeck - Beach Simulation"
 	sound_env = PLAIN
@@ -817,6 +815,7 @@
 
 /area/holodeck/source_chapel
 	name = "\improper Holodeck - Chapel"
+	sound_env = AUDITORIUM
 
 /area/holodeck/source_plating
 	name = "\improper Holodeck - Off"
@@ -859,6 +858,27 @@
 /area/holodeck/source_volleyball
 	name = "\improper Holodeck - Volleyball"
 	sound_env = PLAIN
+
+/area/holodeck/source_desert
+	name = "\improper Holodeck - Desert"
+	sound_env = PLAIN
+
+/area/holodeck/source_space
+	name = "\improper Holodeck - Space"
+	has_gravity = 0
+	sound_env = SPACE
+
+/area/holodeck/source_cafe
+	name = "\improper Holodeck - Cafe"
+	sound_env = PLAIN
+
+/area/holodeck/source_plaza
+	name = "\improper Holodeck - Plaza"
+	sound_env = SMALL_ENCLOSED
+
+/area/holodeck/source_gym
+	name = "\improper Holodeck - Gym"
+	sound_env = SMALL_ENCLOSED
 
 /area/drone_test
 	name = "\improper Biohazard Simulation Arena"

--- a/maps/nerva/nerva_holodecks.dm
+++ b/maps/nerva/nerva_holodecks.dm
@@ -12,6 +12,24 @@
 											 				'sound/effects/wind/wind_5_1.ogg'
 												 			)
 		 												),
+		"desert"           = new/datum/holodeck_program(/area/holodeck/source_desert,
+														list(
+															'sound/effects/wind/wind_2_1.ogg',
+											 				'sound/effects/wind/wind_2_2.ogg',
+											 				'sound/effects/wind/wind_3_1.ogg',
+											 				'sound/effects/wind/wind_4_1.ogg',
+											 				'sound/effects/wind/wind_4_2.ogg',
+											 				'sound/effects/wind/wind_5_1.ogg'
+												 			)
+		 												),
+		"space"            = new/datum/holodeck_program(/area/holodeck/source_space,
+														list(
+															'sound/ambience/ambispace.ogg',
+															'sound/music/main.ogg',
+															'sound/music/space.ogg',
+															'sound/music/traitor.ogg',
+															)
+														),
 		"chapel"			= new/datum/holodeck_program(/area/holodeck/source_chapel, list()),
 		"emptycourt"        = new/datum/holodeck_program(/area/holodeck/source_emptycourt, list('sound/music/THUNDERDOME.ogg')),
 		"boxingcourt"       = new/datum/holodeck_program(/area/holodeck/source_boxingcourt, list('sound/music/THUNDERDOME.ogg')),
@@ -23,6 +41,9 @@
 		"courtroom"         = new/datum/holodeck_program(/area/holodeck/source_courtroom, list('sound/music/traitor.ogg')),
 		"volleyball"        = new/datum/holodeck_program(/area/holodeck/source_volleyball, list('sound/music/THUNDERDOME.ogg')),
 		"wildlifecarp"      = new/datum/holodeck_program(/area/holodeck/source_wildlife, list()),
+		"plaza"             = new/datum/holodeck_program(/area/holodeck/source_plaza),
+		"cafe"              = new/datum/holodeck_program(/area/holodeck/source_cafe),
+		"gym"               = new/datum/holodeck_program(/area/holodeck/source_gym),
 
 		"turnoff"			= new/datum/holodeck_program(/area/holodeck/source_plating, list())
 	)
@@ -43,7 +64,12 @@
 			"Picnic Area"        = "picnicarea",
 			"Theatre"            = "theatre",
 			"Thunderdome Court"  = "thunderdomecourt",
-			"Volleyball Court"   = "volleyball"
+			"Volleyball Court"   = "volleyball",
+			"Plaza"              = "plaza",
+			"Cafe"               = "cafe",
+			"Desert"             = "desert",
+			"Gym"                = "gym",
+			"Space"              = "space"
 		)
 
 	)


### PR DESCRIPTION
Oh boy. This is a biggie.
This originated as some idle chat with players during deadpop, and turned into a big of a rework. Some controversial changes in here I'm sure, but happy to revert or edit any changes. Thought it'd at least be an idea to put these designs out there, whether they're taken up or not!

### Main Map Changes


**Mailing Office**

The mailing office has been moved south to allow for a public lobby, with a public use orders console. This was requested by cargo players so other players can drop by and put their orders in, rather than shouting them over the radio like uncultured heathens. A side-effect is the cargo locker room has been moved to the lower deck to replace the unused storage room.
![Screenshot from 2022-03-22 01:22:10](https://user-images.githubusercontent.com/54823378/159398914-8da4f60a-3944-461b-8f2f-641a9b6c43c4.png)



**Bar/Kitchen**

The bar and kitchen have been merged into a single area that serves both food and drinks. Currently, the cafeteria is woefully underused and a bit of a waste of space; players only ever seem to use the bar. This will hopefully give the chef a bit more to do, instead of splitting the possible 'customers' up. The area that was once the cafeteria has been replaced by the holodeck. Nice and central, and no longer tucked away to be forgotten. Being outside sec gives the holo-court a little more plausibility, as well as being closer to medical for those out-of-hand boxing matches. _It is also in a more central location to emag and spawn carps and cause utter chaos_. A result of this is the kitchen has had a slight extension (as well as all holodeck maps), so now they have a serving hatch to bake doughnuts and throw at security.
![Screenshot from 2022-03-22 01:07:06](https://user-images.githubusercontent.com/54823378/159399391-0fb67460-d3bb-40e1-9dfa-55fe1d15997a.png)



**AI Upload**

As the holodeck has been moved, after discussion, the most logical thing we could think to take its place was AI Upload. It may seem like a bit of an odd move, however, the current AI Upload is _far_ too close to command, and _far_ too easy for them to reset; making subverting the AI as an antag virtually impossible. AI gains a little extra security with thicker walls and the dispenser, antags hopefully get the ability to entertain the thought of AI subversion.
![Screenshot from 2022-03-22 01:04:15](https://user-images.githubusercontent.com/54823378/159399925-296937f8-af6e-4d66-a328-354bc8698efb.png)


**Deck 4 Command**

- The old AI Upload has been replaced by a new room, "Weapons Command". Almost like a Battle Bridge of sorts. Train of thought is the current placement of the weapons console is far too easy to get 1-shot and leave the Nerva defenceless. Moving the console to the old AI Upload adds at least 5 r-walls between it and incoming fire, vs a single r-window. Secondary benefit is once again another opportunity to split command up, or at least place them in a location a little more isolated from what's going on with the rest of the Nerva. Plenty of space and consoles in the room to allow for possible future combat expansion (Electronic Warfare Consoles etc? Who knows)
- The old and, once again, woefully unused emergency storage opposite AI Upload has been converted into a new Substation. This powers Weapons command, Vault, Saferoom, Torpedo room, Bridge, both deck 3 hardpoints and both gunbays, command offices, and bridge storage. Train of thought is if atmospherics and the various decks got their own 'backup' power, something as mission critical as the bridge would likely have its own supply too. Also opens itself up to potential sabotage to cripple command.
![Screenshot from 2022-03-22 01:05:29](https://user-images.githubusercontent.com/54823378/159400811-805c50f5-538b-4955-8d4a-c61b9569d5e4.png)


**Deck 2 Gym**

Another space that never sees any use. As a journalist role was requested, this has been converted into the Journalist's Office, with everything a meddlesome reporter could need. Coat and drone included!
![Screenshot from 2022-03-22 01:08:13](https://user-images.githubusercontent.com/54823378/159401208-233a6c08-257b-472d-a74b-1fca57bcba66.png)


### Other Map Changes

- Request consoles! The Nerva was suffering from a severe lack of request consoles. New ones have been dotted around various departments and set up.
- Navigation beacons have been added and set up for bot patrol paths. Bring back beepsky!
- Lights added to the Deck 1 gunbays.
- Telecoms refresh. For some reason, all the telecom servers, busses, relays, etc were using Wyrm names and presets. This also meant the Combat frequency that was added wasn't even being listened to by Nerva's Telecoms system! Nerva presets added to the map/code and combat frequency added. Telecom consoles are also now set to the correct network for probing.
- Wooden planks that spawn in the library have been swapped for walnut planks. Now if someone renovates the library and completes the floor, it'll actually match and not look awful.
- Saferoom gun cabinet secured by bridge access IDs.
- All 3 thruster bays have had a look over. The buttons have been fixed to work, and a gas control console was added to actually make use of the gas sensors that were sitting in them and were completely unusable.
- SM vent blast door name fixed.
- Xenoflora has had an air supply main line added. This makes  it easy to supply air to plants, and more importantly, allow you to actually refill the artefact room with air as those vents aren't hooked into the main distro.
- Added Science department cut-off valve. This was missing.
- Added missing air alarm in expedition prep
- Added emergency shutters to virtually **everywhere**. There were a **lot** of missing emergency shutters. I've done a quick pass to add shutters wherever I saw they were missing. Namely security that had _none_, expect in the perma brig.
- Added various missing fire alarms. Same as above.
- Added additional blastdoors to Xenobiology. Currently, Xenobiology's lockdown blastdoors only cover the 2 main airlocks... This has been expanded to the lower airlocks and maintenance airlock to actually lock the area down as suggested.

**Other changes**
- A new boolean was added to landmarks `can_copy`. This is to fix a bug with the holodeck's wildlife simulation not spawning carps. This is because the carp spawn landmarks were not being copied over to the holodeck. This boolean has been added to ensure compatibility with other landmarks and to not copy/move landmarks that aren't meant to be.
- Holodeck area `requires_power` set to 0. This is to fix an issue with the Thunderdome court and not being able to use the buttons as they are unpowered.


Again, I'm aware some of this might not be approved, that's all fine! Happy to tweak or remove as requested!