### PR TITLE
Haywire Slugs and Ion Pistol Uplink Addition

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -108,3 +108,9 @@
 	name = ".38 EMP Ammo Box (10 rounds)"
 	item_cost = 6
 	path = /obj/item/ammo_magazine/box/emp
+
+/datum/uplink_item/item/ammo/empslug
+	name = "Haywire Slug"
+	desc = "Single 12-Gauge shotgun slug designed to combat rampant synthetics threats."
+	item_cost = 1
+	path = /obj/item/ammo_casing/shotgun/emp

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -152,3 +152,9 @@
 	name = "Explosive Harpoon"
 	item_cost = 16
 	path = /obj/item/weapon/material/harpoon/bomb
+
+/datum/uplink_item/item/visible_weapons/ionpistol
+	name = "Ion Pistol"
+	desc = "Ion rifle in compact form."
+	item_cost = 36	// TC in line with Magnums/Heavy .44's, to reflect it's nuking capability on Synths.
+	path = /obj/item/weapon/gun/energy/ionrifle/small


### PR DESCRIPTION
## Traitor Uplink Additions:

Traitors can now purchase the following items:

- Ion Pistol:
- Haywire Slugs

This grants antagonists some ability to counter synthetic crew + machines, aside from flashes, Ion Pistol is around the same cost as a magnum, as it will do a large sum of damage to IPCs and Robots on hit, though it has a small magazine.