### PR TITLE
Multi-z path-finding support + Bot path-finding tweaks/fixes

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -103,8 +103,6 @@
 	set_density(0)
 	update_nearby_tiles()
 	QDEL_NULL(dummy)
-	var/turf/T = get_turf(src)
-	T.pathweight = initial(T.pathweight)
 	. = ..()
 
 /obj/machinery/door/Process()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -103,6 +103,8 @@
 	set_density(0)
 	update_nearby_tiles()
 	QDEL_NULL(dummy)
+	var/turf/T = get_turf(src)
+	T.pathweight = initial(T.pathweight)
 	. = ..()
 
 /obj/machinery/door/Process()

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -305,7 +305,7 @@
 /mob/living/bot/proc/startPatrol()
 	var/turf/T = getPatrolTurf()
 	if(T)
-		patrol_path = AStar(get_turf(loc), T, /turf/proc/CardinalTurfsWithAccessWithZ, /turf/proc/Manhatten3dDistance, 0, max_patrol_dist, id = botcard, exclude = obstacle)
+		patrol_path = AStar(get_turf(loc), T, /turf/proc/CardinalTurfsWithAccessWithZ, /turf/proc/Manhattan3dDistance, 0, max_patrol_dist, id = botcard, exclude = obstacle)
 		if(!patrol_path)
 			patrol_path = list()
 		obstacle = null
@@ -493,15 +493,23 @@
 
 /turf/proc/Euclidean3dDistance(turf/t)
 	var/euclid_dist = sqrt(Square(src.x - t.x) + Square(src.y - t.y) + Square(src.z - t.z))
-	var/currentPathweight = ((locate(/obj/machinery/door) in src) && pathweight == 1) ? 2 : pathweight
-	var/targetPathweight = ((locate(/obj/machinery/door) in t) && t.pathweight == 1) ? 2 : t.pathweight
+	var/currentPathweight = src.pathweight
+	var/targetPathweight = t.pathweight
+	if(locate(/obj/machinery/door) in src)
+		currentPathweight += 1
+	if(locate(/obj/machinery/door) in t)
+		targetPathweight += 1
 	return euclid_dist * ((currentPathweight+targetPathweight)/2)
 
-/turf/proc/Manhatten3dDistance(turf/t)
-	var/manhatten_dist = abs(src.x - t.x) + abs(src.y - t.y) + abs(src.z - t.z)
-	var/currentPathweight = ((locate(/obj/machinery/door) in src) && src.pathweight == 1) ? 2 : src.pathweight
-	var/targetPathweight = ((locate(/obj/machinery/door) in t) && t.pathweight == 1) ? 2 : t.pathweight
-	return manhatten_dist * ((currentPathweight+targetPathweight)/2)
+/turf/proc/Manhattan3dDistance(turf/t)
+	var/manhattan_dist = abs(src.x - t.x) + abs(src.y - t.y) + abs(src.z - t.z)
+	var/currentPathweight = src.pathweight
+	var/targetPathweight = t.pathweight
+	if(locate(/obj/machinery/door) in src)
+		currentPathweight += 1
+	if(locate(/obj/machinery/door) in t)
+		targetPathweight += 1
+	return manhattan_dist * ((currentPathweight+targetPathweight)/2)
 
 //NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST + Traversal up and down stairs
 /turf/proc/AllDirTurfsWithAccessWithZ(var/obj/item/weapon/card/id/ID)

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -444,12 +444,15 @@
 		else if(DirBlockedWithAccess(xStep,adir&(NORTH|SOUTH),ID))
 			return 1
 
+		var/blocked = FALSE
 		for(var/obj/O in yStep)	//Both paths free? Check them for objects. So long as one isn't blocked, we can move
 			if(O.density && !istype(O, /obj/machinery/door) && !(O.atom_flags & ATOM_FLAG_CHECKS_BORDER))
-				for(var/obj/OB in xStep)
-					if(OB.density && !istype(OB, /obj/machinery/door) && !(OB.atom_flags & ATOM_FLAG_CHECKS_BORDER))
-						return 1
-				return 0
+				blocked = TRUE
+				break
+		if(blocked)
+			for(var/obj/O in xStep)
+				if(O.density && !istype(O, /obj/machinery/door) && !(O.atom_flags & ATOM_FLAG_CHECKS_BORDER))
+					return 1
 		return 0
 
 	if(DirBlockedWithAccess(A,adir, ID))

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -8,6 +8,7 @@
 
 	wait_if_pulled = 1
 	min_target_dist = 0
+	max_frustration = 5
 
 	var/cleaning = 0
 	var/screwloose = 0

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -17,6 +17,7 @@
 
 	patrol_speed = 2
 	target_speed = 3
+	max_frustration = 5
 	light_strength = 0 //stunbaton makes it's own light
 
 	RequiresAccessToToggle = 1 // Haha no


### PR DESCRIPTION
And here it is! This time done properly. This PR adds multi-z path finding support to the `AStar()` proc as well as addresses some issues currently present in bot pathfinding.

**Changes:**
- New multi-z aware adjacent and distance procs for use with `AStar()`. Currently only implemented in the bots, but could very easily be extended to any other mobs that navigates via `AStar()`
- Adds additional awareness to existing path-finding; such as bolted, powerless, and welded airlocks. AI's will try to avoid these airlocks now and navigate around them
- Tweaked the pathweight of turfs with airlocks on them. Bots will now _slightly_ prefer routes without airlock tiles. This was to combat bots using what are _technically_ shorter routes, that were actually longer due to airlock opening times.
- Set `max_frustration` to the most common bots. This'll allow them to 'give up' and start path-finding again if they get stuck
- Added frustration checks to patrol navigation. Currently bots only get frustrated when navigating to a target. However, there is an issue if bots get a target while on patrol and thus move off of the existing patrol route; once they lose interest in their target, they'll 'dumb' navigate back to the last point on the patrol path by calling `step_towards()`. This leads to many bots simply ramming walls over and over again, and getting trapped in maintenance. Now they'll get frustrated on each failed move to the patrol path, and recalculate using `AStar()` when they're tired of rubbing their metallic cheeks against maintenance.
- Made path-finding aware of railings. Previously they just.. didn't understand them and would walk into them and get stuck
- Dissallowed bot path-finding from using lift airlocks unless they are open. Now that path-finding is z-level aware, bots had the tendency to hurl themselves down the elevator shaft as a shortcut to the bottom deck. As amusing as this is, this could cause the elevator to get stuck as the airlock would be left open, as well as being a massive OSHA violation...

A couple examples of the path-finding changes in action: 

Beepsky working around a wall by taking the stairs either side


https://user-images.githubusercontent.com/54823378/159814095-8b23d30b-9444-49fd-b1c2-e8d139c9bd65.mp4


Beepsky avoiding a bolted airlock and path-finding around

https://user-images.githubusercontent.com/54823378/159814321-09aedaf5-f52b-4689-a32d-2198525fbc02.mp4


Once again, big thanks to @scrdest for the pointers in my last attempt. I wouldn't have noticed this much more (hopefully) elegant implementation without them!

There's also the option in future to potentially path-find using ladders and open space (stalker space carp, anyone?), though currently this is probably overkill and would require code on the mob side of things to handle activating the ladder etc

Any issues, as always, let me know!