### PR TITLE
Multi-Z Pathfinding

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -2,6 +2,8 @@
 //Contents: Ladders, Stairs.//
 //////////////////////////////
 
+GLOBAL_LIST_EMPTY(zlevel_transitions)
+
 /obj/structure/ladder
 	name = "ladder"
 	desc = "A ladder. You can climb it up and down."
@@ -196,7 +198,20 @@
 			return INITIALIZE_HINT_QDEL
 		if(!istype(above))
 			above.ChangeTurf(/turf/simulated/open)
+	if(GLOB.zlevel_transitions["[src.z]"])
+		GLOB.zlevel_transitions["[src.z]"] |= src
+	else
+		GLOB.zlevel_transitions["[src.z]"] = list(src)
+	if(GLOB.zlevel_transitions["[GetAbove(src).z]"])
+		GLOB.zlevel_transitions["[GetAbove(src).z]"] |= GetAbove(src)
+	else
+		GLOB.zlevel_transitions["[GetAbove(src).z]"] = list(GetAbove(src))
 	. = ..()
+
+/obj/structure/stairs/Destroy()
+	GLOB.zlevel_transitions["[src.z]"] -= src
+	GLOB.zlevel_transitions["[GetAbove(src).z]"] -= GetAbove(src)
+	return ..()
 
 /obj/structure/stairs/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
 	if(get_dir(loc, target) == dir && upperStep(mover.loc))


### PR DESCRIPTION
This is a bit of a followup to the addition of navbeacons on the Nerva.
Multi-Z pathfinding! Because without it, Beepsky is too stupid to understand stairs :c

**Changes**

- Added railings to pathfinding obstacles. Beepsky will no longer try to ram through a solid railing, then question his life choices.
- Added bolted check to airlock pathfinding. Beepsky (and other NPCs), are now able to recognise bolted airlocks as obstacles and attempt to path around it! _Clever girl_
- Added `AStarWithZ()` proc. This is the meat of this PR. This a new proc which utilises the currently existing pathfinding code to allow for z level changes to be taken into account. To accommodate this, a new global list has been created, `GLOB.zlevel_transitions`. This is indexed by Z level (string), and returns a list of turfs or stairs that are able to facilitate z-level changes from that z level. At the moment, this is only set to include stairs (and thus open spaces above them), but future expansions could include ladders?

This proc isn't necessarily the most efficient or clever way to handle z transformations, but it does at least allow for dynamic navigation to different floors, something currently impossible. If someone big-brained wants to come along and write some super nerd script to handle all those nodes in a 3 dimensional space, be my guest!
This currently works by stringing along the already available `AStar()` pathfinding proc. The NPC will first identify what z levels it needs to cross to get to its target z level by working its way upwards, then downwards. Then on a level-by-level basis, it'll calculate a valid path to each set of stairs that brings it closer to its target. Finally, it'll insert and append the navigation of it's current turf to the first stair, and from the last stair to its final destination. The end result is a string of paths to the first stairs, between all the other stairs, and then its final destination.

At the moment, the only AI that calls this proc are types of `/mob/living/bot`, but it could easily be expanded to other mobs that follow players.

Again, if someone else has a more elegant and efficient solution then by all means correct or disregard this code!