### PR TITLE
feature: Config-ifies a bunch of Hunger-related values. Balance tweaks.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3637,7 +3637,6 @@
 #include "interface\skin.dmf"
 #include "maps\_map_include.dm"
 #include "maps\_maps.dm"
-#include "maps\away\icarus\icarus_areas.dm"
 #include "maps\deepmaint\deepmaint.dm"
 #include "maps\deepmaint\deepmaint_rooms\template.dm"
 #include "maps\deepmaint\deepmaint_rooms\core\_core_rooms.dm"

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3637,6 +3637,7 @@
 #include "interface\skin.dmf"
 #include "maps\_map_include.dm"
 #include "maps\_maps.dm"
+#include "maps\away\icarus\icarus_areas.dm"
 #include "maps\deepmaint\deepmaint.dm"
 #include "maps\deepmaint\deepmaint_rooms\template.dm"
 #include "maps\deepmaint\deepmaint_rooms\core\_core_rooms.dm"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -467,6 +467,18 @@
 
 	// Can Distortion spread across adjacent station z-levels? NOTE: more CPU-heavy!
 	var/static/bluespace_revenant_radius_zlevel_spread_enabled = TRUE
+
+	// For Equivalent Exchange Hunger: how much does suppression grow per unit of wealth consumed?
+	var/static/bluespace_revenant_wealtheater_suppression_factor = 3
+
+	// For Catabolic Stabilization Hunger: how much does suppression grow per unit of nutrition consumed?
+	var/static/bluespace_revenant_hongry_suppression_factor = 30
+
+	// For Rune Wards Hunger: how much does suppression grow per rune, in fractions of normal growth per decisecond
+	var/static/bluespace_revenant_runewards_suppression_per_ward_factor = 0.2
+
+	// For Rune Wards Hunger: discourages stockpiling/spamming; no more than this much suppression per tick will happen, so more runes is not necessarily more good
+	var/static/bluespace_revenant_runewards_max_suppression_coeff = 2
 	# endif
 
 
@@ -960,6 +972,18 @@
 
 			if ("bluespace_revenant_radius_zlevel_spread_enabled")
 				bluespace_revenant_radius_zlevel_spread_enabled = clamp(text2num(value), FALSE, TRUE)
+
+			if ("bluespace_revenant_wealtheater_suppression_factor")
+				bluespace_revenant_wealtheater_suppression_factor = max(0, text2num(value))
+
+			if ("bluespace_revenant_hongry_suppression_factor")
+				bluespace_revenant_hongry_suppression_factor = max(0, text2num(value))
+
+			if ("bluespace_revenant_runewards_suppression_per_ward_factor")
+				bluespace_revenant_runewards_max_suppression_coeff = max(0, text2num(value))
+
+			if ("bluespace_revenant_runewards_max_suppression_coeff")
+				bluespace_revenant_runewards_max_suppression_coeff = max(0, text2num(value))
 
 			# endif
 

--- a/code/modules/urist/antagonist/revenant/_defines.dm
+++ b/code/modules/urist/antagonist/revenant/_defines.dm
@@ -62,7 +62,7 @@
 // WARNING: these define a 'hidden' variable that in some extremely rare cases might conflict.
 // These leverage a 'do/while FALSE' pattern to create a scope to avoid weird parsing mishaps; it's an old C trick.
 # define BSR_ABORT_IF_UNCONSCIOUS(Trg, Msg) var/mob/living/__LConsc = Trg; if(!istype(__LConsc)) { return FALSE }; if(__LConsc.stat != CONSCIOUS) { to_chat(Trg, Msg); return FALSE };
-# define BSR_ABORT_IF_DEAD(Trg, Msg) var/mob/living/__LAlive = Trg; if(!istype(__LAlive)) { return FALSE }; if(__LAlive.stat != CONSCIOUS) { to_chat(Trg, Msg); return FALSE };
+# define BSR_ABORT_IF_DEAD(Trg, Msg) var/mob/living/__LAlive = Trg; if(!istype(__LAlive)) { return FALSE }; if(__LAlive.stat == DEAD) { to_chat(Trg, Msg); return FALSE };
 
 // Partials to reduce copypasta at the cost of flexibility.
 # define BSR_ABORT_IF_UNCONSCIOUS_PRESET(Trg) BSR_ABORT_IF_UNCONSCIOUS(Trg, "<span class='notice'>You must be conscious to be able to do that!</span>")

--- a/code/modules/urist/antagonist/revenant/archetypes/bluespace.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/bluespace.dm
@@ -407,7 +407,8 @@ Proc needs to be fixed, it fails to locate a dest
 		return
 
 	// Since this is a more stealthable Hunger, this should be fairly inefficient
-	var/suppression_per_unit = BSR_DISTORTION_GROWTH_OVER_DECISECONDS(1, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+	var/suppression_factor = (config?.bluespace_revenant_wealtheater_suppression_factor || 3)
+	var/suppression_per_unit = BSR_DISTORTION_GROWTH_OVER_DECISECONDS(suppression_factor, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
 
 	var/removed = FALSE
 	var/added_suppression = 0

--- a/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
@@ -97,8 +97,8 @@
 
 
 
-/* Simple heal. Does NOT regrow limbs. */
-/mob/proc/bsrevenant_minor_heal()
+/* Big heal. */
+/mob/proc/bsrevenant_incremental_regen()
 	set name = "Fleshmend"
 	set category = "Anomalous Powers"
 	set desc = "Unnatural regeneration. Revive on death, heal wounds/bloodloss otherwise."
@@ -177,7 +177,7 @@
 			var/tox_dmg = L.getToxLoss()
 			if(tox_dmg)
 				L.adjustToxLoss(-tox_dmg)
-				to_chat(L, SPAN_NOTICE("You purge absorbed toxins from your cells (though not your bloodstream)!"))
+				to_chat(L, SPAN_NOTICE("You purge necrotic tissue from your system."))
 
 				if(valid_revenant)
 					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(tox_dmg, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
@@ -202,7 +202,7 @@
 	return !pending
 
 
-/datum/power/revenant/bs_power/minorheal
+/datum/power/revenant/bs_power/fleshmend
 	flavor_tags = list(
 		BSR_FLAVOR_CHIMERA,
 		BSR_FLAVOR_VAMPIRE,
@@ -213,7 +213,7 @@
 	activate_message = "<span class='notice'>You have an uncanny healing factor. You can heal minor damage and even stop bleeding - all at the low low price of just a little bit of damage to the local laws of physics.</span>"
 	name = "Fleshmend"
 	isVerb = TRUE
-	verbpath = /mob/proc/bsrevenant_minor_heal
+	verbpath = /mob/proc/bsrevenant_incremental_regen
 	distortion_threshold = 24000 // 20 mins
 
 

--- a/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
@@ -124,7 +124,7 @@
 
 				// Short-circuit to a return; because reviving is more distortey
 				if(valid_revenant)
-					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(1500, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(6000, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
 					return TRUE
 
 		for(var/obj/item/organ/external/E in H.bad_external_organs)
@@ -158,7 +158,7 @@
 				to_chat(L, SPAN_NOTICE("Your brain itches as you knit its wounds shut."))
 
 				if(valid_revenant)
-					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(brain_dmg*3, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(brain_dmg*30, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
 					return FALSE
 
 		// Clone
@@ -169,7 +169,7 @@
 				to_chat(L, SPAN_NOTICE("You feel your genome rearranging. Somehow."))
 
 				if(valid_revenant)
-					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(clone_dmg, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(clone_dmg*10, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
 					return FALSE
 
 		// Tox
@@ -180,7 +180,7 @@
 				to_chat(L, SPAN_NOTICE("You purge necrotic tissue from your system."))
 
 				if(valid_revenant)
-					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(tox_dmg, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(tox_dmg*25, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
 					return FALSE
 
 		// Brute
@@ -191,7 +191,7 @@
 				to_chat(L, SPAN_NOTICE("You knit your wounds shut."))
 
 				if(valid_revenant)
-					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(brute_dmg, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(brute_dmg*10, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
 					return FALSE
 
 		// Fire left off on purpose

--- a/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
@@ -101,51 +101,103 @@
 /mob/proc/bsrevenant_minor_heal()
 	set name = "Fleshmend"
 	set category = "Anomalous Powers"
-	set desc = "Heal minor damage, stop bleeding. Use multiple times per each wound."
-
-	BSR_ABORT_IF_DEAD_PRESET(src)
+	set desc = "Unnatural regeneration. Revive on death, heal wounds/bloodloss otherwise."
 
 	// if TRUE, we're still waiting for a handler
 	var/pending = TRUE
 
+	var/datum/bluespace_revenant/revenant = src?.mind?.bluespace_revenant
+	var/valid_revenant = istype(revenant)
+
 	var/mob/living/carbon/human/H = src
 
 	if(istype(H))
+		// First things first - if they are dead, revive
 		if(pending)
-			for(var/obj/item/organ/I in H.internal_organs)
-				if(I.damage >= 5)
-					I.damage = max(I.damage - 5, 0)
-					to_chat(H, SPAN_NOTICE("Your [I.name] itches as you knit its wounds shut."))
-					pending = FALSE
-					break
+			if(H.stat == DEAD)
+				H.adjustOxyLoss(-rand(15,20))
+				H.basic_revival()
+				H.visible_message(SPAN_NOTICE("\The [H] shudders violently!"))
+
+				to_chat(H, SPAN_NOTICE("You have revived yourself."))
+				to_chat(H, SPAN_WARNING("By reviving, you have significantly violated the laws of reality!"))
+
+				// Short-circuit to a return; because reviving is more distortey
+				if(valid_revenant)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(1500, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					return TRUE
 
 		for(var/obj/item/organ/external/E in H.bad_external_organs)
 			if(!pending)
 				break
 
-			if((E.status & ORGAN_ARTERY_CUT))
-				to_chat(H, SPAN_NOTICE("You mend the torn artery in your [E.name], stemming the worst of the bleeding."))
-				E.status &= ~ORGAN_ARTERY_CUT
+			if(prob(70))
+				continue
+
+			E.rejuvenate()
+			to_chat(H, SPAN_NOTICE("Your [E.name] itches as you knit its wounds shut."))
+			pending = FALSE
+			break
+
+		if(pending && prob(20))
+			if(H.should_have_organ(BP_HEART) && H.vessel.total_volume < H.species.blood_volume)
+				to_chat(H, SPAN_NOTICE("Your veins seem to swell back with unnaturally restored blood."))
+				H.vessel.add_reagent(/datum/reagent/blood, H.species.blood_volume - H.vessel.total_volume)
+				// Not using restore_blood() because it would double-check the same vars we already checked
+				// H.restore_blood()
 				pending = FALSE
-				break
 
-			for(var/datum/wound/W in E.wounds)
-				if(W.bleeding())
-					W.bleed_timer = 0
-					E.status &= ~ORGAN_BLEEDING
-					to_chat(H, SPAN_NOTICE("You knit together severed veins, stemming the bleeding from your [E.name]."))
-					pending = FALSE
-					break
+	var/mob/living/L = src
 
-			if(E.damage >= 5)
-				to_chat(H, SPAN_NOTICE("Your [E.name] itches as you knit its wounds shut."))
-				pending = FALSE
-				break
+	if(istype(L))
+		// Brain
+		if(pending)
+			var/brain_dmg = L.getBrainLoss()
+			if(brain_dmg)
+				L.adjustBrainLoss(-brain_dmg)
+				to_chat(L, SPAN_NOTICE("Your brain itches as you knit its wounds shut."))
 
-	if(!pending)
-		var/datum/bluespace_revenant/revenant = src?.mind?.bluespace_revenant
-		if(istype(revenant))
-			revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(30, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+				if(valid_revenant)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(brain_dmg*3, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					return FALSE
+
+		// Clone
+		if(pending)
+			var/clone_dmg = L.getCloneLoss()
+			if(clone_dmg)
+				L.adjustCloneLoss(-clone_dmg)
+				to_chat(L, SPAN_NOTICE("You feel your genome rearranging. Somehow."))
+
+				if(valid_revenant)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(clone_dmg, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					return FALSE
+
+		// Tox
+		if(pending)
+			var/tox_dmg = L.getToxLoss()
+			if(tox_dmg)
+				L.adjustToxLoss(-tox_dmg)
+				to_chat(L, SPAN_NOTICE("You purge absorbed toxins from your cells (though not your bloodstream)!"))
+
+				if(valid_revenant)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(tox_dmg, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					return FALSE
+
+		// Brute
+		if(pending)
+			var/brute_dmg = L.getBruteLoss()
+			if(brute_dmg)
+				L.adjustBruteLoss(-brute_dmg)
+				to_chat(L, SPAN_NOTICE("You knit your wounds shut."))
+
+				if(valid_revenant)
+					revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(brute_dmg, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+					return FALSE
+
+		// Fire left off on purpose
+
+	if(!pending && valid_revenant)
+		revenant.total_distortion += BSR_DISTORTION_GROWTH_OVER_SECONDS(300, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
 
 	return !pending
 
@@ -180,7 +232,8 @@
 		return
 
 	// Since this is a more stealthable Hunger, this should be fairly inefficient
-	var/suppression_per_unit = BSR_DISTORTION_GROWTH_OVER_DECISECONDS(10, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+	var/suppression_factor = (config?.bluespace_revenant_hongry_suppression_factor || 30)
+	var/suppression_per_unit = BSR_DISTORTION_GROWTH_OVER_DECISECONDS(suppression_factor, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
 
 	var/removed = FALSE
 	var/added_suppression = 0

--- a/code/modules/urist/antagonist/revenant/archetypes/generic.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/generic.dm
@@ -72,12 +72,10 @@
 	set name = "Unnatural Recovery"
 	set desc = "Removes all stuns"
 
+	BSR_ABORT_IF_DEAD_PRESET(src)
+
 	var/mob/living/carbon/human/C = src
 	if(!istype(C))
-		return
-
-	if(C.stat == DEAD)
-		to_chat(src, SPAN_NOTICE("A bit too late for that now, don't you think?"))
 		return
 
 	// Ling pasta :^)
@@ -101,7 +99,11 @@
 
 /datum/power/revenant/bs_power/unstun
 	flavor_tags = list(
-		BSR_FLAVOR_GENERIC
+		BSR_FLAVOR_CHIMERA,
+		BSR_FLAVOR_VAMPIRE,
+		BSR_FLAVOR_GENERIC,
+		BSR_FLAVOR_FLESH,
+		BSR_FLAVOR_SCIFI
 	)
 	activate_message = ("<span class='notice'>Even when stunned, you can force your body to move normally - at the cost of significant reality slippage.</span>")
 	name = "Unstun"

--- a/code/modules/urist/antagonist/revenant/archetypes/occult.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/occult.dm
@@ -162,8 +162,12 @@
 	if(isnull(src.trackers))
 		src.trackers = list()
 
-	var/suppression_per_ward = BSR_DISTORTION_GROWTH_OVER_DECISECONDS(0.2 * BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
-	var/const/max_suppression_coeff = 1.25 // Discourage stockpiling/spamming
+	var/suppression_per_ward_factor = (config?.bluespace_revenant_runewards_suppression_per_ward_factor || 0.2)
+	var/suppression_per_ward = BSR_DISTORTION_GROWTH_OVER_DECISECONDS(suppression_per_ward_factor * BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DISTORTION_PER_TICK, BSR_DEFAULT_DECISECONDS_PER_TICK)
+
+	// Discourages stockpiling/spamming; no more than this much suppression per tick will happen, so more runes is not necessarily more good
+	var/max_suppression_coeff = (config?.bluespace_revenant_runewards_max_suppression_coeff || 2)
+
 	var/active_wards = 0
 	var/expiring_wards = 0
 

--- a/code/modules/urist/antagonist/revenant/archetypes/vampiric.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/vampiric.dm
@@ -372,7 +372,7 @@
 
 /* FANGS - gives mobs a new unarmed attack that requires head and ignores restraints. */
 /datum/unarmed_attack/bsrevenant_vampbite
-	attack_verb = list("bit", "sank their fangs in")
+	attack_verb = list("bit", "sank /his fangs in")
 	attack_sound = 'sound/weapons/bite.ogg'
 	shredding = 0
 	sharp = 1

--- a/code/modules/urist/antagonist/revenant/archetypes/vampiric.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/vampiric.dm
@@ -372,7 +372,7 @@
 
 /* FANGS - gives mobs a new unarmed attack that requires head and ignores restraints. */
 /datum/unarmed_attack/bsrevenant_vampbite
-	attack_verb = list("bit", "sank his fangs in")
+	attack_verb = list("bit", "sank their fangs in")
 	attack_sound = 'sound/weapons/bite.ogg'
 	shredding = 0
 	sharp = 1
@@ -385,10 +385,6 @@
 	if(!istype(user))
 		return 0
 
-	if(prob(50))
-		// Hack to stop the mobs from ALWAYS biting
-		return 0
-
 	if(user.is_muzzled())
 		return 0
 
@@ -398,6 +394,21 @@
 		return 1
 
 	return 0
+
+
+/datum/unarmed_attack/bsrevenant_vampbite/apply_effects(mob/living/carbon/human/user, mob/living/carbon/human/target, attack_damage, zone)
+	if(target.stat == DEAD)
+		return
+
+	var/armour = target.get_blocked_ratio(zone, DAMAGE_BRUTE, damage = attack_damage)
+
+	if(zone == BP_HEAD && armour < 1 && target.should_have_organ(BP_HEART) && target.vessel.total_volume >= 10)
+		target.apply_effect(5, EFFECT_PAIN, 0)
+		target.visible_message(SPAN_DANGER("[user] sucks on [target]'s neck!"), SPAN_DANGER("You feel your blood getting drained from your body!"))
+		target.vessel.trans_to_mob(user, 10, CHEM_INGEST)
+
+	else
+		. = ..(user, target, attack_damage, zone)
 
 
 /mob/proc/bsrevenant_mutate_fangs()
@@ -424,9 +435,8 @@
 		to_chat(src, "Something has gone wrong with modifying your species; please notify an admin/coder!")
 		return
 
-	// Insert as first to prioritize it
-	curr_species.unarmed_types?.Insert(1, /datum/unarmed_attack/bsrevenant_vampbite)
-	curr_species.unarmed_attacks?.Insert(1, new /datum/unarmed_attack/bsrevenant_vampbite())
+	curr_species.unarmed_types?.Add(/datum/unarmed_attack/bsrevenant_vampbite)
+	curr_species.unarmed_attacks?.Add(new /datum/unarmed_attack/bsrevenant_vampbite())
 
 	H.species = curr_species
 	return TRUE
@@ -442,7 +452,7 @@
 		BSR_FLAVOR_OCCULT,
 		BSR_FLAVOR_DEMONIC
 	)
-	activate_message = "<span class='notice'>You notice your teeth becoming longer, sharper, and thicker. </span>"
+	activate_message = "<span class='notice'>You notice your teeth becoming longer, sharper, and thicker. Aim at humanoids' heads to suck their blood.</span>"
 	name = "Fangs"
 	isVerb = FALSE
 	verbpath = /mob/proc/bsrevenant_mutate_fangs


### PR DESCRIPTION
1. Most Hungers give more Suppression by default now. 
2. Made Vamp fangs actually usable for blood-drinking (aim for the head). 
3. Made regen much more powerful (up to a *full-on revive*) but more expensive and does NOT work on fire wounds (because both vamps and The Thing are weak to fire so it fits).

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->