### PR TITLE
[In-Progress] Adds .22 HUSH Assassin Pistol, .22LR Rifle, Adds .22LR + Hollowpoint Caliber

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -114,3 +114,8 @@
 	desc = "Single 12-Gauge shotgun slug designed to combat rampant synthetics threats."
 	item_cost = 1
 	path = /obj/item/ammo_casing/shotgun/emp
+
+/datum/uplink_item/item/ammo/p10mm_emp
+	name = ".22 pistol magazine (Hollow Point)"
+	item_cost = 6
+	path = /obj/item/ammo_magazine/r22lr/pistol/hollowpoint

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -26,6 +26,12 @@
 	item_cost = 20
 	path = /obj/item/weapon/storage/box/syndie_kit/g9mm
 
+/datum/uplink_item/item/visible_weapons/hush22
+	name = "Hush .22 Assassin Pistol"
+	desc = "An integrally surpressed .22 assassin pistol with hollow point rounds."
+	item_cost = 30
+	path = /obj/item/weapon/gun/projectile/hush22
+
 /datum/uplink_item/item/badassery/money_cannon
 	name = "Modified Money Cannon"
 	item_cost = 48

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -461,14 +461,35 @@
 	max_ammo = 7
 	multiple_sprites = 1
 
-/obj/item/ammo_magazine/22lr
-	name = "magazine (.22LR)"
-	desc = "A commonly used 10-round magazine used for .22LR pistol platforms."
-	icon = 'icons/urist/items/ammo.dmi' // PLACEHOLDER.
-	icon_state = "9x19p" //PLACEHOLDER.
-	caliber = ".22LR"
+/obj/item/ammo_magazine/r22lr/pistol
+	name = "pistol magazine (.22LR)"
+	desc = "A speed loader for revolvers."
+	icon = 'icons/urist/items/ammo.dmi'
+	icon_state = "9mmds"
 	mag_type = MAGAZINE
-	matter = list(MATERIAL_STEEL = 500, MATERIAL_PLASTIC = 300)
+	ammo_type = /obj/item/projectile/bullet/r22lr
+	matter = list(MATERIAL_STEEL = 900)
+	caliber = "22LR"
 	max_ammo = 10
-	multiple_sprites = 1
 
+/obj/item/ammo_magazine/r22lr/riflesmall
+	name = "rifle magazine (.22LR)"
+	desc = "A small 10 round rifle magazine for .22LR based rifles."
+	icon = 'icons/urist/items/ammo.dmi'
+	icon_state = "9mmds"
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/projectile/bullet/r22lr
+	matter = list(MATERIAL_STEEL = 900)
+	caliber = "22LR"
+	max_ammo = 10
+
+/obj/item/ammo_magazine/r22lr/riflesporting
+	name = "sporting rifle magazine (.22LR)"
+	desc = "A sporting magazine designed for .22LR based rifles"
+	icon = 'icons/urist/items/ammo.dmi'
+	icon_state = "9mmds"
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/projectile/bullet/r22lr
+	matter = list(MATERIAL_STEEL = 900)
+	caliber = "22LR"
+	max_ammo = 20

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -460,36 +460,3 @@
 	matter = list(MATERIAL_STEEL = 600)
 	max_ammo = 7
 	multiple_sprites = 1
-
-/obj/item/ammo_magazine/r22lr/pistol
-	name = "pistol magazine (.22LR)"
-	desc = "A speed loader for revolvers."
-	icon = 'icons/urist/items/ammo.dmi'
-	icon_state = "9mmds"
-	mag_type = MAGAZINE
-	ammo_type = /obj/item/projectile/bullet/r22lr
-	matter = list(MATERIAL_STEEL = 900)
-	caliber = "22LR"
-	max_ammo = 10
-
-/obj/item/ammo_magazine/r22lr/riflesmall
-	name = "rifle magazine (.22LR)"
-	desc = "A small 10 round rifle magazine for .22LR based rifles."
-	icon = 'icons/urist/items/ammo.dmi'
-	icon_state = "9mmds"
-	mag_type = MAGAZINE
-	ammo_type = /obj/item/projectile/bullet/r22lr
-	matter = list(MATERIAL_STEEL = 900)
-	caliber = "22LR"
-	max_ammo = 10
-
-/obj/item/ammo_magazine/r22lr/riflesporting
-	name = "sporting rifle magazine (.22LR)"
-	desc = "A sporting magazine designed for .22LR based rifles"
-	icon = 'icons/urist/items/ammo.dmi'
-	icon_state = "9mmds"
-	mag_type = MAGAZINE
-	ammo_type = /obj/item/projectile/bullet/r22lr
-	matter = list(MATERIAL_STEEL = 900)
-	caliber = "22LR"
-	max_ammo = 20

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -460,3 +460,15 @@
 	matter = list(MATERIAL_STEEL = 600)
 	max_ammo = 7
 	multiple_sprites = 1
+
+/obj/item/ammo_magazine/22lr
+	name = "magazine (.22LR)"
+	desc = "A commonly used 10-round magazine used for .22LR pistol platforms."
+	icon = 'icons/urist/items/ammo.dmi' // PLACEHOLDER.
+	icon_state = "9x19p" //PLACEHOLDER.
+	caliber = ".22LR"
+	mag_type = MAGAZINE
+	matter = list(MATERIAL_STEEL = 500, MATERIAL_PLASTIC = 300)
+	max_ammo = 10
+	multiple_sprites = 1
+

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -286,3 +286,9 @@
 	global_icon = "empshell-casing"
 	projectile_type  = /obj/item/projectile/ion
 	matter = list(MATERIAL_STEEL = 260, MATERIAL_URANIUM = 200)
+
+/obj/item/ammo_casing/22lr
+	name = ".22 LR round"
+	desc = "A .22LR bullet casing."
+	caliber = ".22LR"
+	projectile_type = /obj/item/projectile/bullet/pistol/22lr

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -290,11 +290,11 @@
 /obj/item/ammo_casing/r22lr
 	name = ".22LR round"
 	desc = "A .22LR round"
-	caliber = "22lr"
+	caliber = "22LR"
 	projectile_type = /obj/item/projectile/bullet/r22lr
 
 /obj/item/ammo_casing/r22lr
-	name = ".22hp round"
+	name = ".22HP round"
 	desc = "A .22 hollow point round"
-	caliber = "22hp"
+	caliber = "22HP"
 	projectile_type = /obj/item/projectile/bullet/r22lr/r22hp

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -292,3 +292,9 @@
 	desc = "A .22LR round"
 	caliber = "22lr"
 	projectile_type = /obj/item/projectile/bullet/r22lr
+
+/obj/item/ammo_casing/r22lr
+	name = ".22hp round"
+	desc = "A .22 hollow point round"
+	caliber = "22hp"
+	projectile_type = /obj/item/projectile/bullet/r22lr/r22hp

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -287,8 +287,8 @@
 	projectile_type  = /obj/item/projectile/ion
 	matter = list(MATERIAL_STEEL = 260, MATERIAL_URANIUM = 200)
 
-/obj/item/ammo_casing/22lr
-	name = ".22 LR round"
-	desc = "A .22LR bullet casing."
-	caliber = ".22LR"
-	projectile_type = /obj/item/projectile/bullet/pistol/22lr
+/obj/item/ammo_casing/r22lr
+	name = ".22LR round"
+	desc = "A .22LR round"
+	caliber = "22lr"
+	projectile_type = /obj/item/projectile/bullet/r22lr

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -163,6 +163,10 @@
 	embed = 0
 	sharp = 0
 
+/obj/item/projectile/bullet/r22lr //22 Long Rifle (For Rifles and Pistols)
+	damage = 15
+	distance_falloff = 5
+
 //4mm. Tiny, very low damage, does not embed, but has very high penetration. Only to be used for the experimental SMG.
 /obj/item/projectile/bullet/c4mm
 	fire_sound = 'sound/weapons/gunshot/gunshot_4mm.ogg'
@@ -171,11 +175,6 @@
 	armor_penetration = 70
 	embed = 0
 	distance_falloff = 2
-
-/obj/item/projectile/bullet/pistol/22lr
-	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
-	damage = 15
-	distance_fallout = 4
 
 /* shotgun projectiles */
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -167,6 +167,11 @@
 	damage = 15
 	distance_falloff = 5
 
+/obj/item/projectile/bullet/r22lr/r22hp // 22 Hollow Point.
+	damage = 28
+	armor_penetration = 10
+	distance_falloff = 5
+
 //4mm. Tiny, very low damage, does not embed, but has very high penetration. Only to be used for the experimental SMG.
 /obj/item/projectile/bullet/c4mm
 	fire_sound = 'sound/weapons/gunshot/gunshot_4mm.ogg'

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -172,6 +172,11 @@
 	embed = 0
 	distance_falloff = 2
 
+/obj/item/projectile/bullet/pistol/22lr
+	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
+	damage = 15
+	distance_fallout = 4
+
 /* shotgun projectiles */
 
 /obj/item/projectile/bullet/shotgun

--- a/code/modules/urist/items/guns.dm
+++ b/code/modules/urist/items/guns.dm
@@ -920,3 +920,84 @@ the sprite and make my own projectile -Glloyd*/
 	ammo_type = /obj/item/ammo_casing/c9mm
 	max_ammo = 10
 	multiple_sprites = 1
+
+/obj/item/weapon/gun/projectile/sportingrifle // Aways, Etc.
+	item_icons = DEF_URIST_INHANDS
+	name = ".22 sporting rifle"
+	desc = "A lightweight sporting rifle, usually for shooting clay pigeons, or for hunting small game. This is a antiquated design that's remained the same for years."
+	icon = 'icons/urist/items/guns.dmi' // Replace
+	icon_state = "crewpistol" // Replace
+	item_state = "crewpistol" // Replace
+	w_class = 3
+	caliber = "22LR"
+	load_method = MAGAZINE
+	origin_tech = list(TECH_COMBAT = 1)
+	magazine_type = /obj/item/ammo_magazine/r22lr/rifle
+	allowed_magazines = /obj/item/ammo_magazine/r22lr/rifle
+	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg' // Replace
+	one_hand_penalty = 3
+
+	firemodes = list(
+		list(mode_name="semiauto", burst=1, fire_delay=0, one_hand_penalty = 1, move_delay=null, burst_accuracy=null, dispersion=null),
+		list(mode_name="2-round bursts", burst=2, move_delay=6, fire_delay=null, one_hand_penalty = 2, burst_accuracy = list(0,-1,-1,-2,-2), dispersion = list(0.0, 0.6, 0.6)),
+	)
+
+/obj/item/weapon/gun/projectile/hush22
+	item_icons = DEF_URIST_INHANDS
+	name = "hush .22 special"
+	desc = "An integrally surpressed covert pistol, chambered in .22 hollow point. The logo and identifying markers have been manually filed away. "
+	icon = 'icons/urist/items/guns.dmi'
+	icon_state = "crewpistol" // Replace
+	item_state = "crewpistol" // Replace
+	w_class = 1
+	caliber = "22HR"
+	load_method = MAGAZINE
+	origin_tech = list(TECH_COMBAT = 3, TECH_ILLEGAL = 2)
+	magazine_type = /obj/item/ammo_magazine/r22lr/pistol/hollowpoint
+	allowed_magazines = /obj/item/ammo_magazine/r22lr/pistol
+	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
+	one_hand_penalty = 3
+
+/obj/item/ammo_magazine/r22lr/pistol
+	name = "pistol magazine (.22LR)"
+	desc = "A .22LR magazine for a pistol."
+	icon = 'icons/urist/items/ammo.dmi'
+	icon_state = "9mmds" // Replace
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/projectile/bullet/r22lr
+	matter = list(MATERIAL_STEEL = 900)
+	caliber = "22LR"
+	max_ammo = 10
+
+/obj/item/ammo_magazine/r22lr/pistol/hollowpoint
+	name = "pistol magazine (.22HP)"
+	desc = "A .22HP magazine for a pistol."
+	icon = 'icons/urist/items/ammo.dmi'
+	icon_state = "9mmds" // Replace
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/projectile/bullet/r22lr
+	matter = list(MATERIAL_STEEL = 900)
+	caliber = "22HP"
+	max_ammo = 10
+
+/obj/item/ammo_magazine/r22lr/rifle
+	name = "rifle magazine (.22LR)"
+	desc = "A small 10 round rifle magazine for .22LR based rifles."
+	icon = 'icons/urist/items/ammo.dmi'
+	icon_state = "9mmds" // Replace
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/projectile/bullet/r22lr
+	matter = list(MATERIAL_STEEL = 900)
+	caliber = "22LR"
+	max_ammo = 10
+
+/obj/item/ammo_magazine/r22lr/rifle/riflesporting
+	name = "sporting rifle magazine (.22LR)"
+	desc = "A sporting magazine designed for .22LR based rifles"
+	icon = 'icons/urist/items/ammo.dmi'
+	icon_state = "9mmds" // Replace
+	mag_type = MAGAZINE
+	ammo_type = /obj/item/projectile/bullet/r22lr
+	matter = list(MATERIAL_STEEL = 900)
+	caliber = "22LR"
+	max_ammo = 20


### PR DESCRIPTION
# Additions:

### Assassin Pistol 

- Adds the .22 Hush Assassin Pistol - An integrally surpressed pistol for quick dispatching of threats, designed to be a choice in the middle of a stetchkin surpressed pistol, or louder 9mm. **Available for 30TC**
- Adds .22LR calibre, which does low damage, but with a higher rate magazine, can be more of a threat. Printable at a autolathe.
- Adds .22HP (Hollow Point), a uplink-only version that does more damage with minor armour penetration. Unable to be printed at a lathe. **Available for 6 TC (Currently)**

### Sporting Rifle
- Adds the .22LR Sporting Rifle - Which isn't available anywhere yet, but will likely be placed in Aways, or for other uses
- Adds two variants of magazine for the sporting rifle - A 10 round variant and a 25 round rarer variant.
- Selectable in semi, or 2-round burst.


TODO:
- [ ] Add sprites for Assassin Pistol 
- [ ] Add sprites for Sporting Rifle
- [ ] Add sprites for .22LR specific bullets
- [ ] Balancing Pass - Damage + TC