### PR TITLE
Candles + Lighters Tweak

### DIFF
--- a/code/game/objects/items/weapons/candle.dm
+++ b/code/game/objects/items/weapons/candle.dm
@@ -46,7 +46,7 @@
 	if(!lit)
 		lit = 1
 		visible_message("<span class='notice'>\The [user] lights the [name].</span>")
-		set_light(0.3, 0.1, 4, 2)
+		set_light(0.7, 0.1, 3, 2)
 		START_PROCESSING(SSobj, src)
 
 /obj/item/weapon/flame/candle/Process()

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -12,6 +12,7 @@
 	var/max_fuel = 5
 	var/random_colour = FALSE
 	var/available_colors = list(COLOR_WHITE, COLOR_BLUE_GRAY, COLOR_GREEN_GRAY, COLOR_BOTTLE_GREEN, COLOR_DARK_GRAY, COLOR_RED_GRAY, COLOR_GUNMETAL, COLOR_RED, COLOR_YELLOW, COLOR_CYAN, COLOR_GREEN, COLOR_VIOLET, COLOR_NAVY_BLUE, COLOR_PINK)
+	light_color = "#e09d37"
 
 /obj/item/weapon/flame/lighter/Initialize()
 	. = ..()


### PR DESCRIPTION
- All Lighters now how a orange-y color light, instead of the default white light they emit.
- Candles are brighter, and have slightly more light fall off to compensate for said brightness.

Candles were so muted that you could barely see anything, this gives the chaplain and other people a bit more fun and visibility using them.