### PR TITLE
The Great Gunfuckening

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -283,7 +283,7 @@
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
 	projectile_type = /obj/item/projectile/chameleon
 	charge_meter = 0
-	charge_cost = 20 //uses next to no power, since it's just holograms
+	charge_cost = 2 //uses next to no power, since it's just holograms - ACTUALLY uses next to no power now!
 	max_shots = 50
 
 	var/obj/item/projectile/copy_projectile

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -135,14 +135,21 @@
 
 /obj/item/weapon/cell/device/standard
 	name = "standard device power cell"
-	maxcharge = 25
+	maxcharge = 100
 
 /obj/item/weapon/cell/device/high
 	name = "advanced device power cell"
 	desc = "A small power cell designed to power more energy-demanding devices."
 	icon_state = "hdevice"
-	maxcharge = 100
+	maxcharge = 150
 	matter = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 6)
+
+/obj/item/weapon/cell/device/premium
+	name = "premium device power cell"
+	desc = "A small power cell designed to power the most energy-demanding devices."
+	icon_state = "hdevice"
+	maxcharge = 200
+	matter = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 7)
 
 /obj/item/weapon/cell/crap
 	name = "old power cell"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -85,7 +85,7 @@ obj/item/weapon/gun/energy/retro
 	one_hand_penalty = 6 //large and heavy
 	w_class = ITEM_SIZE_HUGE
 	projectile_type = /obj/item/projectile/beam/heavylaser
-	charge_cost = 40
+	charge_cost = 25
 	max_shots = 6
 	accuracy = 2
 	fire_delay = 20
@@ -137,7 +137,7 @@ obj/item/weapon/gun/energy/retro
 	projectile_type = /obj/item/projectile/beam/sniper
 	one_hand_penalty = 5 // The weapon itself is heavy, and the long barrel makes it hard to hold steady with just one hand.
 	slot_flags = SLOT_BACK
-	charge_cost = 40
+	charge_cost = 50
 	max_shots = 4
 	fire_delay = 35
 	force = 10

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -10,7 +10,7 @@
 	obj_flags =  OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BACK
 	one_hand_penalty = 4
-	charge_cost = 25
+	charge_cost = 20
 	max_shots = 10
 	projectile_type = /obj/item/projectile/ion
 	wielded_item_state = "ionrifle-wielded"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -10,7 +10,7 @@
 	obj_flags =  OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BACK
 	one_hand_penalty = 4
-	charge_cost = 30
+	charge_cost = 25
 	max_shots = 10
 	projectile_type = /obj/item/projectile/ion
 	wielded_item_state = "ionrifle-wielded"
@@ -30,7 +30,7 @@
 	force = 5
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	one_hand_penalty = 0
-	charge_cost = 20
+	charge_cost = 25
 	max_shots = 6
 	projectile_type = /obj/item/projectile/ion/small
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -23,6 +23,7 @@
 	one_hand_penalty = 3
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	force = 8
+	charge_cost = 25
 	max_shots = 12
 	accuracy = 1
 	projectile_type = /obj/item/projectile/beam/stun/heavy
@@ -52,6 +53,7 @@
 	item_state = "stunrevolver"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	projectile_type = /obj/item/projectile/energy/electrode
+	charge_cost = 25
 	max_shots = 6
 	combustion = 0
 
@@ -111,6 +113,7 @@
 	item_state = "plasma_stun"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2, TECH_POWER = 3)
 	fire_delay = 20
+	charge_cost = 50
 	max_shots = 4
 	projectile_type = /obj/item/projectile/energy/plasmastun
 	combustion = 0

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -23,7 +23,7 @@
 	one_hand_penalty = 3
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	force = 8
-	charge_cost = 25
+	charge_cost = 12.5
 	max_shots = 12
 	accuracy = 1
 	projectile_type = /obj/item/projectile/beam/stun/heavy

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -68,6 +68,7 @@
 	one_hand_penalty = 6
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	force = 10
+	charge_cost = 20
 	max_shots = 10
 	accuracy = 1
 	projectile_type = /obj/item/projectile/energy/electrode/stunshot

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -7,7 +7,7 @@
 	desc = "A gun that changes temperatures. It has a small label on the side, 'More extreme temperatures will cost more charge!'"
 	var/firing_temperature = T20C
 	var/current_temperature = T20C
-	charge_cost = 4
+	charge_cost = 2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
 	slot_flags = SLOT_BELT|SLOT_BACK
 	one_hand_penalty = 2
@@ -62,7 +62,7 @@
 	switch(firing_temperature)
 		if(0 to 100) charge_cost = 20
 		if(100 to 250) charge_cost = 10
-		if(251 to 300) charge_cost = 4
+		if(251 to 300) charge_cost = 2
 		if(301 to 400) charge_cost = 10
 		if(401 to 500) charge_cost = 20
 

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -62,7 +62,7 @@
 	switch(firing_temperature)
 		if(0 to 100) charge_cost = 20
 		if(100 to 250) charge_cost = 10
-		if(251 to 300) charge_cost = 2
+		if(251 to 300) charge_cost = 4
 		if(301 to 400) charge_cost = 10
 		if(401 to 500) charge_cost = 20
 

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -7,7 +7,7 @@
 	desc = "A gun that changes temperatures. It has a small label on the side, 'More extreme temperatures will cost more charge!'"
 	var/firing_temperature = T20C
 	var/current_temperature = T20C
-	charge_cost = 2
+	charge_cost = 4
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
 	slot_flags = SLOT_BELT|SLOT_BACK
 	one_hand_penalty = 2

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -7,14 +7,14 @@
 	desc = "A gun that changes temperatures. It has a small label on the side, 'More extreme temperatures will cost more charge!'"
 	var/firing_temperature = T20C
 	var/current_temperature = T20C
-	charge_cost = 10
+	charge_cost = 2
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 4, TECH_POWER = 3, TECH_MAGNET = 2)
 	slot_flags = SLOT_BELT|SLOT_BACK
 	one_hand_penalty = 2
 	wielded_item_state = "gun_wielded"
 
 	projectile_type = /obj/item/projectile/temp
-	cell_type = /obj/item/weapon/cell/high
+	cell_type = /obj/item/weapon/cell/device/premium
 	combustion = 0
 
 
@@ -60,11 +60,11 @@
 
 /obj/item/weapon/gun/energy/temperature/Process()
 	switch(firing_temperature)
-		if(0 to 100) charge_cost = 100
-		if(100 to 250) charge_cost = 50
-		if(251 to 300) charge_cost = 10
-		if(301 to 400) charge_cost = 50
-		if(401 to 500) charge_cost = 100
+		if(0 to 100) charge_cost = 20
+		if(100 to 250) charge_cost = 10
+		if(251 to 300) charge_cost = 2
+		if(301 to 400) charge_cost = 10
+		if(401 to 500) charge_cost = 20
 
 	if(current_temperature != firing_temperature)
 		var/difference = abs(current_temperature - firing_temperature)

--- a/code/modules/research/designs/designs_powercell.dm
+++ b/code/modules/research/designs/designs_powercell.dm
@@ -65,3 +65,12 @@
 	materials = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 6)
 	build_path = /obj/item/weapon/cell/device/high
 	sort_string = "DAAAF"
+
+/datum/design/item/powercell/device/premium
+	name = "premium-capacity"
+	build_type = PROTOLATHE | MECHFAB
+	id = "device_cell_premium"
+	req_tech = list(TECH_POWER = 3)
+	materials = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 7)
+	build_path = /obj/item/weapon/cell/device/premium
+	sort_string = "DAAAH"

--- a/code/modules/urist/items/guns.dm
+++ b/code/modules/urist/items/guns.dm
@@ -9,10 +9,11 @@
 	item_state = "gun"
 	fire_sound = 'sound/weapons/Taser.ogg'
 	w_class = 1
-	charge_cost = 150 //How much energy is needed to fire.
+	charge_cost = 10 //How much energy is needed to fire.
 	projectile_type = /obj/item/projectile/energy/electrode
 	origin_tech = "combat=2;magnets=2"
 	modifystate = "senergystun"
+	cell_type = /obj/item/weapon/cell/device/standard
 
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, modifystate="senergystun", fire_sound='sound/weapons/Taser.ogg', fire_delay=null, charge_cost=null),
@@ -96,11 +97,11 @@ the sprite and make my own projectile -Glloyd*/
 	item_state = "gun"
 	fire_sound = 'sound/weapons/Genhit.ogg'
 	w_class = 1
-	charge_cost = 150 //How much energy is needed to fire.
+	charge_cost = 20 //How much energy is needed to fire.
 	projectile_type = /obj/item/projectile/energy/plasma2
 	origin_tech = "combat=3;magnets=2"
 	modifystate = "plasmapistol"
-	cell_type = /obj/item/weapon/cell/crap
+	cell_type = /obj/item/weapon/cell/device/premium
 
 /*	suicide_act(mob/user)
 		viewers(user) << "<span class='danger'>[user] is unloading the [src.name] into their head! Their skin turns purple and starts to melt!</span>"


### PR DESCRIPTION
Cell swapping has been in for a bit, but even the best device cell RnD could make was worse than the default device cells that the guns started with in the majority of cases, meaning there was pretty much no point in building extra cells to reload with.

That changes now.

RnD's device cells have been boosted to 100Wh and 150Wh, and a new cell was added with 200Wh capacity, making cell swapping actually viable now!

In addition, _cell sizes for energy guns that can be cell swapped have been standardized across the board_, and their charge costs have been adjusted accordingly to keep their max shots the same. I'm sure I've missed some somewhere*, but even the Urist guns have been given a pass, _and fixed_, since they currently can't be fired due to their ludicrous charge costs vs the size of their cells.

(As a side note, there's a bug with how cell-swap code determines max cell size and how the temperature gun changes its charge costs based on what temperature it's set to, but I don't know nearly enough about coding to fix that.)

All of these guns have been tested and confirmed to work with the new values:
![dreamseeker_M9jn7fddGO](https://user-images.githubusercontent.com/82348291/159823310-086a7111-610a-49c9-b222-10567976a416.png)

*Pulse weapons were intentionally left alone, partially due to having incredibly wonky max_shots, partially because we're not going to see them in a normal round anyway, and partially because them needing a car battery to fire is fine.