### PR TITLE
Allows grabbed mob movement on ladders

### DIFF
--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -285,6 +285,9 @@
 	return current_grab.grab_slowdown
 
 /obj/item/grab/proc/ladder_carry()
+	if(ismob(affecting))
+		var/mob/M = affecting
+		return current_grab.ladder_carry || M.incapacitated() || M.a_intent == I_HELP
 	return current_grab.ladder_carry
 
 /obj/item/grab/proc/assailant_moved()


### PR DESCRIPTION
Super basic PR for a requested feature. This will allow mobs to transport other mobs up and down ladders.

It requires a reinforced grab, and the other mob to either be incapacitated (unconscious, cuffed, etc) or on the help intent. Simple.