### PR TITLE
fixes antag languages, mining masks, safeties mention, icons + rename one door

### DIFF
--- a/code/game/antagonist/outsider/deathsquad.dm
+++ b/code/game/antagonist/outsider/deathsquad.dm
@@ -19,6 +19,8 @@ GLOBAL_DATUM_INIT(deathsquad, /datum/antagonist/deathsquad, new)
 
 	var/deployed = 0
 
+	required_language = LANGUAGE_GALCOM
+
 /datum/antagonist/deathsquad/attempt_spawn()
 	if(..())
 		deployed = 1

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -26,6 +26,8 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 
 	var/reason = ""
 
+	required_language = LANGUAGE_GALCOM
+
 /datum/antagonist/ert/create_default(mob/source)
 	var/mob/living/carbon/human/M = ..()
 	if(istype(M)) M.age = rand(25,45)

--- a/code/game/antagonist/outsider/foundation.dm
+++ b/code/game/antagonist/outsider/foundation.dm
@@ -27,6 +27,8 @@ GLOBAL_DATUM_INIT(foundation_agents, /datum/antagonist/foundation, new)
 	faction = "foundation"
 	id_type = /obj/item/card/id/foundation
 
+	required_language = LANGUAGE_GALCOM
+
 /datum/antagonist/foundation/equip(mob/living/carbon/human/player)
 
 	if(!..())

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -21,6 +21,8 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 
 	base_to_load = /datum/map_template/ruin/antag_spawn/mercenary
 
+	required_language = LANGUAGE_GALCOM
+
 /datum/antagonist/mercenary/create_global_objectives()
 	if(!..())
 		return 0

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -20,6 +20,8 @@ GLOBAL_DATUM_INIT(ninjas, /datum/antagonist/ninja, new)
 	faction = "ninja"
 	base_to_load = /datum/map_template/ruin/antag_spawn/ninja
 
+	required_language = LANGUAGE_GALCOM
+
 /datum/antagonist/ninja/create_objectives(datum/mind/ninja)
 
 	if(!..())

--- a/code/game/antagonist/outsider/paramount.dm
+++ b/code/game/antagonist/outsider/paramount.dm
@@ -16,6 +16,8 @@ GLOBAL_DATUM_INIT(paramounts, /datum/antagonist/paramount, new)
 	id_type = /obj/item/card/id/syndicate
 	faction = "paramount"
 
+	required_language = LANGUAGE_GALCOM
+
 /datum/antagonist/paramount/equip(mob/living/carbon/human/player)
 
 	if(!..())

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -21,6 +21,8 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	faction = "pirate"
 	base_to_load = /datum/map_template/ruin/antag_spawn/heist
 
+	required_language = LANGUAGE_GALCOM
+
 	var/list/raider_uniforms = list(
 		/obj/item/clothing/under/soviet,
 		/obj/item/clothing/under/pirate,

--- a/code/game/antagonist/outsider/vox.dm
+++ b/code/game/antagonist/outsider/vox.dm
@@ -18,6 +18,8 @@ GLOBAL_DATUM_INIT(vox_raiders, /datum/antagonist/vox, new)
 
 	base_to_load = /datum/map_template/ruin/antag_spawn/vox_raider
 
+	required_language = LANGUAGE_GALCOM
+
 
 /datum/antagonist/vox/build_candidate_list(datum/game_mode/mode, ghosts_only)
 	candidates = list()

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -18,6 +18,8 @@ GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 	faction = "wizard"
 	base_to_load = /datum/map_template/ruin/antag_spawn/wizard
 
+	required_language = LANGUAGE_GALCOM
+
 /datum/antagonist/wizard/create_objectives(datum/mind/wizard)
 
 	if(!..())

--- a/code/modules/codex/entries/guns.dm
+++ b/code/modules/codex/entries/guns.dm
@@ -30,8 +30,8 @@
 	if(one_hand_penalty)
 		traits += "It's best fired with two-handed grip."
 
-	if(has_safety)
-		traits += "It has a safety switch. Control-Click it to toggle safety."
+	//if(has_safety)
+	//	traits += "It has a safety switch. Control-Click it to toggle safety."
 
 	if(is_secure_gun())
 		traits += "It's fitted with secure registration chip. Swipe ID on it to register."

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -66,6 +66,7 @@
 
 /obj/item/gun/projectile/revolver/medium
 	name = "revolver"
+	icon = 'icons/obj/guns/revolvers.dmi'
 	icon_state = "medium"
 	safety_icon = "medium_safety"
 	caliber = CALIBER_PISTOL
@@ -78,6 +79,7 @@
 /obj/item/gun/projectile/revolver/holdout
 	name = "holdout revolver"
 	desc = "The al-Maliki & Mosley Partner is a concealed-carry revolver made for people who do not trust automatic pistols any more than the people they're dealing with."
+	icon = 'icons/obj/guns/revolvers.dmi'
 	icon_state = "holdout"
 	item_state = "pen"
 	caliber = CALIBER_PISTOL_SMALL
@@ -108,7 +110,6 @@
 /obj/item/gun/projectile/revolver/webley
 	name = "service revolver"
 	desc = "The A&M W4. A rugged top break revolver produced by al-Maliki & Mosley. Based on the Webley model, with modern improvements. Uses magnum ammo."
-	icon = 'icons/urist/items/guns.dmi'
 	icon_state = "webley"
 	item_state = "webley"
 	item_icons = URIST_ALL_ONMOBS

--- a/code/modules/reagents/Chemistry-Sublimator.dm
+++ b/code/modules/reagents/Chemistry-Sublimator.dm
@@ -41,7 +41,7 @@
 	machine_name = "reagent sublimator"
 	machine_desc = "Sublimators draw reagents from a provided container and converts them into gases."
 
-	var/icon_set = "subliminator"
+	var/icon_set = "sublimator"
 	var/sublimated_units_per_tick = 20
 	var/obj/item/reagent_containers/container
 	var/list/reagent_whitelist //if this is set, the subliminator will only work with the listed reagents

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1038,7 +1038,7 @@
 /obj/item/reagent_containers/food/snacks/plainsteak
 	name = "plain steak"
 	desc = "A piece of unseasoned cooked meat."
-	icon_state = "meatsteak"
+	icon_state = "meatstake"
 	slice_path = /obj/item/reagent_containers/food/snacks/cutlet
 	slices_num = 3
 	filling_color = "#7a3d11"

--- a/code/modules/urist/datums/fabricator_datums.dm
+++ b/code/modules/urist/datums/fabricator_datums.dm
@@ -90,8 +90,8 @@
 	hidden = 1
 	category = "Arms and Ammunition"
 
-/datum/fabricator_recipe/magazine_762_stripper
-	name = "hunting rifle ammo (7.62mm)"
+/datum/fabricator_recipe/magazine_556_stripper
+	name = "hunting rifle ammo (5.56mm)"
 	path = /obj/item/ammo_magazine/rifle/military/stripper
 	category = "Arms and Ammunition"
 

--- a/code/modules/urist/items/clothes/uristclothes.dm
+++ b/code/modules/urist/items/clothes/uristclothes.dm
@@ -713,7 +713,7 @@ Update 26/07/2014 - All generic clothing goes under obj/item/clothing/under/uris
 	name = "blueshield coat"
 	desc = "NT deluxe ripoff. You finally have your own coat."
 	icon_state = "blueshieldcoat"
-	item_state = "det_suit"
+	item_state = "blueshieldcoat"
 	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	allowed = list(/obj/item/gun/energy,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/device/flashlight,/obj/item/melee/telebaton)

--- a/code/modules/urist/items/uristwar2.dm
+++ b/code/modules/urist/items/uristwar2.dm
@@ -344,7 +344,7 @@
 	name = "Red Army overcoat"
 	desc = "An overcaot worn by Soviet soldiers."
 	icon_state = "ru_rmcoat"
-	item_state = "det_suit"
+	item_state = "ru_rmcoat"
 	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	allowed = list(/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/grenade)

--- a/code/modules/urist/modules/resourcetech/tools.dm
+++ b/code/modules/urist/modules/resourcetech/tools.dm
@@ -56,6 +56,7 @@
 //	accuracy = -1
 //	jam_chance = 5
 	fire_sound = 'sound/weapons/gunshot/gunshot_strong.ogg'
+	screen_shake = 1
 
 	var/scoped = 0
 

--- a/maps/away/stations/pirate/pirate_station.dm
+++ b/maps/away/stations/pirate/pirate_station.dm
@@ -56,6 +56,7 @@ var/global/const/access_away_pirate_station = "ACCESS_AWAY_PIRATE_STATION"
 	spawn_cost = 0
 	accessibility_weight = 10
 	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
+	generate_mining_by_z = 1
 
 /obj/effect/shuttle_landmark/nav_piratestation
 	special = TRUE

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -21772,7 +21772,7 @@
 "aMA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
-	name = "First Officer's Quarters"
+	name = "First Officer's Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,


### PR DESCRIPTION
All antags now have Galactic Common in their required languages.
Plain steak, reagent sublimator, revolvers, blueshield coat and Red Army coat icons now display.
Codex won't tell you to ctrl click a safety that doesn't exist anymore.
Hunting rifle fabricator tells you the correct ammo.
Hunting rifle screen shake decreased from 31 to 1. wtf
Hopefully all the maps generate asteroid walls/ore now.
FO office door now named First Officer's Office instead of First Officer's Quarters.