### PR TITLE
Raises the Emag's amount of uses before breaking.

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -106,7 +106,11 @@
 	icon_state = "emag"
 	item_state = "card-id"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ILLEGAL = 2)
-	var/uses = 24
+	var/uses = 18
+
+/obj/item/weapon/card/emag/New()
+	uses = rand(18, 24)
+	..()
 
 var/const/NO_EMAG_ACT = -50
 /obj/item/weapon/card/emag/resolve_attackby(atom/A, mob/user)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -106,7 +106,7 @@
 	icon_state = "emag"
 	item_state = "card-id"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ILLEGAL = 2)
-	var/uses = 10
+	var/uses = 24
 
 var/const/NO_EMAG_ACT = -50
 /obj/item/weapon/card/emag/resolve_attackby(atom/A, mob/user)


### PR DESCRIPTION
- Considerably increases the Emag's uses to 24, instead of 10.
- The intent behind increasing this is to make it worthwhile spending 32 TC on an item that runs out of uses incredibly quickly. This also gives breathing room to use the Emag more to mess with other systems, such as APCs, Alarms, etc. As you have more charges to use it on.

I forgot to change this during the rebalancing of https://github.com/UristMcStation/UristMcStation/pull/1115

