### PR TITLE
A Whole Batch of QoL changes

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -109,6 +109,8 @@
 
 #define CanInteract(user, state) (CanUseTopic(user, state) == STATUS_INTERACTIVE)
 
+#define CanDefaultInteract(user) (CanUseTopic(user, DefaultTopicState()) == STATUS_INTERACTIVE)
+
 #define CanInteractWith(user, target, state) (target.CanUseTopic(user, state) == STATUS_INTERACTIVE)
 
 #define CanPhysicallyInteract(user) CanInteract(user, GLOB.physical_state)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -257,6 +257,12 @@
 		O.dropInto(loc)
 	toggle_filter()
 
+/obj/machinery/sleeper/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		go_out()
+	else
+		..()
+
 /obj/machinery/sleeper/proc/set_occupant(var/mob/living/carbon/occupant)
 	src.occupant = occupant
 	update_icon()

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -35,6 +35,12 @@
 	src.go_out()
 	add_fingerprint(usr)
 
+/obj/machinery/bodyscanner/AltClick(mob/user)
+	if(CanPhysicallyInteract(user))
+		eject()
+	else
+		..()
+
 /obj/machinery/bodyscanner/verb/move_inside()
 	set src in oview(1)
 	set category = "Object"

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -295,6 +295,17 @@
 	SetName(initial(name))
 	return
 
+/obj/machinery/atmospherics/unary/cryo_cell/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		go_out()
+	else
+		..()
+
+/obj/machinery/atmospherics/unary/cryo_cell/CtrlClick(mob/user)
+	if(CanDefaultInteract(user))
+		on = !on
+		update_icon()
+
 /obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/carbon/M as mob)
 	if (stat & (NOPOWER|BROKEN))
 		to_chat(usr, "<span class='warning'>The cryo cell is not functioning.</span>")

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -27,103 +27,108 @@
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = DEFAULT_BOX_STORAGE
 
-	examine(mob/user)
-		if(..(user, 1))
-			to_chat(user, text("The service panel is [src.open ? "open" : "closed"]."))
-
-	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		if(locked)
-			if (istype(W, /obj/item/weapon/melee/energy/blade) && emag_act(INFINITY, user, "You slice through the lock of \the [src]"))
-				var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-				spark_system.set_up(5, 0, src.loc)
-				spark_system.start()
-				playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
-				playsound(src.loc, "sparks", 50, 1)
-				return
-
-			if(isScrewdriver(W))
-				if (do_after(user, 20, src))
-					src.open =! src.open
-					user.show_message(text("<span class='notice'>You [] the service panel.</span>", (src.open ? "open" : "close")))
-				return
-			if(isMultitool(W) && (src.open == 1)&& (!src.l_hacking))
-				user.show_message("<span class='notice'>Now attempting to reset internal memory, please hold.</span>", 1)
-				src.l_hacking = 1
-				if (do_after(usr, 100, src))
-					if (prob(40))
-						src.l_setshort = 1
-						src.l_set = 0
-						user.show_message("<span class='notice'>Internal memory reset. Please give it a few seconds to reinitialize.</span>", 1)
-						sleep(80)
-						src.l_setshort = 0
-						src.l_hacking = 0
-					else
-						user.show_message("<span class='warning'>Unable to reset internal memory.</span>", 1)
-						src.l_hacking = 0
-				else	src.l_hacking = 0
-				return
-			//At this point you have exhausted all the special things to do when locked
-			// ... but it's still locked.
-			return
-
-		// -> storage/attackby() what with handle insertion, etc
-		..()
-
-
-	MouseDrop(over_object, src_location, over_location)
-		if (locked)
-			src.add_fingerprint(usr)
-			return
-		..()
-
-
-	attack_self(mob/user as mob)
-		user.set_machine(src)
-		var/dat = text("<TT><B>[]</B><BR>\n\nLock Status: []",src, (src.locked ? "LOCKED" : "UNLOCKED"))
-		var/message = "Code"
-		if ((src.l_set == 0) && (!src.emagged) && (!src.l_setshort))
-			dat += text("<p>\n<b>5-DIGIT PASSCODE NOT SET.<br>ENTER NEW PASSCODE.</b>")
-		if (src.emagged)
-			dat += text("<p>\n<font color=red><b>LOCKING SYSTEM ERROR - 1701</b></font>")
-		if (src.l_setshort)
-			dat += text("<p>\n<font color=red><b>ALERT: MEMORY SYSTEM ERROR - 6040 201</b></font>")
-		message = text("[]", src.code)
-		if (!src.locked)
-			message = "*****"
-		dat += text("<HR>\n>[]<BR>\n<A href='?src=\ref[];type=1'>1</A>-<A href='?src=\ref[];type=2'>2</A>-<A href='?src=\ref[];type=3'>3</A><BR>\n<A href='?src=\ref[];type=4'>4</A>-<A href='?src=\ref[];type=5'>5</A>-<A href='?src=\ref[];type=6'>6</A><BR>\n<A href='?src=\ref[];type=7'>7</A>-<A href='?src=\ref[];type=8'>8</A>-<A href='?src=\ref[];type=9'>9</A><BR>\n<A href='?src=\ref[];type=R'>R</A>-<A href='?src=\ref[];type=0'>0</A>-<A href='?src=\ref[];type=E'>E</A><BR>\n</TT>", message, src, src, src, src, src, src, src, src, src, src, src, src)
-		user << browse(dat, "window=caselock;size=300x280")
-
-	Topic(href, href_list)
-		..()
-		if ((usr.stat || usr.restrained()) || (get_dist(src, usr) > 1))
-			return
-		if (href_list["type"])
-			if (href_list["type"] == "E")
-				if ((src.l_set == 0) && (length(src.code) == 5) && (!src.l_setshort) && (src.code != "ERROR"))
-					src.l_code = src.code
-					src.l_set = 1
-				else if ((src.code == src.l_code) && (src.emagged == 0) && (src.l_set == 1))
-					src.locked = 0
-					overlays.Cut()
-					overlays += image('icons/obj/storage.dmi', icon_opened)
-					src.code = null
-				else
-					src.code = "ERROR"
-			else
-				if ((href_list["type"] == "R") && (src.emagged == 0) && (!src.l_setshort))
-					src.locked = 1
-					overlays.Cut()
-					src.code = null
-					src.close(usr)
-				else
-					src.code += text("[]", href_list["type"])
-					if (length(src.code) > 5)
-						src.code = "ERROR"
-			for(var/mob/M in viewers(1, src.loc))
-				if ((M.client && M.machine == src))
-					src.attack_self(M)
-				return
+/obj/item/weapon/storage/secure/AltClick(/mob/user)
+	if (locked)
 		return
+	..()
+
+/obj/item/weapon/storage/secure/examine(mob/user)
+	if(..(user, 1))
+		to_chat(user, text("The service panel is [src.open ? "open" : "closed"]."))
+
+/obj/item/weapon/storage/secure/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(locked)
+		if (istype(W, /obj/item/weapon/melee/energy/blade) && emag_act(INFINITY, user, "You slice through the lock of \the [src]"))
+			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
+			spark_system.set_up(5, 0, src.loc)
+			spark_system.start()
+			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
+			playsound(src.loc, "sparks", 50, 1)
+			return
+
+		if(isScrewdriver(W))
+			if (do_after(user, 20, src))
+				src.open =! src.open
+				user.show_message(text("<span class='notice'>You [] the service panel.</span>", (src.open ? "open" : "close")))
+			return
+		if(isMultitool(W) && (src.open == 1)&& (!src.l_hacking))
+			user.show_message("<span class='notice'>Now attempting to reset internal memory, please hold.</span>", 1)
+			src.l_hacking = 1
+			if (do_after(usr, 100, src))
+				if (prob(40))
+					src.l_setshort = 1
+					src.l_set = 0
+					user.show_message("<span class='notice'>Internal memory reset. Please give it a few seconds to reinitialize.</span>", 1)
+					sleep(80)
+					src.l_setshort = 0
+					src.l_hacking = 0
+				else
+					user.show_message("<span class='warning'>Unable to reset internal memory.</span>", 1)
+					src.l_hacking = 0
+			else	src.l_hacking = 0
+			return
+		//At this point you have exhausted all the special things to do when locked
+		// ... but it's still locked.
+		return
+
+	// -> storage/attackby() what with handle insertion, etc
+	..()
+
+
+/obj/item/weapon/storage/secure/MouseDrop(over_object, src_location, over_location)
+	if (locked)
+		src.add_fingerprint(usr)
+		return
+	..()
+
+
+/obj/item/weapon/storage/secure/attack_self(mob/user as mob)
+	user.set_machine(src)
+	var/dat = text("<TT><B>[]</B><BR>\n\nLock Status: []",src, (src.locked ? "LOCKED" : "UNLOCKED"))
+	var/message = "Code"
+	if ((src.l_set == 0) && (!src.emagged) && (!src.l_setshort))
+		dat += text("<p>\n<b>5-DIGIT PASSCODE NOT SET.<br>ENTER NEW PASSCODE.</b>")
+	if (src.emagged)
+		dat += text("<p>\n<font color=red><b>LOCKING SYSTEM ERROR - 1701</b></font>")
+	if (src.l_setshort)
+		dat += text("<p>\n<font color=red><b>ALERT: MEMORY SYSTEM ERROR - 6040 201</b></font>")
+	message = text("[]", src.code)
+	if (!src.locked)
+		message = "*****"
+	dat += text("<HR>\n>[]<BR>\n<A href='?src=\ref[];type=1'>1</A>-<A href='?src=\ref[];type=2'>2</A>-<A href='?src=\ref[];type=3'>3</A><BR>\n<A href='?src=\ref[];type=4'>4</A>-<A href='?src=\ref[];type=5'>5</A>-<A href='?src=\ref[];type=6'>6</A><BR>\n<A href='?src=\ref[];type=7'>7</A>-<A href='?src=\ref[];type=8'>8</A>-<A href='?src=\ref[];type=9'>9</A><BR>\n<A href='?src=\ref[];type=R'>R</A>-<A href='?src=\ref[];type=0'>0</A>-<A href='?src=\ref[];type=E'>E</A><BR>\n</TT>", message, src, src, src, src, src, src, src, src, src, src, src, src)
+	user << browse(dat, "window=caselock;size=300x280")
+
+/obj/item/weapon/storage/secure/Topic(href, href_list)
+	..()
+	if ((usr.stat || usr.restrained()) || (get_dist(src, usr) > 1))
+		return
+	if (href_list["type"])
+		if (href_list["type"] == "E")
+			if ((src.l_set == 0) && (length(src.code) == 5) && (!src.l_setshort) && (src.code != "ERROR"))
+				src.l_code = src.code
+				src.l_set = 1
+			else if ((src.code == src.l_code) && (src.emagged == 0) && (src.l_set == 1))
+				src.locked = 0
+				overlays.Cut()
+				overlays += image('icons/obj/storage.dmi', icon_opened)
+				src.code = null
+			else
+				src.code = "ERROR"
+		else
+			if ((href_list["type"] == "R") && (src.emagged == 0) && (!src.l_setshort))
+				src.locked = 1
+				overlays.Cut()
+				src.code = null
+				src.close(usr)
+			else
+				src.code += text("[]", href_list["type"])
+				if (length(src.code) > 5)
+					src.code = "ERROR"
+		for(var/mob/M in viewers(1, src.loc))
+			if ((M.client && M.machine == src))
+				src.attack_self(M)
+			return
+	return
 
 /obj/item/weapon/storage/secure/emag_act(var/remaining_charges, var/mob/user, var/feedback)
 	if(!emagged)
@@ -288,7 +293,7 @@
 		secure = TRUE
 		overlays.Cut()
 		playsound(src,'sound/effects/metal_close.ogg',25,0)
-		visible_message("<span class='notice'>\The [src] clicks as its automatic locks engage.</span>")	
+		visible_message("<span class='notice'>\The [src] clicks as its automatic locks engage.</span>")
 	else
 		next_reminder = 60
 		START_PROCESSING(SSobj, src)
@@ -301,7 +306,7 @@
 			STOP_PROCESSING(SSobj, src)
 			overlays.Cut()
 			playsound(src,'sound/effects/metal_close.ogg',25,0)
-			visible_message("<span class='notice'>\The [src] clicks as its automatic locks engage.</span>")	
+			visible_message("<span class='notice'>\The [src] clicks as its automatic locks engage.</span>")
 		else
 			if(next_reminder)
 				next_reminder = max(next_reminder - (wait /10),0)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -39,6 +39,7 @@
 
 	if ((ishuman(usr) || isrobot(usr) || issmall(usr)) && !usr.incapacitated())
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
+			src.add_fingerprint(usr)
 			src.open(usr)
 			return TRUE
 
@@ -57,6 +58,14 @@
 				if(BP_L_HAND)
 					usr.put_in_l_hand(src)
 
+/obj/item/weapon/storage/AltClick(var/mob/usr)
+	if(!canremove)
+		return
+
+	if ((ishuman(usr) || isrobot(usr) || issmall(usr)) && !usr.incapacitated() && Adjacent(usr))
+		src.add_fingerprint(usr)
+		src.open(usr)
+		return TRUE
 
 /obj/item/weapon/storage/proc/return_inv()
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -246,9 +246,14 @@
 	else
 		to_chat(src, "<span class='notice'>You need to disable a module first!</span>")
 
-/mob/living/silicon/robot/put_in_hands(var/obj/item/W) // No hands.
-	W.forceMove(get_turf(src))
-	return 1
+/mob/living/silicon/put_in_hands(var/obj/item/W) // No hands.
+	if(W.loc)
+		W.dropInto(W.loc)
+
+	else if(loc)
+		W.dropInto(loc)
+
+	return FALSE
 
 //Robots don't use inventory slots, so we need to override this.
 /mob/living/silicon/robot/canUnEquip(obj/item/I)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -25,9 +25,10 @@
 	var/max_pill_count = 20
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags = OBJ_FLAG_ANCHORABLE
+	var/reagent_limit = 120
 
 /obj/machinery/chem_master/New()
-	create_reagents(120)
+	create_reagents(reagent_limit)
 	..()
 
 /obj/machinery/chem_master/ex_act(severity)
@@ -67,17 +68,38 @@
 	else
 		. = ..()
 
+/obj/machinery/chem_master/proc/get_remaining_volume()
+	return Clamp(reagent_limit - reagents.total_volume, 0, reagent_limit)
+
+/obj/machinery/chem_master/proc/eject_beaker(mob/user)
+	if(!beaker)
+		return
+
+	var/obj/item/weapon/reagent_containers/B = beaker
+	user.put_in_hands(B)
+	beaker = null
+	reagents.clear_reagents()
+	icon_state = "mixer0"
+
+/obj/machinery/chem_master/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		eject_beaker(user)
+
+	else
+		..()
+
 /obj/machinery/chem_master/Topic(href, href_list, state)
 	if(..())
 		return 1
+	var/mob/user = usr
 
 	if (href_list["ejectp"])
 		if(loaded_pill_bottle)
 			loaded_pill_bottle.dropInto(loc)
 			loaded_pill_bottle = null
 	else if(href_list["close"])
-		show_browser(usr, null, "window=chem_master")
-		usr.unset_machine()
+		show_browser(user, null, "window=chem_master")
+		user.unset_machine()
 		return
 
 	if(beaker)
@@ -99,14 +121,14 @@
 					dat += "<TITLE>Chemmaster 3000</TITLE>Chemical infos:<BR><BR>Name:<BR>[href_list["name"]]<BR><BR>Description:<BR>[href_list["desc"]]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
 			else
 				dat += "<TITLE>Condimaster 3000</TITLE>Condiment infos:<BR><BR>Name:<BR>[href_list["name"]]<BR><BR>Description:<BR>[href_list["desc"]]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
-			usr << browse(dat, "window=chem_master;size=575x400")
+			user << browse(dat, "window=chem_master;size=575x400")
 			return
 
 		else if (href_list["add"])
 			if(href_list["amount"])
 				var/datum/reagent/their_reagent = locate(href_list["add"]) in R.reagent_list
 				if(their_reagent)
-					var/amount = Clamp((text2num(href_list["amount"])), 0, 200)
+					var/amount = Clamp((text2num(href_list["amount"])), 0, get_remaining_volume())
 					R.trans_type_to(src, their_reagent.type, amount)
 
 		else if (href_list["addcustom"])
@@ -140,14 +162,13 @@
 			mode = !mode
 
 		else if (href_list["main"])
-			attack_hand(usr)
+			attack_hand(user)
 			return
+
 		else if (href_list["eject"])
 			if(beaker)
-				beaker:loc = src.loc
-				beaker = null
-				reagents.clear_reagents()
-				icon_state = "mixer0"
+				eject_beaker(user)
+
 		else if (href_list["createpill"] || href_list["createpill_multiple"])
 			var/count = 1
 
@@ -164,7 +185,7 @@
 			var/amount_per_pill = reagents.total_volume/count
 			if (amount_per_pill > 60) amount_per_pill = 60
 
-			var/name = sanitizeSafe(input(usr,"Name:","Name your pill!","[reagents.get_master_reagent_name()] ([amount_per_pill]u)"), MAX_NAME_LEN)
+			var/name = sanitizeSafe(input(user,"Name:","Name your pill!","[reagents.get_master_reagent_name()] ([amount_per_pill]u)"), MAX_NAME_LEN)
 
 			if(reagents.total_volume/count < 1) //Sanity checking.
 				return
@@ -182,7 +203,7 @@
 
 		else if (href_list["createbottle"])
 			if(!condi)
-				var/name = sanitizeSafe(input(usr,"Name:","Name your bottle!",reagents.get_master_reagent_name()), MAX_NAME_LEN)
+				var/name = sanitizeSafe(input(user,"Name:","Name your bottle!",reagents.get_master_reagent_name()), MAX_NAME_LEN)
 				var/obj/item/weapon/reagent_containers/glass/bottle/P = new/obj/item/weapon/reagent_containers/glass/bottle(src.loc)
 				if(!name) name = reagents.get_master_reagent_name()
 				P.SetName("[name] bottle")
@@ -198,14 +219,14 @@
 			for(var/i = 1 to MAX_PILL_SPRITE)
 				dat += "<tr><td><a href=\"?src=\ref[src]&pill_sprite=[i]\"><img src=\"pill[i].png\" /></a></td></tr>"
 			dat += "</table>"
-			usr << browse(dat, "window=chem_master")
+			user << browse(dat, "window=chem_master")
 			return
 		else if(href_list["change_bottle"])
 			var/dat = "<table>"
 			for(var/sprite in BOTTLE_SPRITES)
 				dat += "<tr><td><a href=\"?src=\ref[src]&bottle_sprite=[sprite]\"><img src=\"[sprite].png\" /></a></td></tr>"
 			dat += "</table>"
-			usr << browse(dat, "window=chem_master")
+			user << browse(dat, "window=chem_master")
 			return
 		else if(href_list["pill_sprite"])
 			pillsprite = href_list["pill_sprite"]
@@ -409,7 +430,7 @@
 	var/is_beaker_ready = 0
 	var/processing_chamber = ""
 	var/beaker_contents = ""
-	var/dat = ""
+	var/dat = list()
 
 	if(!inuse)
 		for (var/obj/item/O in holdingitems)
@@ -431,7 +452,7 @@
 				beaker_contents += "Nothing<br>"
 
 
-		dat = {"
+		dat += {"
 	<b>Processing chamber contains:</b><br>
 	[processing_chamber]<br>
 	[beaker_contents]<hr>
@@ -444,27 +465,28 @@
 			dat += "<A href='?src=\ref[src];action=detach'>Detach the beaker</a><BR>"
 	else
 		dat += "Please wait..."
-	user << browse("<HEAD><TITLE>All-In-One Grinder</TITLE></HEAD><TT>[dat]</TT>", "window=reagentgrinder")
+	dat = "<HEAD><TITLE>[name]</TITLE></HEAD><TT>[JOINTEXT(dat)]</TT>"
+	show_browser(user, strip_improper(dat), "window=reagentgrinder")
 	onclose(user, "reagentgrinder")
 	return
-
 
 /obj/machinery/reagentgrinder/OnTopic(user, href_list)
 	if(href_list["action"])
 		switch(href_list["action"])
-			if ("grind")
-				grind()
+			if("grind")
+				grind(user)
 			if("eject")
 				eject()
-			if ("detach")
-				detach()
+			if("detach")
+				detach(user)
 		interact(user)
 		return TOPIC_REFRESH
 
-/obj/machinery/reagentgrinder/proc/detach()
-	if (!beaker)
+/obj/machinery/reagentgrinder/proc/detach(mob/user)
+	if(!beaker)
 		return
-	beaker.dropInto(loc)
+	var/obj/item/weapon/reagent_containers/B = beaker
+	user.put_in_hands(B)
 	beaker = null
 	update_icon()
 
@@ -529,3 +551,21 @@
 				qdel(O)
 			if (beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 				break
+
+/obj/machinery/reagentgrinder/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		detach(user)
+	else
+		..()
+
+/obj/machinery/reagentgrinder/CtrlClick(mob/user)
+	if(CanDefaultInteract(user))
+		grind(user)
+	else
+		..()
+
+/obj/machinery/reagentgrinder/CtrlAltClick(mob/user)
+	if(CanDefaultInteract(user))
+		eject(user)
+	else
+		..()

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -106,6 +106,15 @@
 		..()
 	return
 
+/obj/machinery/chemical_dispenser/proc/eject_beaker(mob/user)
+	if(!container)
+		return
+
+	var/obj/item/weapon/reagent_containers/B = container
+	user.put_in_hands(B)
+	container = null
+	update_icon()
+
 /obj/machinery/chemical_dispenser/ui_interact(mob/user, ui_key = "main",var/datum/nanoui/ui = null, var/force_open = 1)
 	// this is the data which will be sent to the ui
 	var/data[0]
@@ -154,13 +163,14 @@
 		return TOPIC_HANDLED
 
 	else if(href_list["ejectBeaker"])
-		if(container)
-			var/obj/item/weapon/reagent_containers/B = container
-			B.dropInto(loc)
-			container = null
-			update_icon()
-			return TOPIC_REFRESH
-		return TOPIC_HANDLED
+		eject_beaker(user)
+		return TOPIC_REFRESH
+
+/obj/machinery/chemical_dispenser/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		eject_beaker(user)
+	else
+		..()
 
 /obj/machinery/chemical_dispenser/attack_ai(mob/user as mob)
 	ui_interact(user)

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -75,6 +75,20 @@
 			update_use_power(POWER_USE_IDLE)
 			queue_icon_update()
 
+/obj/machinery/reagent_temperature/proc/eject_beaker(mob/user)
+	if(!container)
+		return
+	var/obj/item/weapon/reagent_containers/B = container
+	user.put_in_hands(B)
+	container = null
+	update_icon()
+
+/obj/machinery/reagent_temperature/AltClick(mob/user)
+	if(CanDefaultInteract(user))
+		eject_beaker(user)
+	else
+		..()
+
 /obj/machinery/reagent_temperature/attack_hand(var/mob/user)
 	interact(user)
 
@@ -184,7 +198,7 @@
 	popup.open()
 
 /obj/machinery/reagent_temperature/CanUseTopic(var/mob/user, var/state, var/href_list)
-	if(href_list["remove_container"])
+	if(href_list && href_list["remove_container"])
 		. = ..(user, GLOB.physical_state, href_list)
 		if(. == STATUS_CLOSE)
 			to_chat(user, SPAN_WARNING("You are too far away."))
@@ -214,11 +228,7 @@
 			to_chat(user, SPAN_WARNING("The button clicks, but nothing happens."))
 
 	if(href_list["remove_container"])
-		if(container)
-			container.dropInto(loc)
-			user.put_in_hands(container)
-			container = null
-			update_icon()
+		eject_beaker(user)
 		. = TOPIC_REFRESH
 
 	if(. == TOPIC_REFRESH)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -31,7 +31,7 @@ exactly 18 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
 exactly 79 "world<< uses" 'world<<|world[[:space:]]<<'
 exactly 52 "world.log<< uses" 'world.log<<|world.log[[:space:]]<<'
-exactly 1230 "<< uses" '(?<!<)<<(?!<)' -P
+exactly 1229 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 27 "text2path uses" 'text2path'
 exactly 72 "update_icon() override" '/update_icon\((.*)\)'  -P


### PR DESCRIPTION
Storage items can now be alt-clicked to access them quickly. Death to click-drag.
Alt Click can now eject people from scanners, cryotubes, or sleepers.
Alt Click can now eject beakers from a chem-master, dispenser, grinder, heater, or cooler.
Ctrl Click can now turn cryotubes on and off.
You can now Ctrl Click a grinder to grind, or CtrlAlt Click to eject the contents.

More to come at some point in a future PR.