### PR TITLE
Bugfixing again

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -8,7 +8,7 @@ var/list/gamemode_cache = list()
 	var/log_access = 0					// log login/logout
 	var/log_say = 0						// log client say
 	var/log_admin = 0					// log admin actions
-	var/log_debug = 1					// log debug output
+	var/log_debug = 0					// log debug output
 	var/log_game = 0					// log game events
 	var/log_vote = 0					// log voting
 	var/log_whisper = 0					// log client whisper
@@ -25,9 +25,9 @@ var/list/gamemode_cache = list()
 	var/allow_vote_restart = 0 			// allow votes to restart
 	var/ert_admin_call_only = 0
 	var/allow_vote_mode = 0				// allow votes to change mode
-	var/allow_admin_jump = 1			// allows admin jumping
-	var/allow_admin_spawning = 1		// allows admin item spawning
-	var/allow_admin_rev = 1				// allows admin revives
+	var/allow_admin_jump = 0			// allows admin jumping
+	var/allow_admin_spawning = 0		// allows admin item spawning
+	var/allow_admin_rev = 0				// allows admin revives
 	var/vote_delay = 6000				// minimum time between voting sessions (deciseconds, 10 minute default)
 	var/vote_period = 600				// length of voting period (deciseconds, default 1 minute)
 	var/vote_autotransfer_initial = 108000 // Length of time before the first autotransfer vote is called
@@ -40,7 +40,7 @@ var/list/gamemode_cache = list()
 	var/del_new_on_log = 1				// del's new players if they log before they spawn in
 	var/feature_object_spell_system = 0 //spawns a spellbook which gives object-type spells instead of verb-type spells for the wizard
 	var/traitor_scaling = 0 			//if amount of traitors scales based on amount of players
-	var/objectives_disabled = 1 			//if objectives are disabled or not
+	var/objectives_enabled = CONFIG_OBJECTIVE_VERB 			//if objectives are disabled or not
 	var/protect_roles_from_antagonist = 1// If security and such can be traitor/cult/other
 	var/continous_rounds = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
 	var/allow_Metadata = 0				// Metadata is supported.
@@ -56,10 +56,10 @@ var/list/gamemode_cache = list()
 	var/list/probabilities = list()		// relative probability of each mode
 	var/humans_need_surnames = 0
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
-	var/allow_ai = 1					// allow ai job
+	var/allow_ai = 0					// allow ai job
 	var/hostedby = null
 	var/respawn_delay = 30
-	var/guest_jobban = 1
+	var/guest_jobban = 0
 	var/usewhitelist = 0
 	var/kick_inactive = 0				//force disconnect for inactive players after this many minutes, if non-0
 	var/mods_can_tempban = 0
@@ -70,14 +70,14 @@ var/list/gamemode_cache = list()
 	var/jobs_have_minimal_access = 0	//determines whether jobs use minimal access or expanded access.
 	var/use_cortical_stacks = 0
 
-	var/cult_ghostwriter = 1               //Allows ghosts to write in blood in cult rounds...
+	var/cult_ghostwriter = 0               //Allows ghosts to write in blood in cult rounds...
 	var/cult_ghostwriter_req_cultists = 10 //...so long as this many cultists are active.
 
 	var/character_slots = 10				// The number of available character slots
 	var/loadout_slots = 3					// The number of loadout slots per character
 
 	var/max_maint_drones = 5				//This many drones can spawn,
-	var/allow_drone_spawn = 1				//assuming the admin allow them to.
+	var/allow_drone_spawn = 0				//assuming the admin allow them to.
 	var/drone_build_time = 1200				//A drone will become available every X ticks since last drone spawn. Default is 2 minutes.
 
 	var/disable_player_mice = 0
@@ -183,7 +183,7 @@ var/list/gamemode_cache = list()
 	// 15, 45, 70 minutes respectively
 	var/list/event_delay_upper = list(EVENT_LEVEL_MUNDANE = 9000,	EVENT_LEVEL_MODERATE = 27000,	EVENT_LEVEL_MAJOR = 42000)
 
-	var/aliens_allowed = 1
+	var/aliens_allowed = 0
 	var/alien_eggs_allowed = 0
 	var/ninjas_allowed = 0
 	var/abandon_allowed = 1
@@ -313,7 +313,7 @@ var/list/gamemode_cache = list()
 					config.log_admin = 1
 
 				if ("log_debug")
-					config.log_debug = text2num(value)
+					config.log_debug = 1
 
 				if ("log_game")
 					config.log_game = 1
@@ -437,7 +437,7 @@ var/list/gamemode_cache = list()
 					config.issuereporturl = value
 
 				if ("ghosts_can_possess_animals")
-					config.ghosts_can_possess_animals = value
+					config.ghosts_can_possess_animals = 1
 
 				if ("guest_jobban")
 					config.guest_jobban = 1
@@ -487,21 +487,21 @@ var/list/gamemode_cache = list()
 				if ("ninjas_allowed")
 					config.ninjas_allowed = 1
 
-				if ("objectives_disabled")
+				if ("objectives_enabled")
 					if(!value)
-						log_misc("Could not find value for objectives_disabled in configuration.")
-						config.objectives_disabled = CONFIG_OBJECTIVE_NONE
+						log_misc("Could not find value for objectives_enabled in configuration.")
+						config.objectives_enabled = CONFIG_OBJECTIVE_NONE
 					else
 						switch(value)
 							if("none")
-								config.objectives_disabled = CONFIG_OBJECTIVE_NONE
+								config.objectives_enabled = CONFIG_OBJECTIVE_NONE
 							if("verb")
-								config.objectives_disabled = CONFIG_OBJECTIVE_VERB
+								config.objectives_enabled = CONFIG_OBJECTIVE_VERB
 							if("all")
-								config.objectives_disabled = CONFIG_OBJECTIVE_ALL
+								config.objectives_enabled = CONFIG_OBJECTIVE_ALL
 							else
 								log_misc("Incorrect objective disabled definition: [value]")
-								config.objectives_disabled = CONFIG_OBJECTIVE_NONE
+								config.objectives_enabled = CONFIG_OBJECTIVE_NONE
 				if("protect_roles_from_antagonist")
 					config.protect_roles_from_antagonist = 1
 
@@ -647,7 +647,7 @@ var/list/gamemode_cache = list()
 					config.loadout_slots = text2num(value)
 
 				if("allow_drone_spawn")
-					config.allow_drone_spawn = text2num(value)
+					config.allow_drone_spawn = 1
 
 				if("drone_build_time")
 					config.drone_build_time = text2num(value)

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -11,6 +11,20 @@
 /hook/startup
 
 /**
+ * Gamemode selected hook
+ * Called in ticker.dm after a potential gamemode has been selected, but before jobs and antags have attempted to spawn
+ * Parameters: /datum/game_mode
+ */
+/hook/gamemode_selected
+
+/**
+ * Gamemode start failed hook
+ * Called in ticker.dm when a selected gamemode is unable to start
+ * Parameters: /datum/game_mode
+ */
+/hook/gamemode_start_failed
+
+/**
  * Roundstart hook.
  * Called in ticker.dm when a round starts.
  */

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -33,6 +33,10 @@ SUBSYSTEM_DEF(supply)
 	//virus dishes uniqueness
 	var/list/sold_virus_strains = list()
 
+	//Price changes
+	var/price_modifier = 0.04	//% price goes down from each sale of a material to the supply station: 4% decrease in value for each item sold
+	var/sold_items = list()	//Items sold to the supply station	//TODO: Generate an inventory of trade_item datums for the station and simulate supply/demand proper
+
 /datum/controller/subsystem/supply/Initialize()
 	. = ..()
 	ordernum = rand(1,9000)
@@ -110,6 +114,8 @@ SUBSYSTEM_DEF(supply)
 
 /datum/controller/subsystem/supply/proc/sell()
 	var/list/material_count = list()
+	var/list/to_sell = list()
+	var/list/crates = list()
 
 	for(var/area/subarea in shuttle.shuttle_area)
 		for(var/atom/movable/AM in subarea)
@@ -121,47 +127,39 @@ SUBSYSTEM_DEF(supply)
 					if(AM.type in CC.wanted_types)
 						CC.Complete(1)
 						qdel(AM)
-						continue
+						break
+
+				if(QDELETED(AM))	//Our atom was qdel'd/used in a contract-- move onto the next atom to free up the reference for GC
+					continue
 
 			if(istype(AM, /obj/structure/closet/crate/))
 				var/obj/structure/closet/crate/CR = AM
-				callHook("sell_crate", list(CR, subarea))
-				add_points_from_source(CR.points_per_crate, "crate")
+				crates[CR] = subarea	//Store the crate to be handled later, as we'll have object refrences we'll need for the contents inside it
 				var/find_slip = 1
-				for(var/atom in CR)
-					// Sell manifests
-					var/atom/A = atom
 
+				for(var/atom/A in CR)
 					if(GLOB.using_map.using_new_cargo)
 						for(var/datum/contract/cargo/CC in GLOB.using_map.contracts) //just in case someone shoved it in a crate
 							if(A.type in CC.wanted_types)
 								CC.Complete(1)
-								//qdel(AM)
-								continue
+								qdel(A)
+								break
 
-						if(istype(A, /obj/item/stack/material))
-							var/obj/item/stack/material/P = A
-							var/material/material = P.get_material()
-							if(material.sale_price > 0)
-								var/materialmoney = P.get_amount() * material.sale_price
-								materialmoney *= GLOB.using_map.new_cargo_inflation
-								materialmoney *= 0.25 //test and balance
-								material_count[material.display_name] += materialmoney
+						if(QDELETED(A))
+							continue
 
-						else
+					//Calculate sales for each material
+					if(istype(A, /obj/item/stack/material))
+						var/obj/item/stack/material/S = A
+						var/amount = S.get_amount()
+						if(S.material.sale_price > 0)
+							material_count[S.material.display_name] += find_item_value(S, amount)
+						if(S.reinf_material?.sale_price > 0)
+							material_count[S.reinf_material.display_name] += find_item_value(S, amount, TRUE)
+						qdel(S)
+						continue
 
-							var/obj/O = A
-							var/addvalue
-
-							if(GLOB.using_map.trading_faction)
-								if(GLOB.using_map.trading_faction.reputation > 50)
-									var/newvalue = (GLOB.using_map.trading_faction.reputation - 50) / 100
-									addvalue = (find_item_value(O) * ((newvalue / 2) + 0.75))
-							else
-								addvalue = (find_item_value(O) * 0.75) //we get even less for selling in bulk
-
-							add_points_from_source(addvalue, "trade")
-
+					// Sell manifests
 					if(find_slip && istype(A,/obj/item/weapon/paper/manifest))
 						var/obj/item/weapon/paper/manifest/slip = A
 						if(!slip.is_copy && slip.stamped && slip.stamped.len) //Any stamp works.
@@ -169,19 +167,12 @@ SUBSYSTEM_DEF(supply)
 							find_slip = 0
 						continue
 
-					// Sell materials
-					if(istype(A, /obj/item/stack/material))
-						var/obj/item/stack/material/P = A
-						if(P.material && P.material.sale_price > 0)
-							material_count[P.material.display_name] += P.get_amount() * P.material.sale_price * P.matter_multiplier
-						if(P.reinf_material && P.reinf_material.sale_price > 0)
-							material_count[P.reinf_material.display_name] += P.get_amount() * P.reinf_material.sale_price * P.matter_multiplier * 0.5
-						continue
-
 					// Must sell ore detector disks in crates
 					if(istype(A, /obj/item/weapon/disk/survey))
 						var/obj/item/weapon/disk/survey/D = A
 						add_points_from_source(round(D.Value() * 0.005), "gep")
+						qdel(D)
+						continue
 
 					// Sell virus dishes.
 					if(istype(A, /obj/item/weapon/virusdish))
@@ -191,12 +182,42 @@ SUBSYSTEM_DEF(supply)
 							if(!(dish.virus2.uniqueID in sold_virus_strains))
 								add_points_from_source(5, "virology_dishes")
 								sold_virus_strains += dish.virus2.uniqueID
+						qdel(dish)
+						continue
 
-			qdel(AM)
+					//Sell anything else that isn't unique or needs special handling
+					if(A.type in to_sell)
+						to_sell[A.type]["count"]++
+						qdel(A)	//We already have an object reference to use for values, duplicate items are safe to qdel
+					else
+						to_sell[A.type] = list("obj" = A, "count" = 1)
 
-	if(material_count.len)
-		for(var/material_type in material_count)
-			add_points_from_source(material_count[material_type], material_type)
+			else
+				qdel(AM)
+
+	var/payout = 0
+
+	//Sell all items in bulk and qdel them
+	for(var/atom_type in to_sell)
+		var/obj/O = to_sell[atom_type]["obj"]
+		var/amount = to_sell[atom_type]["count"]
+		payout += make_trade(O, amount)
+		to_sell[atom_type]["obj"] = null
+		qdel(O)
+
+	//Sell all materials in bulk
+	for(var/material in material_count)
+		add_points_from_source(material_count[material], material)
+
+	//Finally sell all crates in bulk and qdel them, calling the sell_crate hook
+	for(var/obj/structure/closet/crate/CR in crates)
+		callHook("sell_crate", list(CR, crates[CR]))
+		add_points_from_source(CR.points_per_crate, "crate")
+		crates -= CR
+		qdel(CR)
+
+	//Pay our lovely people what they earned
+	add_points_from_source(payout, "trade")
 
 //Buyin
 /datum/controller/subsystem/supply/proc/buy()
@@ -264,16 +285,61 @@ SUBSYSTEM_DEF(supply)
 	var/reason = null
 	var/orderedrank = null //used for supply console printing
 
-/datum/controller/subsystem/supply/proc/find_item_value(var/obj/object) //here we get the value of the items being traded
+/datum/controller/subsystem/supply/proc/make_trade(var/obj/object, var/count = 1)
+	. = find_item_value(object, count)
+	if(.)
+		sold_items[object.type] += count
+	return .
+
+/datum/controller/subsystem/supply/proc/find_item_value(var/obj/object, var/count = 1, var/use_reinf_material = FALSE) //here we get the value of the items being traded
 	if(!object)
 		return 0
 
-	//this uses the default SS13 item_worth procs so its a good fallback
-	. = get_value(object)
+	var/sell_modifier = 1
 
-	var/datum/trade_item/T
+	if(GLOB.using_map.using_new_cargo)
+		if(istype(object, /obj/item/stack/material))	//Materials aren't effected by reduced value/compounded prices. Apply any needed modifiers and sell as-is
+			var/obj/item/stack/material/M = object
+			sell_modifier = GLOB.using_map.new_cargo_inflation * 0.25
+			if(use_reinf_material)
+				return round(round(count * 0.5) * M.reinf_material.sale_price * sell_modifier)
+			return round(count * M.material.sale_price * sell_modifier)
+		
+		else if(GLOB.using_map.trading_faction?.reputation > 50)
+			sell_modifier = (((GLOB.using_map.trading_faction.reputation - 50) / 100) / 2) + 1	//0.5% ~ 25% bonus
+
+	else
+		if(istype(object, /obj/item/stack/material))
+			var/obj/item/stack/material/M = object
+			sell_modifier = M.matter_multiplier
+			if(use_reinf_material)
+				return round(round(count * 0.5) * M.reinf_material.sale_price * sell_modifier)
+			return round(count * M.material.sale_price * sell_modifier)
 
 	//try and find it via the global controller
-	T = SStrade_controller.trade_items_by_type[object.type]
+	var/datum/trade_item/T = SStrade_controller.trade_items_by_type[object.type]
+	var/amount_sold = sold_items[object.type]
+	var/sell_value
+
 	if(T)
-		return T.value
+		if(!T.sellable)
+			return 0
+		sell_value = T.value
+	else
+		sell_value = get_value(object)	//Legacy fallback
+
+	if(amount_sold)
+		sell_value = sell_value*(1 - src.price_modifier)**amount_sold	//A = P(1 + r/n)^nt		--Current price, factoring multiple previous compounded sales
+	return calculate_multiple_sales(sell_value, count, sell_modifier)
+
+/datum/controller/subsystem/supply/proc/calculate_multiple_sales(var/value, var/count, var/sell_modifier = 1)
+	if(!value || !count)
+		return 0
+	var/newPrice = value * sell_modifier
+	var/total_value = newPrice	//Price changes AFTER an obj is sold. Let's skip the first trade then.
+	count--
+	while(count)
+		newPrice = (newPrice * (1-src.price_modifier))	//Calculate what the new price would be with the devalue of selling individually
+		total_value += newPrice
+		count--
+	return round(total_value)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -243,6 +243,7 @@ Helpers
 		bad_modes += mode_to_try
 		return
 
+	callHook("gamemode_selected", list(mode_datum))
 	//Deal with jobs and antags, check that we can actually run the mode.
 	SSjobs.reset_occupations() // Clears all players' role assignments. Clean slate.
 	mode_datum.create_antagonists() // Init operation on the mode; sets up antag datums and such.
@@ -253,6 +254,7 @@ Helpers
 		mode_datum.fail_setup()
 		SSjobs.reset_occupations()
 		bad_modes += mode_datum.config_tag
+		callHook("gamemode_start_failed", list(mode_datum))
 		return
 
 	//Declare victory, make an announcement.

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -35,7 +35,7 @@
 	if(faction_verb)
 		player.current.verbs |= faction_verb
 
-	if(config.objectives_disabled == CONFIG_OBJECTIVE_VERB)
+	if(config.objectives_enabled == CONFIG_OBJECTIVE_VERB)
 		player.current.verbs += /mob/proc/add_objectives
 
 	if(player.current.client)

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -102,7 +102,7 @@
 		to_chat(player.current, "<span class='notice'>[leader_welcome_text]</span>")
 	else
 		to_chat(player.current, "<span class='notice'>[welcome_text]</span>")
-	if (config.objectives_disabled == CONFIG_OBJECTIVE_NONE || !player.objectives.len)
+	if (config.objectives_enabled == CONFIG_OBJECTIVE_NONE || !player.objectives.len)
 		to_chat(player.current, "<span class='notice'>[antag_text]</span>")
 
 	if((flags & ANTAG_HAS_NUKE) && !spawned_nuke)

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -1,12 +1,12 @@
 /datum/antagonist/proc/create_global_objectives(var/override=0)
-	if(config.objectives_disabled != CONFIG_OBJECTIVE_ALL && !override)
+	if(config.objectives_enabled != CONFIG_OBJECTIVE_ALL && !override)
 		return 0
 	if(global_objectives && global_objectives.len)
 		return 0
 	return 1
 
 /datum/antagonist/proc/create_objectives(var/datum/mind/player, var/override=0)
-	if(config.objectives_disabled != CONFIG_OBJECTIVE_ALL && !override)
+	if(config.objectives_enabled != CONFIG_OBJECTIVE_ALL && !override)
 		return 0
 	if(create_global_objectives(override) || global_objectives.len)
 		player.objectives |= global_objectives
@@ -17,7 +17,7 @@
 
 /datum/antagonist/proc/check_victory()
 	var/result = 1
-	if(config.objectives_disabled == CONFIG_OBJECTIVE_NONE)
+	if(config.objectives_enabled == CONFIG_OBJECTIVE_NONE)
 		return 1
 	if(global_objectives && global_objectives.len)
 		for(var/datum/objective/O in global_objectives)

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -144,7 +144,7 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	var/win_msg = ""
 
 	//No objectives, go straight to the feedback.
-	if(config.objectives_disabled == CONFIG_OBJECTIVE_NONE || !global_objectives.len)
+	if(config.objectives_enabled == CONFIG_OBJECTIVE_NONE || !global_objectives.len)
 		return
 
 	var/success = global_objectives.len

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -551,7 +551,7 @@ proc/display_roundstart_logout_report()
 
 	if(!player || !player.current) return
 
-	if(config.objectives_disabled == CONFIG_OBJECTIVE_NONE || !player.objectives.len)
+	if(config.objectives_enabled == CONFIG_OBJECTIVE_NONE || !player.objectives.len)
 		return
 
 	var/obj_count = 1

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -33,7 +33,7 @@ var/list/nuke_disks = list()
 
 /datum/game_mode/nuclear/declare_completion()
 	var/datum/antagonist/merc = GLOB.all_antag_types_[MODE_MERCENARY]
-	if(config.objectives_disabled == CONFIG_OBJECTIVE_NONE || (merc && !merc.global_objectives.len))
+	if(config.objectives_enabled == CONFIG_OBJECTIVE_NONE || (merc && !merc.global_objectives.len))
 		..()
 		return
 	var/disk_rescued = TRUE

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -119,6 +119,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 				to_chat(user, "<span class='info'>Please step onto the holopad.</span>")
 				return
 			if(last_request + 200 < world.time) //don't spam other people with requests either, you jerk!
+				last_request = world.time
 				var/list/holopadlist = list()
 				var/zlevels = GetConnectedZlevels(z)
 				if(GLOB.using_map.use_overmap && map_range >= 0)
@@ -147,7 +148,6 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 				if(targetpad.connected)
 					to_chat(user, "<span class='info'>The pad flashes a busy sign. Maybe you should try again later..</span>")
 					return
-				last_request = world.time
 				make_call(targetpad, conference ? null : user)
 			else
 				to_chat(user, "<span class='notice'>A request for holographic communication was already sent recently.</span>")

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -479,6 +479,8 @@
 	for(var/obj/machinery/door/D in loc)
 		if(!D.density)
 			continue
+		if(istype(D, /obj/machinery/door/blast) && D.density)	//Bots cannot open blast doors but will attempt to anyway.
+			return 1
 		if(istype(D, /obj/machinery/door/window))
 			if(dir & D.dir)
 				return !D.check_access(ID)
@@ -487,7 +489,7 @@
 		else 
 			if(istype(D, /obj/machinery/door/airlock/lift))	//Stop bots committing suicide down the lift shaft, as amusing as it is
 				return !D.check_access(ID) || D.density
-			
+
 			var/obj/machinery/door/airlock/A = D
 			if(istype(A) && (A.locked || A.isAllPowerLoss() || A.welded))	//Avoid airlocks that are bolted, welded, or have no power
 				return 1

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -183,6 +183,12 @@ var/list/ai_verbs_default = list(
 
 	ai_list += src
 	..()
+	if(GLOB.using_map.name == "Nerva")	//A little hacky, but avoids any hard references
+		var/obj/item/device/radio/headset/R = silicon_radio
+		for(var/obj/item/device/encryptionkey/heads/ai_integrated/key in R.encryption_keys)
+			key.channels["Combat"] = 1
+			break
+		R.recalculateChannels()
 	ai_radio = silicon_radio
 	ai_radio.myAi = src
 

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -1,7 +1,7 @@
 var/global/list/empty_playable_ai_cores = list()
 
-/hook/roundstart/proc/spawn_empty_ai()
-	if("AI" in SSticker.mode.disabled_jobs)
+/hook/gamemode_selected/proc/spawn_empty_ai(var/datum/game_mode/mode)
+	if("AI" in mode.disabled_jobs)
 		return 1	// Don't make empty AI's if you can't have them (also applies to Malf)
 	for(var/obj/effect/landmark/start/S in landmarks_list)
 		if(S.name != "AI")
@@ -10,6 +10,12 @@ var/global/list/empty_playable_ai_cores = list()
 			continue
 		empty_playable_ai_cores += new /obj/structure/AIcore/deactivated(get_turf(S))
 
+	return 1
+
+/hook/gamemode_start_failed/proc/despawn_empty_ai(var/datum/game_mode)
+	for(var/obj/structure/AIcore/deactivated/core in empty_playable_ai_cores)
+		empty_playable_ai_cores -= core
+		qdel(core)
 	return 1
 
 /mob/living/silicon/ai/verb/wipe_core()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -738,6 +738,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/reagent_containers/spray/cleaner/drone(src)
 	src.modules += new /obj/item/borg/sight/hud/jani(src)
 	src.modules += new /obj/item/device/plunger/robot(src)
+	src.modules += new /obj/item/device/t_scanner(src)
 
 	robot.internals = new/obj/item/weapon/tank/jetpack/carbondioxide(src)
 	src.modules += robot.internals

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -41,7 +41,16 @@
 
 /mob/new_player/AIize()
 	spawning = 1
-	return ..()
+	if(length(empty_playable_ai_cores))
+		var/obj/structure/AIcore/deactivated/C = empty_playable_ai_cores[1]
+		empty_playable_ai_cores -= C
+		var/mob/living/silicon/ai/A = ..(0)
+		A.forceMove(C.loc)
+		A.on_mob_init()
+		qdel(C)
+		return A
+	else
+		return ..()	//Fallback AIize, spawning a new AI at any AI landmark. This is only used by gamemode antag AI's which don't spawn & check for inactive cores (ie, malf)
 
 /mob/living/carbon/human/AIize(move=1) // 'move' argument needs defining here too because BYOND is dumb
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -99,8 +99,8 @@
 	return bling
 
 /obj/item/weapon/gun/launcher/money/attack_self(mob/user as mob)
-	dispensing = min(input(user, "How many thaler do you want to dispense at a time? (0 to [min(src.receptacle_value,100000)]", "Money Cannon Settings", 20) as num, Clamp(0, receptacle_value, 100000))
-
+	dispensing = input(user, "How many thaler do you want to dispense at a time? (1 to [min(src.receptacle_value,100000)]", "Money Cannon Settings", 20) as num
+	dispensing = Clamp(dispensing, 1, min(src.receptacle_value,100000))
 	to_chat(user, "<span class='notice'>You set [src] to dispense [dispensing] thaler at a time.</span>")
 
 /obj/item/weapon/gun/launcher/money/attack_hand(mob/user as mob)

--- a/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/shipweapons.dm
@@ -215,7 +215,7 @@
 						HitComponents(OM)
 						MapFire()
 
-					homeship.autoannounce("<b>The [src.name] has hit the [OM.ship_category].</b>", "private")
+					homeship.autoannounce("<b>The [src.name] has hit the [OM.ship_category].</b>", "combat")
 
 			if(OM.health <= (OM.maxHealth * 0.5))
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -36,6 +36,9 @@ LOG_SAY
 ## log admin actions
 LOG_ADMIN
 
+## Log adminchat messages
+#LOG_ADMINCHAT
+
 ## log client access (logon/logoff)
 LOG_ACCESS
 
@@ -60,6 +63,9 @@ LOG_PDA
 ## log world.log messages
 # LOG_WORLD_OUTPUT
 
+## log debug output
+LOG_DEBUG
+
 ## log all Topic() calls (for use by coders in tracking down Topic issues)
 # LOG_HREFS
 
@@ -68,6 +74,18 @@ LOG_PDA
 
 ## log admin warning messages
 ##LOG_ADMINWARN  ## Also duplicates a bunch of other messages.
+
+## The "cooldown" time for each occurrence of a unique error
+ERROR_COOLDOWN 600
+
+## How many occurrences before the next will silence them
+ERROR_LIMIT 50
+
+## How long a unique error will be silenced for
+ERROR_SILENCE_TIME 6000
+
+## How long to wait between messaging admins about occurrences of a unique error
+ERROR_MSG_DELAY 50
 
 ## sql switching
 # SQL_ENABLED
@@ -123,8 +141,8 @@ ALLOW_RANDOM_EVENTS
 ## if amount of traitors scales or not
 TRAITOR_SCALING
 
-## if objectives are disabled
-#OBJECTIVES_DISABLED
+## What objectives are enabled. Set to 'none' for no objectives, 'verb' to allow antags to get objectives using the Get Objectives verb, 'all' to assign global objectives
+OBJECTIVES_ENABLED verb
 
 ## make ERT's be only called by admins
 
@@ -141,6 +159,15 @@ USE_CORTICAL_STACKS
 
 ## Comment this out to stop admins being able to choose their personal ooccolor
 ALLOW_ADMIN_OOCCOLOR
+
+## Uncomment to allow admin jumping
+ALLOW_ADMIN_JUMP
+
+## Uncomment to allow admin revives
+ALLOW_ADMIN_REV
+
+## Uncomment to allow admin item spawning
+ALLOW_ADMIN_SPAWNING
 
 ## If metadata is supported
 # ALLOW_METADATA
@@ -194,15 +221,14 @@ ALLOW_AI
 ## set a hosted by name for unix platforms
 HOSTEDBY UristMcStation
 
-## Set to jobban "Guest-" accounts from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
-## Set to 1 to jobban them from those positions, set to 0 to allow them.
+## Uncomment to jobban "Guest-" accounts from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
 GUEST_JOBBAN
 
 ## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)
 GUEST_BAN
 
 ## Set to jobban everyone who's key is not listed in data/whitelist.txt from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
-## Uncomment to 1 to jobban, leave commented out to allow these positions for everyone (but see GUEST_JOBBAN above and regular jobbans)
+## Uncomment to jobban, leave commented out to allow these positions for everyone (but see GUEST_JOBBAN above and regular jobbans)
 # USEWHITELIST
 
 ## set a server location for world reboot. Don't include the byond://, just give the address and port.
@@ -212,17 +238,38 @@ GUEST_BAN
 ## Unlike SERVER, this one shouldn't break auto-reconnect
 #SERVERURL server.net:port
 
+## Uncomment to generate a numeric suffix based on server port
+#SERVERSUFFIX
+
+## Clients require this minimum byond version to join
+#MINIMUM_BYOND_VERSION
+
+## Clients require this minimum byond build to join
+#MINIMUM_BYOND_BUILD
+
+## Clients with these byond versions will be forbidden from joining. Format: byond_version.byond_build . Separate with ; , e.g. 512.1234;512.1235
+#FORBIDDEN_VERSIONS
+
+## Uncomment to delist the server from the hub when no admins are present
+#DELIST_WHEN_NO_ADMINS
+
 ## forum address
-FORUMURL "https://discord.gg/0oRsdvoS1DDd5Rv0"
+FORUMURL https://discord.gg/0oRsdvoS1DDd5Rv0
 
 ## Wiki address
-WIKIURL "https://bay.ss13.me/en/Guides"
+WIKIURL https://bay.ss13.me/en/Guides
 
 ## GitHub address
 GITHUBURL https://github.com/UristMcStation/UristMcStation
 
+## GitHub new issue link
+ISSUEREPORTURL https://github.com/UristMcStation/UristMcStation/issues/new
+
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 #BANAPPEALS http://uristmcstation.com/forum/viewforum.php?f=10
+
+## Max number of players allowed. 0 for unlimited
+#PLAYER_LIMIT 0
 
 ## In-game features
 ## spawns a spellbook which gives object-type spells instead of verb-type spells for the wizard
@@ -246,6 +293,9 @@ ALLOW_BNEWS
 
 ##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
 TICKLAG 0.7
+
+## Set SSinitialization tick limit (default: 98)
+#TICK_LIMIT_MC_INIT 98
 
 ##Defines world FPS. Defaults to 20.
 # FPS 20
@@ -279,6 +329,9 @@ GATEWAY_DELAY 18000
 
 ##Remove the # to let ghosts spin chairs
 #GHOST_INTERACTION
+
+## Allow ghosts to possess certain animals
+#GHOSTS_CAN_POSSESS_ANIMALS
 
 ## Password used for authorizing ircbot and other external tools.
 #COMMS_PASSWORD
@@ -352,11 +405,14 @@ ALIENS_ALLOWED
 ## Uncomment to allow alien xenomorph queens to lay eggs.
 ALIEN_EGGS_ALLOWED
 
-## Uncomment to allow xenos to spawn.
+## Uncomment to allow ninjas to random antag spawn.
 #NINJAS_ALLOWED
 
 ## Uncomment to disable the restrictive weldervision overlay.
 #DISABLE_WELDER_VISION
+
+## Uncomment to disable IC printing from scripts
+#DISABLE_CIRCUIT_PRINTING
 
 ## Uncomment to prevent anyone from joining the round by default.
 #DISABLE_ENTRY
@@ -401,9 +457,6 @@ GENERATE_ASTEROID
 ## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
 #AGGRESSIVE_CHANGELOG
 
-## Uncomment to enable organ decay outside of a body or storage item.
-ORGANS_CAN_DECAY
-
 ## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
 #AGGRESSIVE_CHANGELOG
 
@@ -446,3 +499,24 @@ RADIATION_MATERIAL_RESISTANCE_DIVISOR 2
 
 ## Below this point, radiation is ignored
 RADIATION_LOWER_LIMIT 0.35
+
+## Uncomment to remove cooldowns between clicks
+#NO_CLICK_COOLDOWN
+
+## Uncomment to force human mobs to have a surname: A space must be present in their name
+#HUMANS_NEED_SURNAMES
+
+## Uncomment to disable ghosts from becoming mice
+#DISABLE_PLAYER_MICE
+
+## Uncomment to prevent newly-spawned mice from understanding human speech
+#UNEDUCATED_MICE
+
+## Uncomment to allow players to control drones
+ALLOW_DRONE_SPAWN
+
+## How many ticks until a new drone is available. Default is 2 minutes
+#DRONE_BUILD_TIME 1200
+
+## Max amount of maintenance drones that can spawn. Default is 5
+#MAX_MAINT_DRONES 5

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -25,6 +25,12 @@ ORGAN_HEALTH_MULTIPLIER 100
 ## 100 means normal, 50 means half
 ORGAN_REGENERATION_MULTIPLIER 75
 
+## multiplier which effects how much organ damage spillover is added to mob shock_stage (default 0.5)
+#ORGAN_DAMAGE_SPILLOVER_MULTIPLIER 0.5
+
+## Uncomment to make organs decay if they're not inside a freezer
+ORGANS_CAN_DECAY
+
 ### REVIVAL ###
 
 ## whether pod plants work or not
@@ -57,3 +63,13 @@ MONKEY_DELAY 0
 ALIEN_DELAY 0
 METROID_DELAY 0
 ANIMAL_DELAY 0
+SLIME_DELAY 0
+
+
+### MISC ###
+
+## Max amount of mushrooms where spores will no longer spread (Default 15)
+#MAXIMUM_MUSHROOMS 15
+
+## Uncomment to allow loyalty implants
+#USE_LOYALTY_IMPLANTS

--- a/maps/nerva/nerva_overmap.dm
+++ b/maps/nerva/nerva_overmap.dm
@@ -10,7 +10,7 @@
 	can_board = TRUE
 	target_x_bounds = list(78,165)
 	target_y_bounds = list(63,130)
-	announcement_channel = list("public" = "Common", "private" = "Command", "technical" = "Engineering")
+	announcement_channel = list("public" = "Common", "private" = "Command", "technical" = "Engineering", "combat" = "Combat")
 	evac_x = 143
 	evac_y = 97
 	evac_z = 3


### PR DESCRIPTION
Several bundled bugfixes:

- Fixed a edge case where someone double clicks on a holopad and starts a call, sending 2 requests at the same time and confusing the system. Call cooldown check has been moved further up
- Fixed bot pathfinding to avoid closed blastdoors. Bots try to open all doors with bump, but blastdoors cannot be opened by normal means. They will now check for and avoid closed ones
- Fixed selling items on the NanoTrasen Station shuttle (Closes #1068). Compiles a list and bundles all common items together, then calculates the value of multiple sales taking into account a drop of value caused by selling an individual item. Currently it's set to drop the price by 4% on each sale, this compounds! Can be changed by setting `price_modifier`. Materials currently aren't effected by price drops because they're basically worthless as-is and if they weren't, it'd simply encourage mining to actually become a thing /shrug
- Fixed an issue where readying as AI at roundstart always sent you back to the lobby unless you got selected for antag. This was a really strange one, and a bit of a chicken vs egg situation. This was caused by AI slots being limited by the amount of inactive AI cores present. AI cores would spawn on the roundstart hook depending if the gamemode allowed AIs or not. The issue is, this hook is too late as it is called _after_ jobs have been given out by the jobs subcontroller. However, the previous hook is too early as the gamemode hasn't been set in `SSticker` so it cannot check if AI's are allowed. The solution was to add 2 new hooks: `hook/gamemode_selected` and `hook/gamemode_start_failed`, both of which are passed a `/datum/game_mode` parameter. The `gamemode_selected` hook is called in `SSticker` once a gamemode has been selected via votes, but _before_ any jobs/roles have been assigned. This allows a core to spawn if the mode allows it, and for the job limit for AIs to be properly taken into account. `gamemode_start_failed` is called if the gamemode then fails to start for whatever reason (not enough players, no antags etc). This is currently used to despawn the AI cores to allow for the next gamemode presented to handle spawning again.
- Fixed roundstart AI spawn logic. On fixing the roundstart AI problem, another bug presented itself; roundstart AIs were spawning ontop of inactive AI cores. This was caused by the way `new_player` handled `AIize()`. It used the old method of spawning a new AI mob at the AI landmark, rather than using an inactive core. New logic has been added to use the inactive core first, and if none are available, use the old method as a fallback. As this is called after roles have been handed out, the only situation this will happen is on gamemodes where the AI core wasn't allowed to spawn, but there is an antag role to override the available core check (such as Malf AI)
- Fixed money cannon 0Th infinite round exploit. Previously, you could set the cannon to fire rounds of 0Th and just... spam the  map. Now it requires a minimum of 1
- Fixed combat channel. Somehow during the staging of my last PR to add the combat channel, I missed these changes. Whoops. Actually adds the combat channel to the overmap ship and corrects a missing call to it. Also (a bit jankily) adds the combat frequency to the AI integrated headset so that they are able to access it. It is jank, but this was the best way I could think of without having any hard references for paths that are Nerva only subtypes and thus not guaranteed to be included.
- Added T-scanner to drones. Because it is a pain pulling up every single tile to try and find a broken cable.
- Fixed the wiki and discord buttons from giving scuffed URLs
- Added a _bunch_ of missing config options + corrected default logic. While doing this PR, I noticed several config options were completely missing from `config.txt` and `game_options.txt`. These have been added in and commented/uncommented to match our current settings. Several options were also unchangeable via `config.txt`. This was caused by the variable being initialised as 1, with the config option setting the var to 1 if it was uncommented-- no way to set it to 0. These options have been set to init to 0, and have been uncommented to set to 1 where they were previously by happenstance. The only option that will change from all of this is `ORGANS_CAN_DECAY`. This was set to true, however was placed in `config.txt`, but this option is only read in `game_options.txt` where it has now been moved.
- Config `OBJECTIVES_DISABLED` option & variable renamed to `OBJECTIVES_ENABLED`. Because.. that's actually what it does... Determines which objectives types are enabled, not disabled

As usual, give me a good yelling if I've done anything stupid or anything needs changing (namely that AI radio). Always happy to switch things over!