### PR TITLE
Fix Advanced ProcCall

### DIFF
--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -99,6 +99,9 @@
 			clear()
 			return
 
+	else
+		procname = "/proc/[procname]"
+
 	arguments = list()
 	do_args()
 


### PR DESCRIPTION
Fixes an oversight that caused some issues when calling a proc that's not a method with `Advanced ProcCall`. This brings the syntax in line with other call verbs, such as SDQL2 where the end user is not expected to include the proceeding `/proc/`, as well as the syntax for targeted proc calls, which also do not expect  `/proc/`