### PR TITLE
Rebalances traitor costs+ammo+adding antag items

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -6,11 +6,11 @@
 	category = /datum/uplink_category/ammunition
 
 /datum/uplink_item/item/ammo/c45m
-	name = ".45"
+	name = ".45 pistol magazine"
 	path = /obj/item/ammo_magazine/c45m
 
 /datum/uplink_item/item/ammo/mc9mm
-	name = "9mm"
+	name = "9mm pistol magazine"
 	item_cost = 3
 	path = /obj/item/ammo_magazine/mc9mm
 
@@ -19,20 +19,24 @@
 	path = /obj/item/ammo_magazine/chemdart
 
 /datum/uplink_item/item/ammo/mc9mmds
-	name = "9mm double-stack"
+	name = "9mm double-stack magazine"
 	item_cost = 6
 	path = /obj/item/ammo_magazine/mc9mmds
 
 /datum/uplink_item/item/ammo/a44
-	name = ".44"
+	name = ".44 speed loader"
 	item_cost = 8
 	path = /obj/item/ammo_magazine/a44
 
+/datum/uplink_item/item/ammo/a357
+	name = ".357 speed loader"
+	item_cost = 8
+	path = /obj/item/ammo_magazine/c357
+
 /datum/uplink_item/item/ammo/a556
-	name = "5.56mm"
+	name = "5.56mm magazine"
 	item_cost = 8
 	path = /obj/item/ammo_magazine/c556
-	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/sniperammo
 	name = "14.5mm"
@@ -65,7 +69,6 @@
 	name = "10mm SMG Magazine"
 	item_cost = 8
 	path = /obj/item/ammo_magazine/a10mm
-	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/p10mm
 	name = "10mm Pistol Magazine"
@@ -90,7 +93,6 @@
 	name = "Flechette Magazine"
 	item_cost = 8
 	path = /obj/item/weapon/magnetic_ammo
-	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/c45m_emp
 	name = ".45 EMP Ammo Box (10 rounds)"
@@ -98,11 +100,11 @@
 	path = /obj/item/ammo_magazine/box/emp/c45
 
 /datum/uplink_item/item/ammo/p10mm_emp
-	name = "10mm EMP Ammmo Box (10 rounds)"
+	name = "10mm EMP Ammo Box (10 rounds)"
 	item_cost = 8
 	path = /obj/item/ammo_magazine/box/emp/a10mm
 
 /datum/uplink_item/item/ammo/c38_emp
-	name = ".38 EMP Ammmo Box (10 rounds)"
+	name = ".38 EMP Ammo Box (10 rounds)"
 	item_cost = 6
 	path = /obj/item/ammo_magazine/box/emp

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -122,3 +122,15 @@
 	path = /obj/effect/spawner/newbomb/traitor
 	desc = "A remote-activated phoron-oxygen bomb assembly with built-in signaler. \
 			A flashing disclaimer begins with the warning 'SOME DISASSEMBLY/REASSEMBLY REQUIRED.'"
+
+/datum/uplink_item/item/tools/ductape
+	name = "Duct Tape"
+	desc = "A roll of duct tape."
+	item_cost = 2
+	path = /obj/item/weapon/tape_roll
+
+/datum/uplink_item/item/tools/handcuffs
+	name = "Handcuffs"
+	desc = "A set of handcuffs."
+	item_cost = 6
+	path = /obj/item/weapon/handcuffs

--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -78,3 +78,13 @@
 	item_cost = 60
 	antag_roles = list(MODE_MERCENARY)
 	path = /obj/item/weapon/storage/box/supermatters
+
+/datum/uplink_item/item/grenades/metalfoam
+	name = "1x Metal Foam Grenade"
+	item_cost = 4
+	path = /obj/item/weapon/grenade/chem_grenade/metalfoam
+
+/datum/uplink_item/item/grenades/metalfoams
+	name = "5x Metal Foam Grenades"
+	item_cost = 16
+	path = /obj/item/weapon/storage/box/metalfoams

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -43,16 +43,16 @@
 	item_cost = 24
 	path = /obj/item/weapon/gun/energy/gun
 
-/datum/uplink_item/item/visible_weapons/revolver
+/datum/uplink_item/item/visible_weapons/revolver //357 and 44 revolvers are functionally identical
 	name = "Revolver, .357"
-	desc = ".357 revolver, with ammunition."
-	item_cost = 56
+	desc = ".357 Magnum revolver, with ammunition."
+	item_cost = 36
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver
 
 /datum/uplink_item/item/visible_weapons/revolver2
 	name = "Revolver, .44"
-	desc = ".44 magnum revolver, with ammunition."
-	item_cost = 48
+	desc = ".44 Magnum revolver, with ammunition."
+	item_cost = 36
 	path = /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver2
 
 /datum/uplink_item/item/visible_weapons/grenade_launcher
@@ -63,17 +63,17 @@
 //These are for traitors (or other antags, perhaps) to have the option of purchasing some merc gear.
 /datum/uplink_item/item/visible_weapons/submachinegun
 	name = "Submachine Gun"
-	item_cost = 52
+	item_cost = 64
 	path = /obj/item/weapon/gun/projectile/automatic/c20r
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
 	name = "Assault Rifle"
-	item_cost = 60
+	item_cost = 68
 	path = /obj/item/weapon/gun/projectile/automatic/sts35
 
 /datum/uplink_item/item/visible_weapons/advanced_energy_gun
 	name = "Advanced Energy Gun"
-	item_cost = 60
+	item_cost = 68
 	path = /obj/item/weapon/gun/energy/gun/nuclear
 
 /datum/uplink_item/item/visible_weapons/heavysniper
@@ -107,7 +107,7 @@
 
 /datum/uplink_item/item/visible_weapons/deagle
 	name = "Magnum Pistol"
-	item_cost = 52
+	item_cost = 60
 	path = /obj/item/weapon/gun/projectile/magnum_pistol
 
 /datum/uplink_item/item/visible_weapons/beretta

--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -16,7 +16,7 @@
 
 /datum/uplink_item/item/implants/imp_explosive
 	name = "Explosive Implant (DANGER!)"
-	item_cost = 40
+	item_cost = 24
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_explosive
 
 /datum/uplink_item/item/implants/imp_uplink

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -2,7 +2,7 @@
 /obj/item/supply_beacon
 	name = "inactive supply beacon"
 	icon = 'icons/obj/supplybeacon.dmi'
-	desc = "An inactive, hacked supply beacon stamped with the Nyx Rapid Fabrication logo. Good for one (1) ballistic supply pod shipment."
+	desc = "An inactive, hacked supply beacon stamped with the Nyx Rapid Fabrication logo. Good for one (1) ballistic supply pod shipment. Contents not guaranteed to be weaponry."
 	icon_state = "beacon"
 	var/deploy_path = /obj/machinery/power/supply_beacon
 	var/deploy_time = 30

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -234,6 +234,12 @@
 	icon_state = "flashbang"
 	startswith = list(/obj/item/weapon/grenade/anti_photon = 5)
 
+/obj/item/weapon/storage/box/metalfoams
+	name = "box of metal foam grenades"
+	desc = "A box 5 metal foam grenades."
+	icon_state = "flashbang"
+	startswith = list(/obj/item/weapon/grenade/chem_grenade/metalfoam = 5)
+
 /obj/item/weapon/storage/box/supermatters
 	name = "box of supermatter grenades"
 	desc = "A box containing 5 highly experimental supermatter grenades."

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -58,4 +58,4 @@
 	item_state = "toolbox_syndi"
 	origin_tech = list(TECH_COMBAT = 1, TECH_ILLEGAL = 1)
 	attack_cooldown = 10
-	startswith = list(/obj/item/clothing/gloves/insulated, /obj/item/weapon/screwdriver, /obj/item/weapon/wrench, /obj/item/weapon/weldingtool, /obj/item/weapon/crowbar, /obj/item/weapon/wirecutters, /obj/item/device/multitool)
+	startswith = list(/obj/item/clothing/gloves/insulated, /obj/item/weapon/storage/belt/utility, /obj/item/weapon/screwdriver, /obj/item/weapon/wrench, /obj/item/weapon/weldingtool, /obj/item/weapon/crowbar, /obj/item/weapon/wirecutters, /obj/item/device/multitool)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -97,7 +97,7 @@
 /obj/item/weapon/storage/backpack/satchel/syndie_kit/revolver2
 	startswith = list(
 		/obj/item/weapon/gun/projectile/revolver/webley,
-		/obj/item/ammo_magazine/c357
+		/obj/item/ammo_magazine/c44
 	)
 
 /obj/item/weapon/storage/box/syndie_kit/toxin

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -53,7 +53,7 @@
 	ammo_type = /obj/item/ammo_casing/c38/rubber
 
 /obj/item/ammo_magazine/c44
-	name = "speed loader (.44 magnum)"
+	name = "speed loader (.44 Magnum)"
 	desc = "A speed loader for revolvers."
 	icon = 'icons/urist/items/ammo.dmi'
 	icon_state = "44"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/revolver
 	name = "revolver"
-	desc = "The Lumoco Arms HE Colt is a choice revolver for when you absolutely, positively need to put a hole in the other guy. Uses .44 Magnum ammo."
+	desc = "The Lumoco Arms HE Colt is a choice revolver for when you absolutely, positively need to put a hole in the other guy. Uses .357 Magnum ammo."
 	icon = 'icons/urist/items/revolvers.dmi'
 	icon_state = "revolver"
 	item_state = "revolver"
@@ -138,13 +138,13 @@
 
 /obj/item/weapon/gun/projectile/revolver/webley
 	name = "service revolver"
-	desc = "The A&M W4. A rugged top break revolver produced by al-Maliki & Mosley. Based on the Webley model, with modern improvements. Uses .357 Magnum rounds."
+	desc = "The A&M W4. A rugged top break revolver produced by al-Maliki & Mosley. Based on the Webley model, with modern improvements. Uses .44 Magnum ammo."
 	icon_state = "webley"
 	item_state = "webley"
 	item_icons = URIST_ALL_ONMOBS
 	item_state = "webley"
 	wielded_item_state = "webley"
 	max_shells = 6
-	caliber = ".357"
+	caliber = ".44"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
-	ammo_type = /obj/item/ammo_casing/c357
+	ammo_type = /obj/item/ammo_casing/c44


### PR DESCRIPTION
Removes some ammo noob traps (any gun you can buy should let you buy ammo too, except railguns)
Raises the cost of some of the strongest firearms
Unifies cost of 357 and 44 and lowers them in total. They're much weaker than they were years ago and functionally identical. Revolvers themselves have also been fixed so the 44 no longer takes 357.
Syndicate toolbox now comes with a toolbelt
You can now buy cuffs/duct tape and metal foam grenades
Explosive implant cost largely reduced.
Decreases odds of ballistic pod buyers thinking they are getting guns