### PR TITLE
Adds client scanner result output preference + Tweaks

### DIFF
--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -17,6 +17,11 @@
 /obj/item/device/scanner/health/scan(atom/A, mob/user)
 	scan_data = medical_scan_action(A, user, src, mode)
 	playsound(src, 'sound/effects/fastbeep.ogg', 20)
+	if (user.client?.get_preference_value(/datum/client_preference/scan_results_in_window) == GLOB.PREF_YES)
+		show_menu(user)
+		return
+
+	to_chat(user, "<hr>[scan_data]<hr>")
 
 /proc/medical_scan_action(atom/target, mob/living/user, obj/scanner, verbose)
 	if (!user.IsAdvancedToolUser())
@@ -57,9 +62,6 @@
 		return
 
 	. = medical_scan_results(scan_subject, verbose)
-	to_chat(user, "<hr>")
-	to_chat(user, .)
-	to_chat(user, "<hr>")
 
 /proc/medical_scan_results(mob/living/carbon/human/H, verbose)
 	. = list()

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -301,6 +301,12 @@ var/global/list/_client_preferences_by_type
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 	default_value = GLOB.PREF_SHOW
 
+/datum/client_preference/scan_results_in_window
+	description = "Display scanner results in window"
+	key = "SCAN_RESULTS_WINDOWED"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+	default_value = GLOB.PREF_YES
+
 /********************
 * General Staff Preferences *
 ********************/

--- a/code/modules/modular_computers/file_system/programs/generic/scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/scanner.dm
@@ -19,14 +19,17 @@
 	var/scan_file_type = /datum/computer_file/data/text
 	var/list/metadata_buffer = list()
 	var/paper_type
+	/// Whether the scan output is to be posted to the user's chat/scanner window
+	var/post_output = FALSE
 
 /datum/computer_file/program/scanner/proc/connect_scanner()
 	if(!computer)
 		return FALSE
 	var/obj/item/stock_parts/computer/scanner/scanner = computer.get_component(PART_SCANNER)
-	if(scanner && istype(src, scanner.driver_type))
+	if(istype(src, scanner?.driver_type))
 		using_scanner = TRUE
 		scanner.driver = src
+		post_output = scanner.default_post_action
 		return TRUE
 	return FALSE
 
@@ -88,6 +91,10 @@
 			to_chat(usr, "Scan save failed.")
 		return TOPIC_HANDLED
 
+	if(href_list["output"])
+		src.post_output = text2num(href_list["output"])
+		return TOPIC_HANDLED
+
 	if(.)
 		SSnano.update_uis(NM)
 
@@ -105,6 +112,7 @@
 		data["scanner_enabled"] = scanner.enabled
 		data["can_view_scan"] = scanner.can_view_scan
 		data["can_save_scan"] = (scanner.can_save_scan && prog.data_buffer)
+	data["post_output"] = prog.post_output
 	data["using_scanner"] = prog.using_scanner
 	data["check_scanning"] = prog.check_scanning()
 	data["data_buffer"] = digitalPencode2html(prog.data_buffer)

--- a/code/modules/modular_computers/hardware/scanners/scanner.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner.dm
@@ -18,6 +18,8 @@
 	var/can_view_scan = TRUE
 	/// Whether the scan output can be saved to disk.
 	var/can_save_scan = TRUE
+	/// Whether by default this scanner will output results to chat/window
+	var/default_post_action = FALSE
 
 /obj/item/stock_parts/computer/scanner/Destroy()
 	do_before_uninstall()

--- a/code/modules/modular_computers/hardware/scanners/scanner_atmos.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner_atmos.dm
@@ -2,6 +2,7 @@
 	name = "atmospheric scanner module"
 	desc = "An atmospheric scanner module. It can scan the surroundings and report the composition of gases."
 	can_run_scan = 1
+	default_post_action = TRUE
 
 /obj/item/stock_parts/computer/scanner/atmos/can_use_scanner(mob/user, atom/target, proximity = TRUE)
 	if(!..())
@@ -21,20 +22,33 @@
 		SPAN_NOTICE("You run \the [src] over \the [target]."),
 		range = 2
 	)
-	var/data = scan_data(user, target, proximity)
-	if (!data)
-		return
-	if (driver?.using_scanner)
-		driver.data_buffer = html2pencode(data)
-		SSnano.update_uis(driver.NM)
 
-/obj/item/stock_parts/computer/scanner/atmos/proc/scan_data(mob/user, atom/target, proximity = TRUE)
+	var/post_to_window = user.client?.get_preference_value(/datum/client_preference/scan_results_in_window) == GLOB.PREF_YES
+
+	var/data = scan_data(user, target, proximity, !post_to_window)
+	if (!data || !driver?.using_scanner)
+		return
+
+	driver.data_buffer = data //html2pencode(data)
+	SSnano.update_uis(driver.NM)
+
+	if(!driver.post_output)
+		return
+
+	if (post_to_window)
+		var/datum/browser/popup = new(user, "scanner", "[capitalize(name)] scan - [target]", 350, 400)
+		popup.set_content("<hr>[driver.data_buffer]")
+		popup.open()
+	else
+		to_chat(user, "<hr>[driver.data_buffer]<hr>")
+
+/obj/item/stock_parts/computer/scanner/atmos/proc/scan_data(mob/user, atom/target, proximity = TRUE, var/legacy = FALSE)
 	if(!can_use_scanner(user, target, proximity))
 		return 0
 	var/air_contents = target.return_air()
 	if(!air_contents)
 		return 0
-	return atmosanalyzer_scan(target, air_contents)
+	return atmosanalyzer_scan(target, air_contents, legacy)
 
 /obj/item/stock_parts/computer/scanner/atmos/can_use_scanner(mob/user, atom/target, proximity)
 	if (!isobj(target) && !isturf(target))

--- a/code/modules/modular_computers/hardware/scanners/scanner_medical.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner_medical.dm
@@ -1,6 +1,7 @@
 /obj/item/stock_parts/computer/scanner/medical
 	name = "medical scanner module"
 	desc = "A medical scanner module. It can be used to scan patients and display medical information."
+	default_post_action = TRUE
 
 /obj/item/stock_parts/computer/scanner/medical/do_on_afterattack(mob/user, atom/target, proximity)
 	if(!can_use_scanner(user, target, proximity))
@@ -8,6 +9,20 @@
 
 	var/dat = medical_scan_action(target, user, loc, 1)
 
-	if(dat && driver && driver.using_scanner)
-		driver.data_buffer = html2pencode(dat)
-		SSnano.update_uis(driver.NM)
+	playsound(src, 'sound/effects/fastbeep.ogg', 20)
+
+	if(!dat || !driver?.using_scanner)
+		return
+
+	driver.data_buffer = dat	//html2pencode(dat) --Unnecessary conversion? NanoUI accepts html....
+	SSnano.update_uis(driver.NM)
+
+	if (!driver.post_output)
+		return
+
+	if (user.client?.get_preference_value(/datum/client_preference/scan_results_in_window) == GLOB.PREF_YES)
+		var/datum/browser/popup = new(user, "scanner", "[capitalize(name)] scan - [target]", 450, 600)
+		popup.set_content("<hr>[driver.data_buffer]")
+		popup.open()
+	else
+		to_chat(user, "<hr>[driver.data_buffer]<hr>")

--- a/nano/templates/scanner.tmpl
+++ b/nano/templates/scanner.tmpl
@@ -22,6 +22,13 @@
 			{{:helper.link('Perform Scan', null, {'scan' : 1}, data.check_scanning ? null : 'disabled')}}
 			{{:helper.link('Save Scan', null, {'save' : 1}, data.can_save_scan ? null : 'disabled')}}
 		</div>
+		<div class="itemLabel">
+			Notify on output:
+		</div>
+		<div class="itemLabel">
+			{{:helper.link('Enabled', null, {'output': 1}, data.post_output ? 'selected' : null)}}
+			{{:helper.link('Disabled', null, {'output': 0}, data.post_output ? null : 'selected')}}
+		</div>
 	</div>
 	{{if data.can_view_scan}}
 		<h3>Scan Preview:</h3><br>


### PR DESCRIPTION
Bay being Bay have done things half-arsed and left things inconsistent. Currently, performing a scan with a gas analyser will make the scan result appear in a new window rather than posting to chat. But medical scanners will only ever post to chat... This PR rectifies this behaviour to make it consistent. Some players did not like this feature, while others did. So let's make it optional.

- Adds a new client preference `Display scanner results in window`. Scanner results that have the ability to be posted to a new window will be. If disabled, the old legacy behaviour takes effect and everything goes to chat. This defaults to on.
- Removed `html2pencode` conversion in the health and gas PDA scanner code. Not sure why this was ever there, nanoUI is html...
- Added new option to the scanner PDA program; `Notify on output` (I suck at naming things). Always seemed odd to me that PDA scanners required you to open the PDA to see the results. Enabling this option (default on for medical + gas scanners) will have the scan results post to the player's desired output (new window, or chat), rather than only being able to see the results in the program itself. With the exception of the old medical scan proc, that was hardcoded to output to chat for some dumb reason rather than simply returning the data...
- Slight tweaks to the atmospheric scanner proc. Without this, if the client pref is set to output to chat, it's... stupidly large and eats all of chat with huge formatting and unneeded context. This reverts it to post similar output to the chat as it used to before (volume info is new, but can be handy).
- Adds the beep boop noises to the medical scanner on PDAs