### PR TITLE
More Bugfixing/Tweaks

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1230,6 +1230,7 @@
 	products = list(/obj/item/weapon/soap = 4,
 					/obj/item/weapon/soap/nanotrasen = 4,
 					/obj/item/weapon/soap/deluxe = 4,
+					/obj/item/weapon/storage/box/detergent = 3,
 					/obj/item/weapon/mirror = 8,
 					/obj/item/weapon/haircomb/random = 8,
 					/obj/item/weapon/haircomb/brush = 4,
@@ -1237,15 +1238,16 @@
 					)
 	premium = list(/obj/item/weapon/soap/gold = 1)
 	contraband = list(/obj/item/weapon/soap/syndie = 4,
-					  /obj/item/weapon/inflatable_duck = 1)
+					/obj/item/weapon/inflatable_duck = 1)
 	prices = list(/obj/item/weapon/soap = 20,
-				  /obj/item/weapon/soap/nanotrasen = 30,
-				  /obj/item/weapon/soap/deluxe = 60,
-				  /obj/item/weapon/soap/syndie = 10,
-				  /obj/item/weapon/mirror = 40,
-				  /obj/item/weapon/haircomb/random = 40,
-				  /obj/item/weapon/haircomb/brush = 80,
-				  /obj/item/weapon/towel/random = 50
+					/obj/item/weapon/soap/nanotrasen = 30,
+					/obj/item/weapon/soap/deluxe = 60,
+					/obj/item/weapon/storage/box/detergent = 60,
+					/obj/item/weapon/soap/syndie = 10,
+					/obj/item/weapon/mirror = 40,
+					/obj/item/weapon/haircomb/random = 40,
+					/obj/item/weapon/haircomb/brush = 80,
+					/obj/item/weapon/towel/random = 50
 					)
 
 //a food variant of the boda machine, only has one item currently.

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -774,7 +774,7 @@
 	anchored = 1
 	simulated = 0
 	power_usage = 0
-	channels=list("Engineering" = 1, "Security" = 1, "Medical" = 1, "Command" = 1, "Common" = 1, "Science" = 1, "Supply" = 1, "Service" = 1, "Exploration" = 1)
+	channels=list("Engineering" = 1, "Security" = 1, "Medical" = 1, "Command" = 1, "Common" = 1, "Science" = 1, "Supply" = 1, "Service" = 1, "Exploration" = 1, "Combat" = 1)
 	cell = null
 
 /obj/item/device/radio/announcer/Destroy()

--- a/code/modules/mob/living/simple_animal/hostile/hostile2.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile2.dm
@@ -138,7 +138,7 @@ mob/living/simple_animal/hostile/Initialize()
 		if(L.faction == src.faction && !attack_same || L.faction != src.faction && attack_same == 2 || L.faction != attack_faction && attack_faction)
 			return 0
 
-		if(L in friends)
+		if(weakref(L) in friends)
 			return 0
 
 		return 1

--- a/code/modules/urist/gamemodes/scom/civilian_mobs.dm
+++ b/code/modules/urist/gamemodes/scom/civilian_mobs.dm
@@ -45,11 +45,6 @@
 	icon_living = "gunman"
 	icon_dead = "gunman_dead"
 
-/mob/living/simple_animal/hostile/scom/civ/combat/police/Initialize()
-	. = ..()
-	var/area/A = get_area(src)
-	if(A?.type == /area/spacestations/nanotrasenspace)
-		stance = HOSTILE_STANCE_TIRED //Prevents any targetting/agression for NPC's on the NT station
 
 /mob/living/simple_animal/hostile/scom/civ/combat/mil
 	name = "soldier"

--- a/code/modules/urist/gamemodes/scom/civilian_mobs.dm
+++ b/code/modules/urist/gamemodes/scom/civilian_mobs.dm
@@ -45,6 +45,12 @@
 	icon_living = "gunman"
 	icon_dead = "gunman_dead"
 
+/mob/living/simple_animal/hostile/scom/civ/combat/police/Initialize()
+	. = ..()
+	var/area/A = get_area(src)
+	if(A?.type == /area/spacestations/nanotrasenspace)
+		stance = HOSTILE_STANCE_TIRED //Prevents any targetting/agression for NPC's on the NT station
+
 /mob/living/simple_animal/hostile/scom/civ/combat/mil
 	name = "soldier"
 	desc = "A soldier from a local military force."

--- a/code/modules/urist/modules/newtrading/NPC/NPC_types/colonist.dm
+++ b/code/modules/urist/modules/newtrading/NPC/NPC_types/colonist.dm
@@ -115,6 +115,12 @@
 		speak += "I saw a mudcrab the other day. Vile creatures they are." //the chances of this being heard are so small, but I had to put it in.
 	..()
 
+/mob/living/simple_animal/hostile/npc/colonist/Initialize()
+	. = ..()
+	var/area/A = get_area(src)
+	if(A?.type == /area/spacestations/nanotrasenspace)
+		stance = HOSTILE_STANCE_TIRED //Prevents any targetting/agression for NPC's on the NT station
+
 /mob/living/simple_animal/hostile/npc/colonist/labourer
 	angryprob = 25
 	jumpsuits = list(\

--- a/code/modules/urist/modules/newtrading/NPC/NPC_types/colonist.dm
+++ b/code/modules/urist/modules/newtrading/NPC/NPC_types/colonist.dm
@@ -115,11 +115,6 @@
 		speak += "I saw a mudcrab the other day. Vile creatures they are." //the chances of this being heard are so small, but I had to put it in.
 	..()
 
-/mob/living/simple_animal/hostile/npc/colonist/Initialize()
-	. = ..()
-	var/area/A = get_area(src)
-	if(A?.type == /area/spacestations/nanotrasenspace)
-		stance = HOSTILE_STANCE_TIRED //Prevents any targetting/agression for NPC's on the NT station
 
 /mob/living/simple_animal/hostile/npc/colonist/labourer
 	angryprob = 25

--- a/code/modules/urist/modules/shipbattles/ship_overmaps.dm
+++ b/code/modules/urist/modules/shipbattles/ship_overmaps.dm
@@ -11,7 +11,7 @@
 	var/landmarks = list()
 	var/target_x_bounds = list()
 	var/target_y_bounds = list()
-	var/list/announcement_channel = list("public" = null, "private" = null, "technical" = null)
+	var/list/announcement_channel = list("public" = null, "private" = null, "technical" = null, "combat" = null)
 	var/fleeing = FALSE
 	var/flee_timer = 0
 	var/can_escape = TRUE

--- a/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
@@ -132,7 +132,7 @@
 		var/evaded = FALSE
 		for(var/datum/shipcomponents/engines/E in OM.components)
 			if(!E.broken && prob(E.evasion_chance))
-				homeship.autoannounce("<b>The [src.name] has missed the [OM.ship_category].</b>", "private")
+				homeship.autoannounce("<b>The [src.name] has missed the [OM.ship_category].</b>", "combat")
 				evaded = TRUE
 				break
 
@@ -143,7 +143,7 @@
 					for(var/datum/shipcomponents/point_defence/PD in OM.components)	//Roll through each PD unit. Only one needs to hit to stop the projectile.
 						if(!PD.broken && prob(PD.intercept_chance))
 							intercepted = TRUE
-							homeship.autoannounce("<b>The [src.name] was intercepted by the [OM.ship_category]'s [PD.name].</b>", "private")	//Let the firing ship know PD is annoying.
+							homeship.autoannounce("<b>The [src.name] was intercepted by the [OM.ship_category]'s [PD.name].</b>", "combat")	//Let the firing ship know PD is annoying.
 							break
 
 				if(!intercepted)
@@ -176,7 +176,7 @@
 								HitComponents(OM)
 								MapFire()
 
-					homeship.autoannounce("<b>The [src.name] has hit the [OM.ship_category].</b>", "private")
+					homeship.autoannounce("<b>The [src.name] has hit the [OM.ship_category].</b>", "combat")
 
 			else //do we pass through the shield? let's do our damage
 						//not so fast, we've got point defence now
@@ -186,7 +186,7 @@
 					for(var/datum/shipcomponents/point_defence/PD in OM.components)	//Roll through each PD unit. Only one needs to hit to stop the projectile.
 						if(!PD.broken && prob(PD.intercept_chance))
 							intercepted = TRUE
-							homeship.autoannounce("<b>The [src.name] was intercepted by the [OM.ship_category]'s [PD.name].</b>", "private")	//Let the firing ship know PD is annoying.
+							homeship.autoannounce("<b>The [src.name] was intercepted by the [OM.ship_category]'s [PD.name].</b>", "combat")	//Let the firing ship know PD is annoying.
 							break
 
 				if(!intercepted)	//Let's take the damage outside the for loop to stop dupe damages if multiple PD's failed

--- a/maps/nerva/nerva_holodecks.dm
+++ b/maps/nerva/nerva_holodecks.dm
@@ -35,7 +35,6 @@
 			"Winter Simulation"  = "winter sim",
 			"Holographic Chapel" = "chapel",
 			"Basketball Court"   = "basketball",
-			"Beach"              = "beach",
 			"Boxing Ring"        = "boxingcourt",
 			"Courtroom"          = "courtroom",
 			"Empty Court"        = "emptycourt",


### PR DESCRIPTION
**Changes**

- Adds detergent to the lavatory vending machine next to the washing machines. Washing machines will not work at all without them, and there's no way currently to get them on the Nerva.
- Adds combat channel use to ship combat. All combat feedback (shots missed, hit etc) now go to the combat channel to avoid command channel spam. (Will require the changes to telecoms introduced in #1062 )
- Fixed a missing weakref check in mobs' friend lists. This would cause space carp summoned by an emagged holodeck to attack the emagger, which was not the intention. I thought we were friends?
- Fixed (see: fudged) odd NPC behaviour on the NT station. Currently if you're an antag (faction changed) and you visit the NT station; you will be mobbed, followed, and subsequently nuzzled to death. This patch forces all NPC that spawn on the NT station to set their stance to `HOSTILE_STANCE_TIRED`, which prevents their targeting loops from happening. This is the best I could come up with, without forcing global changes that might have unwanted knock-on effects. NT NPCs are now tree-hugging pacifists.
- Removed the mysterious second beach program from the holodeck program list, which was so secretive it forgot to exist.