### PR TITLE
RETURN THE BWOINK

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -423,7 +423,7 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 		C.received_irc_pm = world.time
 		C.irc_admin = input["sender"]
 
-		sound_to(C, 'sound/ui/pm-notify.ogg')
+		sound_to(C, 'sound/effects/adminhelp.ogg')
 		to_chat(C, message)
 
 		for(var/client/A as anything in GLOB.admins)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -123,7 +123,7 @@ var/global/list/adminhelp_ignored_words = list("unknown","the","a","an","of","mo
 			if(X.is_afk())
 				admin_number_afk++
 			if(X.get_preference_value(/datum/client_preference/staff/play_adminhelp_ping) == GLOB.PREF_HEAR)
-				sound_to(X, 'sound/ui/pm-notify.ogg')
+				sound_to(X, 'sound/effects/adminhelp.ogg')
 			to_chat(X, msg)
 	//show it to the person adminhelping too
 	to_chat(src, SPAN_CLASS("staff_pm", "PM to-<b>Staff</b> (<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>): [original_msg]"))

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -128,7 +128,7 @@
 	//play the receiving admin the adminhelp sound (if they have them enabled)
 	//non-admins shouldn't be able to disable this
 	if(C.get_preference_value(/datum/client_preference/staff/play_adminhelp_ping) == GLOB.PREF_HEAR)
-		sound_to(C, 'sound/ui/pm-notify.ogg')
+		sound_to(C, 'sound/effects/adminhelp.ogg')
 
 	log_admin("PM: [key_name(src)]->[key_name(C)]: [msg]")
 	adminmsg2adminirc(src, C, html_decode(msg))


### PR DESCRIPTION
RETURNS THE **BWOINK**.

Fuck Bay. Give me my **BWOINK** back.


In all seriousness, the new alert is kinda terrible and _really_ easy to miss if tabbed out. 
I've left the new alert in for staffwarns but PMs really should be attention grabbing.