### PR TITLE
Signage Pass

### DIFF
--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -5906,6 +5906,16 @@
 	dir = 4;
 	icon_state = "camera"
 	},
+/obj/structure/sign/directions/urist/trajan{
+	dir = 4;
+	pixel_y = -8;
+	pixel_x = -32
+	},
+/obj/structure/sign/directions/urist/antonine{
+	dir = 4;
+	pixel_y = 8;
+	pixel_x = -32
+	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "kI" = (
@@ -5992,6 +6002,11 @@
 	c_tag = "Hanger Expedition Prep - Port";
 	dir = 8;
 	icon_state = "camera"
+	},
+/obj/structure/sign/directions/urist/antonine{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/hangar)
@@ -21182,6 +21197,15 @@
 /area/maintenance/fourth_deck/fp)
 "ND" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/directions/urist/trajan{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/structure/sign/directions/urist/antonine{
+	dir = 8;
+	pixel_y = 8;
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/logistics/hangar)
 "NF" = (

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -11693,6 +11693,10 @@
 	tag = "icon-corner_white (SOUTHWEST)"
 	},
 /obj/machinery/light,
+/obj/structure/sign/directions/urist/botany{
+	dir = 4;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "atp" = (
@@ -13040,6 +13044,13 @@
 "avI" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/sign/directions/urist/antonine{
+	pixel_x = 32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/urist/trajan{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -15270,6 +15281,20 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/sign/directions/urist/atmos{
+	pixel_x = 32;
+	pixel_y = 8;
+	dir = 1
+	},
+/obj/structure/sign/directions/urist/chapel{
+	pixel_x = 32;
+	dir = 1
+	},
+/obj/structure/sign/directions/urist/toolstorage{
+	pixel_x = 32;
+	pixel_y = -8;
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "aAf" = (
@@ -17268,6 +17293,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/sign/directions/urist/janitor{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "aDH" = (
@@ -18087,6 +18115,20 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
+/obj/structure/sign/directions/urist/botany{
+	pixel_y = -22;
+	dir = 4
+	},
+/obj/structure/sign/directions/urist/eva{
+	pixel_y = -30;
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	icon_state = "direction_eng";
+	pixel_y = -38;
+	tag = "icon-direction_eng (WEST)"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "aFc" = (
@@ -18253,6 +18295,10 @@
 	icon_state = "direction_med";
 	pixel_y = -22;
 	tag = "icon-direction_med (NORTH)"
+	},
+/obj/structure/sign/directions/urist/botany{
+	dir = 1;
+	pixel_y = -30
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -18481,6 +18527,9 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
+/obj/structure/sign/directions/urist/eva{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFw" = (
@@ -18634,6 +18683,10 @@
 	tag = "icon-direction_bridge (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/sign/directions/urist/eva{
+	pixel_y = -38;
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFI" = (
@@ -18657,6 +18710,10 @@
 	tag = "icon-direction_supply (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/sign/directions/urist/toolstorage{
+	pixel_y = -38;
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFJ" = (
@@ -28328,6 +28385,15 @@
 /obj/item/weapon/reagent_containers/food/condiment/small/saltshaker,
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
+"chN" = (
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	icon_state = "direction_eng";
+	pixel_y = -8;
+	tag = "icon-direction_eng (WEST)"
+	},
+/turf/simulated/wall/prepainted,
+/area/civilian/cryo1)
 "csj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -31788,6 +31854,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/civilian/abandonedoffice)
+"wYG" = (
+/obj/effect/paint_stripe/red,
+/obj/structure/sign/directions/urist/botany{
+	pixel_y = 6;
+	dir = 8
+	},
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/checkpoint)
 "xah" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -49423,7 +49497,7 @@ kdu
 azZ
 aze
 aBY
-aux
+chN
 aDG
 aEV
 aGn
@@ -56886,7 +56960,7 @@ pMv
 kBU
 aoC
 mPt
-mPt
+wYG
 aso
 atC
 sPK

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -4668,6 +4668,13 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing/mapped,
+/obj/structure/sign/directions/security{
+	pixel_x = -32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/urist/eva{
+	pixel_x = -32
+	},
 /turf/simulated/open,
 /area/hallway/fore/second_deck)
 "jD" = (
@@ -8657,6 +8664,18 @@
 	c_tag = "Second Deck Fore Hallway - Starboard";
 	dir = 1;
 	icon_state = "camera"
+	},
+/obj/structure/sign/directions/urist/atmos{
+	pixel_y = -40;
+	dir = 8
+	},
+/obj/structure/sign/directions/urist/toolstorage{
+	pixel_y = -24;
+	dir = 8
+	},
+/obj/structure/sign/directions/urist/chapel{
+	pixel_y = -32;
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -16108,6 +16127,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"OP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9;
+	icon_state = "corner_white";
+	tag = "icon-corner_white (NORTHWEST)"
+	},
+/obj/structure/sign/directions/urist/atmos{
+	pixel_x = -32;
+	pixel_y = 8;
+	dir = 8
+	},
+/obj/structure/sign/directions/urist/chapel{
+	pixel_x = -32;
+	dir = 4
+	},
+/obj/structure/sign/directions/urist/toolstorage{
+	pixel_x = -32;
+	pixel_y = -8;
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "OR" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Counselor's Office";
@@ -17044,6 +17088,13 @@
 "Uc" = (
 /turf/simulated/wall/prepainted,
 /area/chapel)
+"Uf" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/directions/urist/chapel{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Ul" = (
 /obj/item/ammo_magazine/c44,
 /obj/structure/closet/secure_closet/nervacap,
@@ -17404,6 +17455,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
+"WA" = (
+/obj/structure/sign/directions/urist/toolstorage{
+	pixel_x = -32;
+	pixel_y = 24;
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "WC" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
@@ -37609,7 +37668,7 @@ Ah
 Ah
 mR
 jh
-hF
+OP
 IT
 VK
 rp
@@ -41852,7 +41911,7 @@ hJ
 hJ
 hJ
 hJ
-pH
+Uf
 LA
 ru
 sm
@@ -42054,7 +42113,7 @@ me
 nd
 BX
 hJ
-iK
+WA
 iK
 ru
 sn


### PR DESCRIPTION
Adds a bunch of new signs to Nerva pointing to various POE, such as the Trajan, Antonine, Atmos, etc based on previously added signs. Tried to keep it neat.

Based on:
https://github.com/UristMcStation/UristMcStation/pull/1118