### PR TITLE
Fixes prescription bug, ports unconsciousness msgs, codex, typo

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -171,6 +171,10 @@
 
 #define JOINTEXT(X) jointext(X, null)
 
+#define SPAN_CLASS(class, X) "<span class='[class]'>[X]</span>"
+
+#define SPAN_BOLD(X) SPAN_CLASS("bold", "[X]")
+
 #define SPAN_NOTICE(X) "<span class='notice'>[X]</span>"
 
 #define SPAN_WARNING(X) "<span class='warning'>[X]</span>"

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -94,7 +94,9 @@
 
 	suppressing = !suppressing
 	user.visible_message("<span class='notice'>\The [user] switches [suppressing ? "on" : "off"] \the [src]'s neural suppressor.</span>")
-
+	if (victim.stat == UNCONSCIOUS)
+		to_chat(victim, SPAN_NOTICE(SPAN_BOLD("... [pick("good feeling", "white light", "pain fades away", "safe now")] ...")))
+	return TRUE
 
 /obj/machinery/optable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -61,6 +61,8 @@
 
 	if(iscarbon(occupant) && stasis > 1)
 		occupant.SetStasis(stasis)
+		if (occupant.stat == UNCONSCIOUS && prob(20))
+			to_chat(occupant, SPAN_NOTICE(SPAN_BOLD("... [pick("comfy", "feels slow", "warm")] ...")))
 
 /obj/machinery/sleeper/on_update_icon()
 	icon_state = "sleeper_[occupant ? "1" : "0"]"

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -263,6 +263,8 @@
 			occupant.heal_organ_damage(heal_brute,heal_fire)
 		if(beaker)
 			beaker.reagents.trans_to_mob(occupant, REM, CHEM_BLOOD)
+		if (occupant.stat == UNCONSCIOUS && prob(2))
+			to_chat(occupant, SPAN_NOTICE(SPAN_BOLD("... [pick("comfy", "feels slow", "warm")] ...")))
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/heat_gas_contents()
 	if(air_contents.total_moles < 1)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -113,6 +113,8 @@
 					user.visible_message(SPAN_NOTICE("\The [user] places a bandaid over \a [W.desc] on [M]'s [affecting.name]."), \
 					                              SPAN_NOTICE("You place a bandaid over \a [W.desc] on [M]'s [affecting.name].") )
 				W.bandage()
+				if (M.stat == UNCONSCIOUS && prob(25))
+					to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels a little better", "hurts a little less")] ...")))
 				playsound(src, pick(apply_sounds), 25)
 				used++
 			affecting.update_damages()
@@ -209,6 +211,8 @@
 				W.disinfect()
 				W.heal_damage(heal_brute)
 				used++
+				if (M.stat == UNCONSCIOUS && prob(25))
+					to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels better", "hurts less")] ...")))
 			affecting.update_damages()
 			if(used == amount)
 				if(affecting.is_bandaged())
@@ -253,6 +257,8 @@
 			use(1)
 			affecting.salve()
 			affecting.disinfect()
+			if (M.stat == UNCONSCIOUS && prob(25))
+				to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels better", "hurts less")] ...")))
 
 /obj/item/stack/medical/splint
 	name = "medical splints"

--- a/code/modules/codex/entries/misc.dm
+++ b/code/modules/codex/entries/misc.dm
@@ -17,3 +17,11 @@
 	mechanics_text = "Load money into the cannon by picking it up with the gun, or feeding it directly by hand. Use in your hand to configure how much money you want to fire per shot."
 	lore_text = "These devices were invented several centuries ago and are a distinctly human cultural infection. They have produced knockoffs as timeless and as insipid as the potato gun and the paddle ball, showing up in all corners of the galaxy. The Money Cannon variation is noteworthy for its sturdiness and build quality, but is, at the end of the day, just another knockoff of the ancient originals."
 	antag_text = "Sliding a cryptographic sequencer into the receptacle will short the motors and override their speed. If you set the cannon to dispense 100 thaler or more, this might make a handy weapon."
+
+/datum/codex_entry/ssd
+	display_name = "SSD/S.S.D."
+	mechanics_text = "When a player has disconnected or ghosted, they display a special message when they're examined, colored in purple. If the message indicates something like them staring blankly, being fast asleep, or displaying a SYSTEM OFFLINE message, it's likely that the player's closed their BYOND client or lost their connection. In such a case, it's possible they'll resume play soon or at a later time. These players are referred as \"going SSD\" or otherwise being SSD.<br><br>\
+	\
+	If the message displays something more severe, like being completely comatose or having a full system failure, the player has voluntarily ghosted while still alive - this means that the character won't return back to the round as a player, short of invervention from an admin. For clarity, these cases will also always mention that the player won't be recovering or waking up any time soon.<br><br>\
+	\
+	The server's rules likely have special clauses regarding SSD players. Check the rule list before you touch a player who's disconnected or take any actions on them."

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -184,7 +184,7 @@
 	var/ssd_msg = species.get_ssd(src)
 	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
 		if(!key)
-			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. It doesn't look like [T.he] [T.is] waking up anytime soon.</span>\n"
+			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg]. [T.He] won't be recovering any time soon.</span>\n"
 		else if(!client)
 			msg += "<span class='deadsay'>[T.He] [T.is] [ssd_msg].</span>\n"
 

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -272,7 +272,7 @@ var/global/list/sparring_attack_cache = list()
 				"<span class='danger'>[user] stomped \his [shoe_text] down onto [target]'s [organ]!</span>"))
 		if(5)
 			user.visible_message(pick(
-				"<span class='danger'>[user] stomped down hard onto [target]'s [organ][pick("", "with their [shoe_text]")]!</span>",
+				"<span class='danger'>[user] stomped down hard onto [target]'s [organ][pick("", " with their [shoe_text]")]!</span>",
 				"<span class='danger'>[user] slammed \his [shoe_text] down onto [target]'s [organ]!</span>"))
 
 /datum/unarmed_attack/light_strike

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -174,6 +174,8 @@
 		set_fullscreen(eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
 		set_fullscreen(druggy, "high", /obj/screen/fullscreen/high)
 
+	set_fullscreen(stat == UNCONSCIOUS, "blind", /obj/screen/fullscreen/blind)
+
 	if(machine)
 		var/viewflags = machine.check_eye(src)
 		if(viewflags < 0)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -53,6 +53,7 @@
 	var/mob_size	= MOB_MEDIUM
 	var/strength    = STR_MEDIUM
 	var/show_ssd = "fast asleep"
+	var/show_coma = "completely comatose"
 	var/virus_immune
 	var/short_sighted                         // Permanent weldervision.
 	var/light_sensitive                       // Ditto, but requires sunglasses to fix
@@ -535,6 +536,8 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		return 1
 
 	H.set_fullscreen(H.eye_blind && !H.equipment_prescription, "blind", /obj/screen/fullscreen/blind)
+	H.set_fullscreen(H.stat == UNCONSCIOUS, "blind", /obj/screen/fullscreen/blind)
+
 
 	if(config.welder_vision)
 		H.set_fullscreen(H.equipment_tint_total, "welder", /obj/screen/fullscreen/impaired, H.equipment_tint_total)

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -44,7 +44,10 @@
 	return ((H && H.isSynthetic()) ? "gives one shrill beep before falling lifeless." : death_message)
 
 /datum/species/proc/get_ssd(var/mob/living/carbon/human/H)
-	return ((H && H.isSynthetic()) ? "flashing a 'system offline' glyph on their monitor" : show_ssd)
+	if (H.key)
+		return ((H && H.isSynthetic()) ? "flashing a 'system offline' glyph on their monitor" : show_ssd)
+	else
+		return ((H && H.isSynthetic()) ? "displaying a blue screen on their monitor indicating total system failure" : show_coma)
 
 /datum/species/proc/get_blood_colour(var/mob/living/carbon/human/H)
 	return ((H && H.isSynthetic()) ? SYNTH_BLOOD_COLOUR : blood_color)

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -15,6 +15,7 @@
 	greater_form = SPECIES_HUMAN
 	mob_size = MOB_SMALL
 	show_ssd = null
+	show_coma = null
 	health_hud_intensity = 1.75
 
 	gibbed_anim = "gibbed-m"
@@ -83,7 +84,7 @@
 				touchables += O
 		var/obj/touchy = pick(touchables)
 		touchy.attack_hand(H)
-	
+
 	if(prob(1))
 		H.emote(pick("scratch","jump","roll","tail"))
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -109,6 +109,8 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			H.bloody_body(target,0)
 	if(shock_level)
 		target.shock_stage = max(target.shock_stage, shock_level)
+	if (target.stat == UNCONSCIOUS && prob(20))
+		to_chat(target, SPAN_NOTICE(SPAN_BOLD("... [pick("bright light", "faraway pain", "something moving in you", "soft beeping")] ...")))
 	return
 
 // does stuff to end the step, which is normally print a message + do whatever this step changes


### PR DESCRIPTION
Thanks Bay.
-Prescription-glasses wearing mobs will now see as much as any unconscious person: very little.
-Mildly-positive messages will sift to your unconscious brain when you are bandaged/sleepered/cryoed/sleeperstasis'd.
-If you're ghosted you give a coma message instead of an SSD one.
-Codex entry for SSD, melee typo fix.