### PR TITLE
Bugfixing again

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -182,6 +182,9 @@
 		var/mob/living/carbon/C = M
 		if(!C.handcuffed)
 			C.handcuffed = src
+	else if(istype(M, /mob/living/simple_animal/hostile))
+		var/mob/living/simple_animal/hostile/HM = M
+		HM.LoseTarget()
 	return 1
 
 /obj/effect/energy_net/post_buckle_mob(mob/living/M)

--- a/code/modules/alarm/alarm_handler.dm
+++ b/code/modules/alarm/alarm_handler.dm
@@ -112,6 +112,19 @@
 /datum/alarm_handler/proc/unregister_alarm(var/object)
 	listeners -= object
 
-/datum/alarm_handler/proc/notify_listeners(var/alarm, var/was_raised)
+/datum/alarm_handler/proc/notify_listeners(var/datum/alarm/alarm, var/was_raised)
 	for(var/listener in listeners)
-		call(listener, listeners[listener])(src, alarm, was_raised)
+		var/z = null
+
+		var/atom/atom_listener = listener
+		var/datum/nano_module/module = listener
+
+		if(istype(atom_listener))
+			z = atom_listener.z
+		else if(istype(module))
+			var/atom/host = module.host
+			if(host && istype(host))
+				z = host.z
+
+		if(!z || AreConnectedZLevels(z, alarm.alarm_z()))
+			call(listener, listeners[listener])(src, alarm, was_raised)

--- a/code/modules/events/maint_drones.dm
+++ b/code/modules/events/maint_drones.dm
@@ -17,7 +17,7 @@
 	var/naming
 	switch(severity)
 		if(EVENT_LEVEL_MUNDANE)
-			naming = "malfuncion"
+			naming = "malfunction"
 		if(EVENT_LEVEL_MODERATE)
 			naming = "uprising"
 		if(EVENT_LEVEL_MAJOR)

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -11,6 +11,7 @@
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 4)
+	force = 1
 
 	var/full = SOULSTONE_EMPTY
 	var/is_evil = 1

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -491,3 +491,7 @@
 /mob/living/simple_animal/Destroy()
 	GLOB.simple_mob_list.Remove(src)
 	..()
+
+/mob/living/simple_animal/restrained()
+	if(buckled && istype(buckled, /obj/effect/energy_net/safari))
+		return 1


### PR DESCRIPTION
Just a few small bugs I've noticed/been told about.

Fixes the following:

- `simple_animal`'s being able to attack while netted: Tweaked the code so that netted `simple_animal`'s count as restrained.
- Soulstone not recapturing shards: This relies on 'attacking' the shard with the soulstone. Attack calls are ignored if the item has no `force`.. Derp.
- Typo in the maintenance drone event
- Silicons receiving alarms for aways: Added a connected Z-level check before alerting the listener