### PR TITLE
Fixes Bay Skill for Floor Slipping

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -118,10 +118,6 @@
 			if(M.buckled || (MOVING_DELIBERATELY(M) && prob(min(100, 100/(wet/10))) ) )
 				return
 
-			// skillcheck for slipping
-			if(!prob(min(100, M.skill_fail_chance(SKILL_HAULING, 100, SKILL_MAX+1)/(3/wet))))
-				return
-
 			var/slip_dist = 1
 			var/slip_stun = 6
 			var/floor_type = "wet"


### PR DESCRIPTION
Players could setup SKILL_HAULING (Athletics Skill) to a high value such as Mastery to have a pretty decent chance at avoiding slipping.
This just removes the skillcheck, so now everyone slips the same, regardless of jobs assigned skills/character setup.