### PR TITLE
fixes access/windoors/contract/cycler/tug

### DIFF
--- a/code/datums/item_modifiers/space_suits.dm
+++ b/code/datums/item_modifiers/space_suits.dm
@@ -67,7 +67,7 @@
 		/obj/item/clothing/head/helmet/space = list(
 			SETUP_NAME = "excavation voidsuit helmet",
 			SETUP_ICON_STATE = "rig0-excavation",
-			SETUP_ITEM_STATE = "excavation_helm"
+			SETUP_ITEM_STATE = "excavation-helm"
 		),
 		/obj/item/clothing/suit/space/void = list(
 			SETUP_NAME = "excavation voidsuit",

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -241,6 +241,9 @@
 	else if (src.density)
 		flick(text("[]deny", src.base_state), src)
 
+/obj/machinery/door/window/attack_ai(mob/user as mob)
+	return src.attack_hand(user)
+
 /obj/machinery/door/window/create_electronics(electronics_type = /obj/item/airlock_electronics)
 	electronics = ..()
 	return electronics

--- a/code/game/objects/items/weapons/implants/implantpad.dm
+++ b/code/game/objects/items/weapons/implants/implantpad.dm
@@ -2,7 +2,7 @@
 
 /obj/item/implantpad
 	name = "implant pad"
-	desc = "Used to reprogramm implants."
+	desc = "Used to reprogram implants."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "implantpad-0"
 	item_state = "electronic"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/goose.dm
@@ -84,7 +84,8 @@
 	skull_type = /obj/item/pen/fancy/quill
 
 /mob/living/simple_animal/hostile/retaliate/goose/doctor
-	name = "\improper Dr. Anatidae"
+	name = "Dr. Anatidae"
+	real_name = "Dr. Anatidae"
 	desc = "A large waterfowl, known for its beauty and quick temper when provoked. This one has a nametag, 'Dr. Anatidae'. What an odd Pet.."
 	icon_state = "goose_labcoat"
 	icon_living = "goose_labcoat"

--- a/code/modules/urist/modules/newtrading/contracts/cargo_contracts.dm
+++ b/code/modules/urist/modules/newtrading/contracts/cargo_contracts.dm
@@ -62,13 +62,13 @@
 
 //robotics
 
-/datum/contract/cargo/robotics/durandparts
+/datum/contract/cargo/robotics/heavymechparts
 	name = "Heavy Mech Parts Delivery Contract"
 	wanted_types = list(/obj/item/mech_component/chassis/heavy, /obj/item/mech_component/manipulators/heavy, /obj/item/mech_component/propulsion/heavy, /obj/item/mech_component/sensors/heavy)
 	money = 850
 	rep_points = 2
 
-/datum/contract/cargo/robotics/durandparts/New()
+/datum/contract/cargo/robotics/heavymechparts/New()
 	amount = rand(3,6)
 	desc = "Pirates hit our last shipment of high-tech mech parts, and NanoTrasen Security Forces are worried about future attacks. We need the [GLOB.using_map.station_name] to ship [amount] heavy mech parts at the nearest trading station, as soon as possible. Any parts will do, legs, arms, whatever, we're desparate."
 	..()

--- a/code/modules/urist/modules/newtrading/contracts/cargo_papers.dm
+++ b/code/modules/urist/modules/newtrading/contracts/cargo_papers.dm
@@ -17,8 +17,8 @@
 
 //robotics
 
-/obj/item/paper/contract/nanotrasen/cargo/robotics/durandparts
-	contract_type = /datum/contract/cargo/robotics/durandparts
+/obj/item/paper/contract/nanotrasen/cargo/robotics/heavymechparts
+	contract_type = /datum/contract/cargo/robotics/heavymechparts
 
 /obj/item/paper/contract/nanotrasen/cargo/robotics/lasercannon
 	contract_type = /datum/contract/cargo/robotics/lasercannon

--- a/code/modules/urist/modules/newtrading/trade/trade_items/contracts.dm
+++ b/code/modules/urist/modules/newtrading/trade/trade_items/contracts.dm
@@ -52,9 +52,9 @@
 //robotics
 
 
-/datum/trade_item/contract/ntsec/durandparts
-	name = "Durand Parts Delivery Contract"
-	item_type = /obj/item/paper/contract/nanotrasen/cargo/robotics/durandparts
+/datum/trade_item/contract/ntsec/heavymechparts
+	name = "Heavy Mech Parts Delivery Contract"
+	item_type = /obj/item/paper/contract/nanotrasen/cargo/robotics/heavymechparts
 	category = "ntseccontract"
 
 /datum/trade_item/contract/ntsec/lasercannon

--- a/code/modules/xenoarcheaology/tools/equipment.dm
+++ b/code/modules/xenoarcheaology/tools/equipment.dm
@@ -37,10 +37,10 @@
 	name = "excavation voidsuit helmet"
 	desc = "A sophisticated voidsuit helmet, capable of protecting the wearer from many exotic alien energies."
 	icon_state = "rig0-excavation"
-	item_state = "excavation_helm"
+	item_state = "excavation-helm"
 	item_state_slots = list(
-		slot_l_hand_str = "excavation_helm",
-		slot_r_hand_str = "excavation_helm",
+		slot_l_hand_str = "excavation-helm",
+		slot_r_hand_str = "excavation-helm",
 	)
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -13291,7 +13291,9 @@
 /area/maintenance/fourth_deck/central)
 "xU" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance"
+	name = "Cargo Bay Maintenance";
+	autoset_access = 0;
+	req_access = list(list("ACCESS_CARGO","ACCESS_XENOBIO"))
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -13370,7 +13372,9 @@
 /area/logistics/advwork)
 "xZ" = (
 /obj/machinery/door/airlock/research{
-	name = "Advanced Fabrication Workshop"
+	name = "Advanced Fabrication Workshop";
+	autoset_access = 0;
+	req_access = list(list("ACCESS_CARGO","ACCESS_XENOBIO"))
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -13527,7 +13531,6 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft,
 /obj/machinery/door/window/brigdoor/westright,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
@@ -21963,7 +21966,9 @@
 /area/command/bottom_hallway)
 "TA" = (
 /obj/machinery/door/airlock/glass/mining{
-	name = "Cargo Workshop"
+	name = "Cargo Workshop";
+	autoset_access = 0;
+	req_access = list(list("ACCESS_CARGO","ACCESS_XENOBIO"))
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -24695,7 +24695,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/logistics/uppercargo)
 "aRh" = (
-/obj/vehicle/train/cargo/engine,
+/obj/vehicle/train/cargo/engine{
+	dir = 2
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -30824,7 +30826,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/mining{
-	name = "Delivery Office"
+	name = "Delivery Office";
+	autoset_access = 0;
+	req_access = list("ACCESS_SORTING")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
@@ -51614,7 +51618,7 @@ aGu
 aOH
 vDQ
 aPV
-aRf
+aRh
 aSg
 aRi
 aRi
@@ -52220,7 +52224,7 @@ aMj
 aNw
 aOK
 aPY
-aRh
+aRf
 aSi
 aTi
 aUc

--- a/maps/nerva/obj/nerva_machinery.dm
+++ b/maps/nerva/obj/nerva_machinery.dm
@@ -3,6 +3,7 @@
 	name = "Exploration suit cycler"
 	model_text = "Exploration"
 	req_access = list(access_expedition)
+	available_modifications = list(/singleton/item_modifier/space_suit/explorer)
 	species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
 
 /obj/machinery/suit_storage_unit/explorer


### PR DESCRIPTION
"reprogramm" -> "reprogram"
Excavation helm onmob icon displays correctly
AIs can now toggle windoors
Dr. Anatidae no longer displays 'the' when emoting
Durand contract is now Heavy Mech Parts. It takes heavy mech parts.
Expedition prep suit cycler no longer magically makes invisible suits of different types
Mailing office and R&D are accessible by janitors and scientists respectively
The cargo tug is now properly latched at roundstart