### PR TITLE
Angry cubes go rogue & a couple of bug fixes

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -114,18 +114,28 @@
 	for(var/datum/mind/player in mode.get_players_for_role(id))
 		if(ghosts_only && !(isghostmind(player) || isnewplayer(player.current)))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: Only ghosts may join as this role!")
-		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
-			log_debug("[key_name(player)] is not eligible to become a [role_text]: Is only [player.current.client.player_age] day\s old, has to be [minimum_player_age] day\s!")
-		else if(player.special_role)
+			continue
+		if(config.use_age_restriction_for_antags)
+			if(!isnum(player.current.client.player_age))
+				log_warning("Config option USE_AGE_RESTRICTION_FOR_ANTAGS is set but a database connection could not be established")
+				continue
+			else if(player.current.client.player_age < minimum_player_age)
+				log_debug("[key_name(player)] is not eligible to become a [role_text]: Is only [player.current.client.player_age] day\s old, has to be [minimum_player_age] day\s!")
+				continue
+		if(player.special_role)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They already have a special role ([player.special_role])!")
-		else if (player in pending_antagonists)
+			continue
+		if(player in pending_antagonists)
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They have already been selected for this role!")
-		else if(!can_become_antag(player))
+			continue
+		if(!can_become_antag(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are blacklisted for this role!")
-		else if(player_is_antag(player))
+			continue
+		if(player_is_antag(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!")
-		else
-			candidates |= player
+			continue
+
+		candidates |= player
 
 	return candidates
 
@@ -136,13 +146,23 @@
 	// Keeping broken up for readability
 	for(var/datum/mind/player in mode.get_players_for_role(id))
 		if(ghosts_only && !(isghostmind(player) || isnewplayer(player.current)))
-		else if(config.use_age_restriction_for_antags && player.current.client.player_age < minimum_player_age)
-		else if(player.special_role)
-		else if (player in pending_antagonists)
-		else if(!can_become_antag(player))
-		else if(player_is_antag(player))
-		else
-			candidates |= player
+			continue
+		if(config.use_age_restriction_for_antags)
+			if(!isnum(player.current.client.player_age))
+				log_warning("Config option USE_AGE_RESTRICTION_FOR_ANTAGS is set but a database connection could not be established")
+				continue
+			else if(player.current.client.player_age < minimum_player_age)
+				continue
+		if(player.special_role)
+			continue
+		if(player in pending_antagonists)
+			continue
+		if(!can_become_antag(player))
+			continue
+		if(player_is_antag(player))
+			continue
+
+		candidates |= player
 
 	return candidates
 
@@ -178,6 +198,7 @@
 	if(!add_antagonist(player,0,0,0,1,1))
 		log_debug("Could not auto-spawn a [role_text], failed to add antagonist.")
 		return 0
+	pending_antagonists -= player
 
 	reset_antag_selection()
 

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_networking.dm
@@ -216,4 +216,5 @@
 		command_announcement.Announce("Our system administrators just reported that we've been locked out from your control network. Whoever did this now has full access to [GLOB.using_map.station_name]'s systems.", "Network Administration Center")
 	user.hack_can_fail = 0
 	user.system_override = 2
-	user.verbs += new/datum/game_mode/malfunction/verb/ai_destroy_station()
+	if(SSticker.mode.name == "AI Malfunction")	//Rampant AI's can get override, but no boom if the gamemode isn't Malf
+		user.verbs += new/datum/game_mode/malfunction/verb/ai_destroy_station()


### PR DESCRIPTION
It has been raised previously that people thought that antag AI's should still get the rogue AI abilities. After poking at the code, I noticed that traitor AI's _do_ get the Rogue verbs once `equip()` is called, however the AI role was blacklisted from getting traitor for some reason? I assumed this was an oversight so removed the blacklisted role and overrode some of the parent procs to properly factor in a rogue AI. 

Previously the player would be made **both** a traitor and rampant AI. This new way drafts the player as before, then uses the malf antag type to handle the spawn/equip rather than the traitor antag type. The end result is the traitor gamemode is aware that the rogue AI exists and counts it as a traitor (so auto-antag keeps track), but the AI is only rampant/rogue rather than both. In addition, the detonate station verb has been disabled unless the gamemode is actually Malfunction, though the override ability is still usable (Just allows the player to hack all remaining APCs for big stonk CPU points)

A couple of quick bugfixes were also added as I noticed runtimes:

- Fixed a runtime when comparing player age against the `minimum_player_age` variable. This happened in cases where a database connection could not be established or wasn't set up, but `USE_AGE_RESTRICTION_FOR_ANTAGS` had been set in the config options. For some reason, `client.player_age` is set to a _string_ if no database could be retrieved... Added a catch and output to the log if this happens.
- Fixed an issue where added antags could suddenly have their special role revoked instantly. During `attempt_auto_spawn()` player candidates are added to the `candidates` list. The first player in that list would then attempt to spawn, then afterwards `reset_antag_selection()` would be called which resets all special roles for all players in the `candidates` list. I believe this is to clean up all unsuccessful canditates if multiple were selected, so that they could return to their normie lives. However, the player that was successfully spawned was still actually present in that list and would then have their role removed by the proc... Opps.


As always, happy to change things as required!