### PR TITLE
[Bugfix] Air Control Consoles

### DIFF
--- a/code/game/machinery/air_sensor.dm
+++ b/code/game/machinery/air_sensor.dm
@@ -88,7 +88,7 @@
 	frequency = ATMOS_ENGINE_FREQ
 
 /obj/machinery/air_sensor/dist
-	stock_part_presets = list(/singleton/stock_part_preset/radio/basic_transmitter/air_sensor/engine = 1)
+	stock_part_presets = list(/singleton/stock_part_preset/radio/basic_transmitter/air_sensor/dist = 1)
 
-/singleton/stock_part_preset/radio/basic_transmitter/air_sensor/engine
+/singleton/stock_part_preset/radio/basic_transmitter/air_sensor/dist
 	frequency = ATMOS_DIST_FREQ

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -86,6 +86,7 @@
 		data["frequency"] = "[frequency/10].0"
 	data["input_tag"] = input_tag
 	data["output_tag"] = output_tag
+	data["sensor_name"] = sensor_name
 	data["sensor_tag"] = sensor_tag
 
 	if(input_info)

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -11674,7 +11674,7 @@
 	input_tag = "d4_starboard_chamber_in";
 	name = "Chamber Gas Control";
 	output_tag = "d4_starboard_chamber_out";
-	sensor_tag = "d4_starboard_chamber_sensor"
+	sensor_tag = "d4_starboard_chamber_sensor";
 	sensor_name = "Combustion Chamber"
 	},
 /turf/simulated/floor/reinforced,
@@ -18754,7 +18754,7 @@
 	dir = 2;
 	icon_state = "computer";
 	name = "Atmospheric Sensors";
-	sensor_tag = "hadrian_out"
+	sensor_tag = "hadrian_out";
 	sensor_name = "External Atmosphere"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -21502,7 +21502,7 @@
 	dir = 1;
 	icon_state = "computer";
 	name = "Atmospheric Sensors";
-	sensor_tag = "trajan_out"
+	sensor_tag = "trajan_out";
 	sensor_name = "External Atmosphere"
 	},
 /obj/item/device/radio/intercom{

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -2306,7 +2306,8 @@
 	input_tag = "d4_port_chamber_in";
 	name = "Chamber Gas Control";
 	output_tag = "d4_port_chamber_out";
-	sensor_tag = list("d4_port_chamber_sensor"="Combustion Chamber")
+	sensor_tag = "d4_port_chamber_sensor"
+	sensor_name = "Combustion Chamber"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
@@ -3168,7 +3169,7 @@
 /turf/simulated/floor/tiled,
 /area/antonine_hangar/start)
 "ge" = (
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos/tank{
 	dir = 4;
 	id_tag = "d4_port_chamber_out";
 	internal_pressure_bound = 35000;
@@ -3422,7 +3423,7 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/bdportengine)
 "gI" = (
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos/tank{
 	dir = 1;
 	id_tag = "d4_port_chamber_out";
 	internal_pressure_bound = 35000;
@@ -9985,7 +9986,7 @@
 /area/engineering/bdstarengine)
 "rW" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos/tank{
 	id_tag = "d4_starboard_chamber_out";
 	internal_pressure_bound = 35000;
 	internal_pressure_bound_default = 35000
@@ -10284,7 +10285,7 @@
 	pixel_x = -24
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos/tank{
 	dir = 4;
 	id_tag = "d4_starboard_chamber_out";
 	internal_pressure_bound = 35000;
@@ -11673,7 +11674,8 @@
 	input_tag = "d4_starboard_chamber_in";
 	name = "Chamber Gas Control";
 	output_tag = "d4_starboard_chamber_out";
-	sensor_tag = list("d4_starboard_chamber_sensor"="Combustion Chamber")
+	sensor_tag = "d4_starboard_chamber_sensor"
+	sensor_name = "Combustion Chamber"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/bdstarengine)
@@ -18752,7 +18754,8 @@
 	dir = 2;
 	icon_state = "computer";
 	name = "Atmospheric Sensors";
-	sensor_tag = list("hadrian_out")
+	sensor_tag = "hadrian_out"
+	sensor_name = "External Atmosphere"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hadrian/storage)
@@ -21499,7 +21502,8 @@
 	dir = 1;
 	icon_state = "computer";
 	name = "Atmospheric Sensors";
-	sensor_tag = list("trajan_out")
+	sensor_tag = "trajan_out"
+	sensor_name = "External Atmosphere"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -21297,7 +21297,7 @@
 	name = "Engine Cooling Control";
 	output_tag = "cooling_out";
 	pressure_setting = 100;
-	sensor_tag = "engine_sensor"
+	sensor_tag = "engine_sensor";
 	sensor_name = "Engine Core"
 	},
 /obj/machinery/button/blast_door{

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -15568,7 +15568,7 @@
 /turf/simulated/floor/greengrid/airless,
 /area/engineering/engine)
 "aBI" = (
-/obj/machinery/air_sensor{
+/obj/machinery/air_sensor/engine{
 	id_tag = "engine_sensor"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -21297,7 +21297,8 @@
 	name = "Engine Cooling Control";
 	output_tag = "cooling_out";
 	pressure_setting = 100;
-	sensor_tag = list("engine_sensor"="Engine Core")
+	sensor_tag = "engine_sensor"
+	sensor_name = "Engine Core"
 	},
 /obj/machinery/button/blast_door{
 	desc = "A remote control-switch for the engine charging port.";

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -1366,7 +1366,7 @@
 	input_tag = "fuel_in";
 	name = "Fuel Supply Control";
 	output_tag = "fuel_out";
-	sensor_tag = "fuel_sensor"
+	sensor_tag = "fuel_sensor";
 	sensor_name = "Fuel Tank"
 	},
 /obj/item/device/radio/intercom{
@@ -5077,7 +5077,7 @@
 	input_tag = "d2_c_chamber_in";
 	name = "Chamber Gas Control";
 	output_tag = "d2_c_chamber_out";
-	sensor_tag = "d2_c_chamber_sensor"
+	sensor_tag = "d2_c_chamber_sensor";
 	sensor_name = "Combustion Chamber"
 	},
 /turf/simulated/floor/reinforced,
@@ -10357,7 +10357,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensor_tag = "co2_sensor"
+	sensor_tag = "co2_sensor";
 	sensor_name = "Carbon Dioxide Tank"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -11262,7 +11262,7 @@
 	input_tag = "h2_in";
 	name = "Hydrogen Supply Control";
 	output_tag = "h2_out";
-	sensor_tag = "h2_sensor"
+	sensor_tag = "h2_sensor";
 	sensor_name = "Hydrogen Tank"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -11713,7 +11713,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensor_tag = "n2_sensor"
+	sensor_tag = "n2_sensor";
 	sensor_name = "Nitrogen Tank"
 	},
 /turf/simulated/floor/tiled,
@@ -12027,7 +12027,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensor_tag = "n2o_sensor"
+	sensor_tag = "n2o_sensor";
 	sensor_name = "Nitrous Oxide Tank"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -12539,7 +12539,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensor_tag = "o2_sensor"
+	sensor_tag = "o2_sensor";
 	sensor_name = "Oxygen Tank"
 	},
 /turf/simulated/floor/tiled,

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -912,7 +912,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/prison)
 "co" = (
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 4;
 	external_pressure_bound = 0;
 	external_pressure_bound_default = 0;
@@ -1366,7 +1366,8 @@
 	input_tag = "fuel_in";
 	name = "Fuel Supply Control";
 	output_tag = "fuel_out";
-	sensor_tag = list("fuel_sensor"="Tank")
+	sensor_tag = "fuel_sensor"
+	sensor_name = "Fuel Tank"
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -3576,7 +3577,7 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
 "hu" = (
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos/tank{
 	id_tag = "d2_c_chamber_out";
 	internal_pressure_bound = 35000;
 	internal_pressure_bound_default = 35000
@@ -3828,7 +3829,7 @@
 	pixel_x = -24
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos/tank{
 	dir = 4;
 	id_tag = "d2_c_chamber_out";
 	internal_pressure_bound = 35000;
@@ -5076,7 +5077,8 @@
 	input_tag = "d2_c_chamber_in";
 	name = "Chamber Gas Control";
 	output_tag = "d2_c_chamber_out";
-	sensor_tag = list("d2_c_chamber_sensor"="Combustion Chamber")
+	sensor_tag = "d2_c_chamber_sensor"
+	sensor_name = "Combustion Chamber"
 	},
 /turf/simulated/floor/reinforced,
 /area/engineering/fdengine)
@@ -10355,7 +10357,8 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensor_tag = list("co2_sensor"="Tank")
+	sensor_tag = "co2_sensor"
+	sensor_name = "Carbon Dioxide Tank"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 2;
@@ -10754,7 +10757,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmospherics)
 "vo" = (
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 8;
 	external_pressure_bound = 0;
 	external_pressure_bound_default = 0;
@@ -11259,7 +11262,8 @@
 	input_tag = "h2_in";
 	name = "Hydrogen Supply Control";
 	output_tag = "h2_out";
-	sensor_tag = list("tox_sensor"="Tank")
+	sensor_tag = "h2_sensor"
+	sensor_name = "Hydrogen Tank"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 2;
@@ -11574,7 +11578,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "xd" = (
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 8;
 	external_pressure_bound = 0;
 	external_pressure_bound_default = 0;
@@ -11589,7 +11593,7 @@
 	use_power = 1
 	},
 /obj/machinery/air_sensor{
-	id_tag = "tox_sensor"
+	id_tag = "h2_sensor"
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/engineering/atmospherics)
@@ -11709,7 +11713,8 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensor_tag = list("n2_sensor"="Tank")
+	sensor_tag = "n2_sensor"
+	sensor_name = "Nitrogen Tank"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -11888,7 +11893,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "xJ" = (
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 4;
 	external_pressure_bound = 0;
 	external_pressure_bound_default = 0;
@@ -12022,7 +12027,8 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensor_tag = list("n2o_sensor"="Tank")
+	sensor_tag = "n2o_sensor"
+	sensor_name = "Nitrous Oxide Tank"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 2;
@@ -12267,7 +12273,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
 "yv" = (
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 8;
 	external_pressure_bound = 0;
 	external_pressure_bound_default = 0;
@@ -12533,7 +12539,8 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensor_tag = list("o2_sensor"="Tank")
+	sensor_tag = "o2_sensor"
+	sensor_name = "Oxygen Tank"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmospherics)
@@ -12860,7 +12867,7 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/engineering/atmospherics)
 "zC" = (
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 1;
 	external_pressure_bound = 0;
 	external_pressure_bound_default = 0;

--- a/maps/nerva/nerva_unit_testing.dm
+++ b/maps/nerva/nerva_unit_testing.dm
@@ -3,9 +3,9 @@
 
 	apc_test_exempt_areas = list(
 		/area/space = NO_SCRUBBER|NO_VENT|NO_APC,
-		/area/engineering/bdstarengine = NO_SCRUBBER,
-		/area/engineering/bdportengine = NO_SCRUBBER,
-		/area/engineering/fdengine = NO_SCRUBBER,
+		/area/engineering/bdstarengine = NO_SCRUBBER|NO_VENT,
+		/area/engineering/bdportengine = NO_SCRUBBER|NO_VENT,
+		/area/engineering/fdengine = NO_SCRUBBER|NO_VENT,
 		/area/shuttle/escape_pod1/station = NO_SCRUBBER|NO_VENT,
 		/area/shuttle/escape_pod2/station = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/shuttle/escape_pod3/station = NO_SCRUBBER|NO_VENT|NO_APC,


### PR DESCRIPTION
Bay appears to have changed the way they handle air gas sensors; from utilising an assoc list, to instead using a single dedicated variable for both sensor name & tag. This caused essentially all gas sensors accessed via gas control consoles to be broken.
I have noticed however, that there are some remains of the old assoc list style (See ln:64-71 of `atmo_control.dm`), but the rest of the code + UI (see the settings page for the consoles) seem to be directed to only allowing a single sensor. Currently I've stuck with the 1 single sensor route, but I could edit the UI and such at a later date if we want the ability to have multiple.

I've also fixed a bunch of vents and sensors which weren't using the correct subtype, which meant they were on the incorrect frequencies and inaccessible to the control consoles. (Currently, essentially every output vent in atmospherics is unusable)

This fixes all thruster bay output vents + sensors, Nerva fuel tank output vent + sensor, Trajan + Hadrian external sensors, SM core sensor, all atmospherics sensors + output vents.