### PR TITLE
Fixes comb & urist pistol icons

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -95,7 +95,7 @@
 	name = "silenced pistol"
 	desc = "A handgun with an integral silencer. Uses .45 rounds."
 	icon = 'icons/urist/items/pistols.dmi'
-	icon_state = "silenced_pistol"
+	icon_state = "pistol-silencer"
 	item_icons = URIST_ALL_ONMOBS
 	item_state = "pistol-silencer"
 	wielded_item_state = "pistol-silencer"

--- a/code/modules/urist/items/uristvanity.dm
+++ b/code/modules/urist/items/uristvanity.dm
@@ -121,9 +121,10 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	name = "purple comb"
 	desc = "A pristine purple comb made from flexible plastic."
 	w_class = 2.0
-	icon = 'icons/urist/items/old_bay_custom_items.dmi'
-	icon_state = "purplecomb"
-	item_state = "purplecomb"
+	icon = 'icons/obj/items.dmi'
+	icon_state = "comb"
+	item_state = "comb"
+	color = "#9932cc"
 
 	attack_self(mob/user)
 		if(user.r_hand == src || user.l_hand == src)


### PR DESCRIPTION
Fixes the urist-specific silenced pistol icon changed in #919 
Fixes the urist comb by having it be a recolor of the normal comb