### PR TITLE
Bugfixing again

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -411,9 +411,8 @@
 
 /obj/item/weapon/storage/box/lights/bulbs/empty
 	startswith = null
-
-/obj/item/weapon/storage/box/lights/bulbs/empty
-	startswith = null
+	max_w_class = ITEM_SIZE_SMALL
+	max_storage_space = 25
 
 /obj/item/weapon/storage/box/lights/tubes
 	name = "box of replacement tubes"
@@ -429,9 +428,8 @@
 
 /obj/item/weapon/storage/box/lights/tubes/empty
 	startswith = null
-
-/obj/item/weapon/storage/box/lights/tubes/empty
-	startswith = null
+	max_w_class = ITEM_SIZE_SMALL
+	max_storage_space = 25
 
 /obj/item/weapon/storage/box/lights/mixed
 	name = "box of replacement lights"
@@ -442,9 +440,8 @@
 
 /obj/item/weapon/storage/box/lights/mixed/empty
 	startswith = null
-
-/obj/item/weapon/storage/box/lights/mixed/empty
-	startswith = null
+	max_w_class = ITEM_SIZE_SMALL
+	max_storage_space = 25
 
 /obj/item/weapon/storage/box/glowsticks
 	name = "box of mixed glowsticks"

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -381,6 +381,8 @@
 			return 1
 
 /obj/item/weapon/storage/proc/make_exact_fit()
+	if(!contents.len)	//Prevent making storage with 0 slots
+		return
 	storage_slots = contents.len
 
 	can_hold.Cut()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -171,7 +171,10 @@
 			to_chat(user,"<span class='notice'>You transfer [count] round\s into [src].</span>")
 			playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
 		update_icon()
-		AM.update_icon()
+		if(!AM.stored_ammo.len && istype(AM, /obj/item/ammo_magazine/bundle))
+			qdel(AM)
+		else
+			AM.update_icon()
 	else ..()
 
 /obj/item/ammo_magazine/attack_self(mob/user)

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -68,24 +68,18 @@
 	icon_state = "44_r"
 	ammo_type = /obj/item/ammo_casing/c44/rubber
 
-/obj/item/ammo_magazine/shotbundle
-	name = "fistful of shotgun shells"
-	desc = "A fistful of shotgun shells."
-	icon = 'icons/urist/items/shotbundle.dmi'
-	icon_state = "slshell-1"
-	caliber = "shotgun"
-	ammo_type = /obj/item/ammo_casing/shotgun
-	matter = list(MATERIAL_STEEL = 0)
+/obj/item/ammo_magazine/bundle
 	initial_ammo = 0
 	max_ammo = 4
-	multiple_sprites = 1
 	w_class = ITEM_SIZE_NORMAL
+	matter = list(MATERIAL_STEEL = 0)
+	multiple_sprites = 1
 
-/obj/item/ammo_magazine/shotbundle/attack_hand(mob/user)
-	..()
+/obj/item/ammo_magazine/bundle/attack_hand(mob/user)
+	. = ..()
 	check_ammo_count(user)
 
-/obj/item/ammo_magazine/shotbundle/proc/check_ammo_count(mob/user)
+/obj/item/ammo_magazine/bundle/proc/check_ammo_count(mob/user)
 	if(stored_ammo.len <= 1)
 		user.drop_from_inventory(src, null)
 		if(stored_ammo.len)
@@ -93,18 +87,24 @@
 			stored_ammo.Cut()
 		qdel(src)
 
-
-/obj/item/ammo_magazine/shotbundle/attack_self(mob/user)
+/obj/item/ammo_magazine/bundle/attack_self(mob/user)
 	..()
 	qdel(src)
 
-/obj/item/ammo_magazine/shotbundle/on_update_icon()
+/obj/item/ammo_magazine/bundle/on_update_icon()
 	overlays.Cut()
 	var/count = 1
 	for(var/obj/item/ammo_casing/C in stored_ammo)
-		overlays += image("icons/urist/items/shotbundle.dmi", "[C.icon_state]-[count]")
+		overlays += image(src.icon, "[C.icon_state]-[count]")
 		count++
 
+/obj/item/ammo_magazine/bundle/shotbundle
+	name = "fistful of shotgun shells"
+	desc = "A fistful of shotgun shells."
+	icon = 'icons/urist/items/shotbundle.dmi'
+	icon_state = "slshell-1"
+	caliber = "shotgun"
+	ammo_type = /obj/item/ammo_casing/shotgun
 
 /obj/item/ammo_magazine/shotholder
 	name = "shotgun slug holder"

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -133,17 +133,18 @@
 		var/obj/item/ammo_casing/shotgun/empty_check = I
 		if(!empty_check.BB)
 			return
-		var/obj/item/ammo_magazine/shotbundle/C = new /obj/item/ammo_magazine/shotbundle()
+		var/obj/item/ammo_magazine/bundle/shotbundle/C = new /obj/item/ammo_magazine/bundle/shotbundle()
 		C.attackby(I, user)
 		C.attackby(src, user)
 		user.put_in_hands(C)
 		return
-	if(istype(I, /obj/item/ammo_magazine/shotbundle))
+	if(istype(I, /obj/item/ammo_magazine/bundle/shotbundle))
 		if(!BB)
 			return
 		I.attackby(src, user)
 		return
 	..()
+
 /obj/item/ammo_casing/shotgun/pellet
 	name = "shotgun shell"
 	desc = "A 12 gauge shell."

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -18,8 +18,8 @@
 		loaded.Insert(1, C)
 		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
 		playsound(loc, load_sound, 50, 1)
-		if(istype(AM, /obj/item/ammo_magazine/shotbundle))
-			var/obj/item/ammo_magazine/shotbundle/SB = A
+		if(istype(AM, /obj/item/ammo_magazine/bundle/shotbundle))
+			var/obj/item/ammo_magazine/bundle/shotbundle/SB = A
 			SB.check_ammo_count(user)
 		AM.update_icon()
 		return


### PR DESCRIPTION
Fixes a couple of bugs raised by AseaHeru in Discord

- New lighttube boxes made from cardboard would not take any items. This was caused by the `make_exact_fit()` proc that'd assume the storage item would already have contents and set `max_storage_space` to match the count of contents. As these new boxes had no contents, this was being set to 0. Added a check for contents under the `make_exact_fit()` proc and set default values for the boxes manually to match what pre-spawned boxes have.
- Fistful of shotgun shells were remaining with 0 shells once inserted into an ammo holder. This makes sense for magazines but not a fistful of shells. This was caused by a missing `qdel()` call/check in the `ammo_magazine/attackby()` proc. To facilitate future possible ammo expansion and to avoid strict typecasting, I've refactored the fistful of shotgun shells to be under a new subtype of ammo_magazine, `ammo_magazine/bundle`. Any future fistful of x ammo types can go here and the correct qdel checks and icon updates will apply

Gonna tag @Cheedows here as he worked on the ammo PR in case he had any input or concerns.

As always, let me know if there's any issues, it's been a hot while since I last touched and DM code.