### PR TITLE
Terran marine_space faction fix

### DIFF
--- a/code/modules/urist/mob/humanhostiles.dm
+++ b/code/modules/urist/mob/humanhostiles.dm
@@ -254,7 +254,6 @@
 	faction = "terran"
 
 /mob/living/simple_animal/hostile/urist/terran/marine_space
-	faction = "terran"
 	name = "\improper Terran Confederacy Marine"
 	desc = "A Terran Confederacy Marine. This one is wearing a voidsuit."
 	ranged = 1


### PR DESCRIPTION
fixes the marine_space simplemob having the Terran faction and therefore always being very intolerant and angry about the fact that people aren't wearing their confederation pins at any given moment. I did this by removing the faction= "Terran" being set at the root mob and therefore might not actually have done it right. But it should be good to go.