### PR TITLE
fixes monolithic asteroid and xenoarch loop, adds more character slots

### DIFF
--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -93,15 +93,15 @@ SUBSYSTEM_DEF(xenoarch)
 			//have a chance for an artifact to spawn here, but not in animal or plant digsites
 			if(isnull(M.artifact_find) && digsite != DIGSITE_GARDEN && digsite != DIGSITE_ANIMAL)
 				artifact_spawning_turfs.Add(archeo_turf)
+		CHECK_TICK
 
 	//create artifact machinery
 	var/num_artifacts_spawn = rand(ARTIFACTSPAWNNUM_LOWER, ARTIFACTSPAWNNUM_UPPER)
-	while(artifact_spawning_turfs.len > num_artifacts_spawn)
-		pick_n_take(artifact_spawning_turfs)
-
-	var/list/artifacts_spawnturf_temp = artifact_spawning_turfs.Copy()
-	while(artifacts_spawnturf_temp.len > 0)
-		var/turf/simulated/mineral/artifact_turf = pop(artifacts_spawnturf_temp)
+	var/list/final_artifact_spawning_turfs = list()
+	for(var/i = 1 to num_artifacts_spawn)
+		final_artifact_spawning_turfs += pick_n_take(artifact_spawning_turfs)
+	artifact_spawning_turfs = final_artifact_spawning_turfs
+	for(var/turf/simulated/mineral/artifact_turf in artifact_spawning_turfs)
 		artifact_turf.artifact_find = new()
 
 #undef XENOARCH_SPAWN_CHANCE

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -97,6 +97,10 @@
 	icon_state = "sector"
 	anchored = 1
 
+// Because of the way these are spawned, they will potentially have their invisibility adjusted by the turfs they are mapped on
+// prior to being moved to the overmap. This blocks that. Use set_invisibility to adjust invisibility as needed instead.
+/obj/effect/overmap/sector/hide()
+
 /obj/effect/overmap/sector/Initialize()
 	. = ..()
 	if(known)

--- a/config/config.txt
+++ b/config/config.txt
@@ -375,7 +375,7 @@ ALLOW_CULT_GHOSTWRITER
 REQ_CULT_GHOSTWRITER 6
 
 ## Sets the number of available character slots
-CHARACTER_SLOTS 10
+CHARACTER_SLOTS 20
 
 ## Sets the number of loadout slots per character
 LOADOUT_SLOTS 3


### PR DESCRIPTION
from 10 character slots to 20
ports bay fix for invisible away missions (aka the monolithic asteroid). vox/pirate etc are still 'hidden' just as they were
ports bay fix for xenoarch looping in init