### PR TITLE
disables bay antag map spawning

### DIFF
--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -22,7 +22,7 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 	initial_spawn_target = 7
 	show_objectives_on_creation = 0 //we are not antagonists, we do not need the antagonist shpiel/objectives
 
-	base_to_load = /datum/map_template/ruin/antag_spawn/ert
+//	base_to_load = /datum/map_template/ruin/antag_spawn/ert
 
 	var/reason = ""
 

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -19,7 +19,7 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 
 	faction = "mercenary"
 
-	base_to_load = /datum/map_template/ruin/antag_spawn/mercenary
+//	base_to_load = /datum/map_template/ruin/antag_spawn/mercenary
 
 /datum/antagonist/mercenary/create_global_objectives()
 	if(!..())

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -18,7 +18,7 @@ GLOBAL_DATUM_INIT(ninjas, /datum/antagonist/ninja, new)
 	id_type = /obj/item/card/id/syndicate
 
 	faction = "ninja"
-	base_to_load = /datum/map_template/ruin/antag_spawn/ninja
+//	base_to_load = /datum/map_template/ruin/antag_spawn/ninja
 
 /datum/antagonist/ninja/create_objectives(datum/mind/ninja)
 

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -19,7 +19,7 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	id_type = /obj/item/card/id/syndicate
 
 	faction = "pirate"
-	base_to_load = /datum/map_template/ruin/antag_spawn/heist
+//	base_to_load = /datum/map_template/ruin/antag_spawn/heist
 
 	var/list/raider_uniforms = list(
 		/obj/item/clothing/under/soviet,

--- a/code/game/antagonist/outsider/vox.dm
+++ b/code/game/antagonist/outsider/vox.dm
@@ -16,7 +16,7 @@ GLOBAL_DATUM_INIT(vox_raiders, /datum/antagonist/vox, new)
 
 	id_type = /obj/item/card/id/syndicate
 
-	base_to_load = /datum/map_template/ruin/antag_spawn/vox_raider
+//	base_to_load = /datum/map_template/ruin/antag_spawn/vox_raider
 
 
 /datum/antagonist/vox/build_candidate_list(datum/game_mode/mode, ghosts_only)

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -16,7 +16,7 @@ GLOBAL_DATUM_INIT(wizards, /datum/antagonist/wizard, new)
 	min_player_age = 18
 
 	faction = "wizard"
-	base_to_load = /datum/map_template/ruin/antag_spawn/wizard
+//	base_to_load = /datum/map_template/ruin/antag_spawn/wizard
 
 /datum/antagonist/wizard/create_objectives(datum/mind/wizard)
 


### PR DESCRIPTION
Fixes issues with antag spawning/shuttles. We actually use the admin z, so it makes more sense to keep this stuff there, especially for adminfuckery and events. Less Bay maps to maintain this way too. We will need to update the antag bases on the admin z though. But that's for a future PR.