### PR TITLE
Raises TEG max output to 1500kW

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -11,7 +11,7 @@
 	construct_state = /singleton/machine_construction/default/panel_closed
 	maximum_component_parts = list(/obj/item/stock_parts = 16)
 
-	var/max_power = 3000000
+	var/max_power = 1500000
 	var/thermal_efficiency = 0.65
 
 	var/obj/machinery/atmospherics/binary/circulator/circ1

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -11,7 +11,7 @@
 	construct_state = /singleton/machine_construction/default/panel_closed
 	maximum_component_parts = list(/obj/item/stock_parts = 16)
 
-	var/max_power = 500000
+	var/max_power = 3000000
 	var/thermal_efficiency = 0.65
 
 	var/obj/machinery/atmospherics/binary/circulator/circ1


### PR DESCRIPTION
Seeing as a super simple SM setup can get you 1,000-2,000kW... This 500kW limit is insanely dumb.
Raises that to 3,000kW per TEG before side-effects start to kick in. Should give some wriggle room for people who want to push more power without going tooooo ham