### PR TITLE
Surgical & medical borg merge + surgery fixes/tweaks

### DIFF
--- a/code/_global_vars/lists/flavor.dm
+++ b/code/_global_vars/lists/flavor.dm
@@ -1,6 +1,6 @@
 // Used by robots and robot preferences.
 GLOBAL_LIST_INIT(robot_module_types, list(
-	"Standard", "Engineering", "Surgeon",  "Crisis",
+	"Standard", "Engineering", "Medical",
 	"Miner",    "Janitor",     "Service",  "Clerical", "Security",
 	"Research"
 )) // This shouldn't be a static list. Am I the only one who cares about extendability around here?

--- a/code/global.dm
+++ b/code/global.dm
@@ -147,7 +147,7 @@ var/global/list/alphabet_uppercase = list("A","B","C","D","E","F","G","H","I","J
 
 // Used by robots and robot preferences.
 var/list/robot_module_types = list(
-	"Standard", "Engineering", "Surgeon",  "Crisis",
+	"Standard", "Engineering", "Medical",
 	"Miner",    "Janitor",     "Service",      "Clerical", "Security",
 	"Research"
 )

--- a/code/modules/library/manuals/engineering.dm
+++ b/code/modules/library/manuals/engineering.dm
@@ -168,8 +168,8 @@
 				  <li>Destination Tagger</li>
 				</ul>
 
-				<h3>Crisis Cyborg</h3>
-				The crisis cyborg module is prepared to handle a variety of non-surgical medical emergencies.<br>A medical cyborg comes with:
+				<h3>Medical Cyborg</h3>
+				The medical cyborg module is prepared to handle a variety of medical and surgical emergencies.<br>A medical cyborg comes with:
 				<ul>
 				  <li>Crowbar</li>
 				  <li>Health Analyzer</li>
@@ -184,23 +184,7 @@
 				  <li>Fire Extinguisher</li>
 				  <li>Inflatables Dispenser</li>
 				  <li>Roll of Tape</li>
-				</ul>
-
-				<h3>Surgeon Cyborg</h3>
-				The surgeon cyborg modules is prepared to handle a variety of surgical medical emergencies.<br>A medical cyborg comes with:
-				<ul>
 				  <li>Set of Surgery Tools</li>
-				  <li>Health Analyzer</li>
-				  <li>Roller Bed Rack</li>
-				  <li>Body Bag Rack</li>
-				  <li>Hypospray</li>
-				  <li>Automatic Defibrillator</li>
-				  <li>Industrial Dropper</li>
-				  <li>Syringe</li>
-				  <li>Chemistry Gripper</li>
-				  <li>Fire Extinguisher</li>
-				  <li>Inflatables Dispenser</li>
-				  <li>Roll of Tape</li>
 				</ul>
 
 				<h2><a name="Construction">Cyborg Construction</h2>

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -4,8 +4,7 @@ var/global/list/robot_modules = list(
 	"Clerical" 		= /obj/item/weapon/robot_module/clerical/general,
 	"Research" 		= /obj/item/weapon/robot_module/research,
 	"Miner" 		= /obj/item/weapon/robot_module/miner,
-	"Crisis" 		= /obj/item/weapon/robot_module/medical/crisis,
-	"Surgeon" 		= /obj/item/weapon/robot_module/medical/surgeon,
+	"Medical" 		= /obj/item/weapon/robot_module/medical,
 	"Security" 		= /obj/item/weapon/robot_module/security/general,
 	"Combat" 		= /obj/item/weapon/robot_module/security/combat,
 	"Engineering"	= /obj/item/weapon/robot_module/engineering/general,
@@ -192,7 +191,6 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/melee/baton/loaded(src)
 	src.modules += new /obj/item/weapon/extinguisher(src)
 	src.modules += new /obj/item/weapon/wrench(src)
-	src.modules += new /obj/item/weapon/crowbar(src)
 	src.modules += new /obj/item/device/healthanalyzer(src)
 	src.emag = new /obj/item/weapon/melee/energy/sword(src)
 	..()
@@ -204,28 +202,31 @@ var/global/list/robot_modules = list(
 	subsystems = list(/datum/nano_module/crew_monitor)
 	can_be_pushed = 0
 
-/obj/item/weapon/robot_module/medical/surgeon
-	name = "surgeon robot module"
 	sprites = list(
 					"Basic" = "Medbot",
 					"Standard" = "surgeon",
 					"Advanced Droid" = "droid-medical",
 					"Needles" = "medicalrobot",
-					"Drone" = "drone-surgery",
+					"Drone" = "drone-medical",
+					"Drone - Surgery" = "drone-surgery",
+					"Drone - Chemistry" = "drone-chemistry",
 					"Ravensdale" = "ravensdale-Medical",
 					"Advanced-Drone" = "Advanced-Drone-Medical",
 					"Wiredroid" = "Wiredroid-Medical",
-					"Worm" = "Worm-Surgeon",
-					"Spider" = "Spider-Surgeon",
-					"Eyebot" = "Eyebot-surgeon"
+					"Worm" = "Worm-Crisis",
+					"Spider" = "Spider-Crisis",
+					"Spider - Surgery" = "Spider-Surgeon",
+					"Eyebot" = "Eyebot-crisis",
 					)
 
-/obj/item/weapon/robot_module/medical/surgeon/New()
-	src.modules	+= new /obj/item/weapon/crowbar(src)
+/obj/item/weapon/robot_module/medical/New()
 	src.modules += new /obj/item/device/flash(src)
-	src.modules += new /obj/item/borg/sight/hud/med(src)
+	src.modules += new /obj/item/weapon/shockpaddles/robot(src)
 	src.modules += new /obj/item/device/healthanalyzer(src)
-	src.modules += new /obj/item/weapon/reagent_containers/borghypo/surgeon(src)
+	src.modules += new /obj/item/device/reagent_scanner/adv(src)
+	src.modules += new /obj/item/weapon/reagent_containers/borghypo/medical(src)
+	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
+	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/scalpel/manager(src)
 	src.modules += new /obj/item/weapon/hemostat(src)
 	src.modules += new /obj/item/weapon/retractor(src)
@@ -236,69 +237,13 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/circular_saw(src)
 	src.modules += new /obj/item/weapon/surgicaldrill(src)
 	src.modules += new /obj/item/weapon/gripper/organ(src)
-	src.modules += new /obj/item/robot_rack/roller(src, 1)
-	src.modules += new /obj/item/weapon/shockpaddles/robot(src)
-	src.modules += new /obj/item/weapon/crowbar(src)
-	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
-	src.emag.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
-	src.emag.SetName("Polyacid spray")
-
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
-	synths += medicine
-
-	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
-	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
-	N.uses_charge = 1
-	N.charge_costs = list(1000)
-	N.synths = list(medicine)
-	B.uses_charge = 1
-	B.charge_costs = list(1000)
-	B.synths = list(medicine)
-	src.modules += N
-	src.modules += B
-
-	..()
-
-/obj/item/weapon/robot_module/medical/surgeon/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
-	if(src.emag)
-		var/obj/item/weapon/reagent_containers/spray/PS = src.emag
-		PS.reagents.add_reagent(/datum/reagent/acid/polyacid, 2 * amount)
-	..()
-
-/obj/item/weapon/robot_module/medical/crisis
-	name = "crisis robot module"
-	sprites = list(
-					"Basic" = "Medbot",
-					"Standard" = "surgeon",
-					"Advanced Droid" = "droid-medical",
-					"Needles" = "medicalrobot",
-					"Drone - Medical" = "drone-medical",
-					"Drone - Chemistry" = "drone-chemistry",
-					"Ravensdale" = "ravensdale-Medical",
-					"Advanced-Drone" = "Advanced-Drone-Medical",
-					"Wiredroid" = "Wiredroid-Medical",
-					"Worm" = "Worm-Crisis",
-					"Spider" = "Spider-Crisis",
-					"Eyebot" = "Eyebot-crisis"
-					)
-
-/obj/item/weapon/robot_module/medical/crisis/New()
-	src.modules += new /obj/item/weapon/crowbar(src)
-	src.modules += new /obj/item/device/flash(src)
-	src.modules += new /obj/item/borg/sight/hud/med(src)
-	src.modules += new /obj/item/device/healthanalyzer(src)
-	src.modules += new /obj/item/device/reagent_scanner/adv(src)
+	src.modules += new /obj/item/weapon/gripper/chemistry(src)
 	src.modules += new /obj/item/robot_rack/roller(src, 1)
 	src.modules += new /obj/item/robot_rack/body_bag(src)
-	src.modules += new /obj/item/weapon/reagent_containers/borghypo/crisis(src)
-	src.modules += new /obj/item/weapon/shockpaddles/robot(src)
-	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
-	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
-	src.modules += new /obj/item/weapon/gripper/chemistry(src)
-	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.modules += new /obj/item/taperoll/medical(src)
-	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src) // Allows usage of inflatables. Since they are basically robotic alternative to EMTs, they should probably have them.
-	src.modules += new /obj/item/weapon/crowbar(src)
+	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src)
+	src.modules	+= new /obj/item/weapon/crowbar(src)
+	src.modules += new /obj/item/weapon/extinguisher/mini(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
 	src.emag.SetName("Polyacid spray")
@@ -306,25 +251,30 @@ var/global/list/robot_modules = list(
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
 	synths += medicine
 
+	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
+	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	var/obj/item/stack/medical/ointment/O = new /obj/item/stack/medical/ointment(src)
-	var/obj/item/stack/medical/bruise_pack/B = new /obj/item/stack/medical/bruise_pack(src)
 	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
 	O.synths = list(medicine)
+	N.uses_charge = 1
+	N.charge_costs = list(1000)
+	N.synths = list(medicine)
 	B.uses_charge = 1
 	B.charge_costs = list(1000)
 	B.synths = list(medicine)
 	S.uses_charge = 1
 	S.charge_costs = list(1000)
 	S.synths = list(medicine)
-	src.modules += O
+	src.modules += N
 	src.modules += B
+	src.modules += O
 	src.modules += S
 
 	..()
 
-/obj/item/weapon/robot_module/medical/crisis/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
+/obj/item/weapon/robot_module/medical/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/weapon/reagent_containers/syringe/S = locate() in src.modules
 	if(S.mode == 2)
 		S.reagents.clear_reagents()
@@ -472,7 +422,6 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/taperoll/police(src)
 	src.modules += new /obj/item/device/megaphone(src)
 	src.modules += new /obj/item/device/holowarrant(src)
-	src.modules += new /obj/item/weapon/crowbar(src)
 	src.modules += new /obj/item/device/hailer(src)
 	src.emag = new /obj/item/weapon/gun/energy/laser/mounted(src)
 	..()
@@ -517,7 +466,6 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.modules += new /obj/item/borg/sight/hud/jani(src)
 	src.modules += new /obj/item/device/plunger/robot(src)
-	src.modules += new /obj/item/weapon/crowbar(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent(/datum/reagent/lube, 250)
 	src.emag.SetName("Lube spray")
@@ -573,7 +521,6 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/robot_harvester(src)
 	src.modules += new /obj/item/weapon/material/kitchen/rollingpin(src)
 	src.modules += new /obj/item/weapon/material/knife(src)
-	src.modules += new /obj/item/weapon/crowbar(src)
 
 	var/obj/item/weapon/rsf/M = new /obj/item/weapon/rsf(src)
 	M.stored_matter = 30
@@ -623,7 +570,6 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/stamp(src)
 	src.modules += new /obj/item/weapon/stamp/denied(src)
 	src.modules += new /obj/item/device/destTagger(src)
-	src.modules += new /obj/item/weapon/crowbar(src)
 	src.emag = new /obj/item/weapon/stamp/chameleon(src)
 
 	var/datum/matter_synth/package_wrap = new /datum/matter_synth/package_wrap()
@@ -673,7 +619,6 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/storage/sheetsnatcher/borg(src)
 	src.modules += new /obj/item/weapon/gripper/miner(src)
 	src.modules += new /obj/item/weapon/mining_scanner(src)
-	src.modules += new /obj/item/weapon/crowbar(src)
 	src.emag = new /obj/item/weapon/gun/energy/plasmacutter(src)
 	..()
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -738,13 +738,15 @@ Note that amputating the affected organ does in fact remove the infection from t
 	for(var/datum/wound/W in wounds)
 
 		if(W.damage <= 0)
+			wounds -= W
 			qdel(W)
 			continue
 
-		if(W.damage_type == BURN)
-			burn_dam += W.damage
-		else
-			brute_dam += W.damage
+		if(!W.is_surgical())
+			if(W.damage_type == BURN)
+				burn_dam += W.damage
+			else
+				brute_dam += W.damage
 
 		if(bleeds && W.bleeding() && (H && H.should_have_organ(BP_HEART)))
 			W.bleed_timer--
@@ -1406,7 +1408,7 @@ obj/item/organ/external/proc/remove_clamps()
 		var/bone = encased ? encased : "bone"
 		if(status & ORGAN_BROKEN)
 			bone = "broken [bone]"
-		wound_descriptors["a [bone] exposed"] = 1
+		wound_descriptors["[bone] exposed"] = 1
 
 		if(!encased || how_open() >= SURGERY_ENCASED)
 			var/list/bits = list()

--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -131,7 +131,7 @@
 // heal the given amount of damage, and if the given amount of damage was more
 // than what needed to be healed, return how much heal was left
 /datum/wound/proc/heal_damage(amount)
-	if(embedded_objects.len)
+	if(embedded_objects.len || clamped)
 		return amount // heal nothing
 	var/healed_damage = min(src.damage, amount)
 	amount -= healed_damage

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -17,11 +17,8 @@
 	var/list/reagent_volumes = list()
 	var/list/reagent_names = list()
 
-/obj/item/weapon/reagent_containers/borghypo/surgeon
-	reagent_ids = list(/datum/reagent/bicaridine, /datum/reagent/dexalin, /datum/reagent/tramadol)
-
-/obj/item/weapon/reagent_containers/borghypo/crisis
-	reagent_ids = list(/datum/reagent/tricordrazine, /datum/reagent/inaprovaline, /datum/reagent/tramadol)
+/obj/item/weapon/reagent_containers/borghypo/medical
+	reagent_ids = list(/datum/reagent/inaprovaline, /datum/reagent/bicaridine, /datum/reagent/tricordrazine, /datum/reagent/dexalin, /datum/reagent/tramadol)
 
 /obj/item/weapon/reagent_containers/borghypo/Initialize()
 	. = ..()

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -42,8 +42,9 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has made a bloodless incision on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have made a bloodless incision on [target]'s [affected.name] with \the [tool].</span>",)
-	affected.createwound(CUT, affected.min_broken_damage/2, 1)
+	var/datum/wound/W = affected.createwound(CUT, affected.min_broken_damage/2, 1)
 	affected.clamp()
+	W.desc = "clean surgical incision"
 	spread_germs_to_organ(affected, user)
 
 /decl/surgery_step/generic/cut_with_laser/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -75,9 +76,10 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has constructed a prepared incision on and within [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have constructed a prepared incision on and within [target]'s [affected.name] with \the [tool].</span>",)
-	affected.createwound(CUT, affected.min_broken_damage/2, 1) // incision
+	var/datum/wound/W = affected.createwound(CUT, affected.min_broken_damage/2, 1) // incision
 	affected.clamp() // clamp
 	affected.open_incision() // retract
+	W.desc = "clean surgical incision"
 
 /decl/surgery_step/generic/managed/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -122,7 +124,9 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has made [access_string] on [target]'s [affected.name] with \the [tool].</span>", \
 	"<span class='notice'>You have made [access_string] on [target]'s [affected.name] with \the [tool].</span>",)
-	affected.createwound(CUT, affected.min_broken_damage/2, 1)
+	var/datum/wound/W = affected.createwound(CUT, affected.min_broken_damage/2, 1)
+	if(istype(tool, /obj/item/weapon/scalpel))
+		W.desc = "clean surgical incision"
 	playsound(target.loc, 'sound/weapons/bladeslice.ogg', 15, 1)
 
 /decl/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -259,8 +263,8 @@
 /decl/surgery_step/generic/cauterize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/datum/wound/W = affected.get_incision()
-	user.visible_message("[user] is beginning to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool]." , \
-	"You are beginning to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool].")
+	user.visible_message("[user] starts to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool]." , \
+	"You start to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("Your [affected.name] is being burned!",40,affecting = affected)
 	..()
 
@@ -312,8 +316,8 @@
 
 /decl/surgery_step/generic/amputate/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] is beginning to amputate [target]'s [affected.name] with \the [tool]." , \
-	"<FONT size=3>You are beginning to cut through [target]'s [affected.amputation_point] with \the [tool].</FONT>")
+	user.visible_message("[user] starts to amputate [target]'s [affected.name] with \the [tool]." , \
+	"<FONT size=3>You start to cut through [target]'s [affected.amputation_point] with \the [tool].</FONT>")
 	target.custom_pain("Your [affected.amputation_point] is being ripped apart!",100,affecting = affected)
 	..()
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -202,7 +202,11 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			return TRUE
 
 	// Otherwise we can make a start on surgery!
-	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT && user.get_active_hand() == src)
+	else if(istype(M) && !QDELETED(M) && user.a_intent != I_HURT)
+		if(user.get_active_hand() != src)
+			var/obj/item/weapon/gripper/organ/gripper = user.get_active_hand()	//Grippers spoof attackby procs so they will be the active hand, not the src
+			if(!istype(gripper) || gripper.wrapped != src)
+				return FALSE
 		// Double-check this in case it changed between initial check and now.
 		if(zone in M.surgeries_in_progress)
 			to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))


### PR DESCRIPTION
- Merges the crisis and surgery borg modules together, due to both being crippled without the functionality of the other in terms of giving actual medical aid
- Fixes the organ gripper not being able to be used during surgery steps, due to a check for the organ in their active hand
- Removes duplicate crowbars over all borg modules
- Fixes null entries in wound lists in external organs as well as GC runtimes caused by wounds. Caused by not removing wounds from the wound list before calling `qdel` leaving references
- Fixed/tweaked various verbiage during surgery: Duplicate a's, awkward phrasing etc
- Changed wounds created by scalpels and surgical tools description to be "clean surgical incision". "Large ugly ripped cut" does not make sense for a incision site unless using ghetto tools.
- Added clamped check to wound `heal_damage()` proc. This prevents things like Bicaridine from closing clamped incision sites (surgical wounds already do not auto-heal, so logically this makes sense to me). Admin rejuv will still close the site and heal as intended.
- Removed surgical wound 'damage' from total damage/health tally. Surgical wounds would already not show up as damage to the limb _unless_ another wound is later inflicted on the limb to cause more damage. Happy to reverse this if necessary, but as the damage wasn't tallied on surgery steps, I assumed this was intentional.