### PR TITLE
Doubles pull speed; pre-merge gun accuracy; remove added burst fire penalty

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -210,16 +210,6 @@
 	. += move_intent.move_delay
 	. += encumbrance() * (2)
 
-	if(pulling)
-		if(istype(pulling, /obj))
-			var/obj/O = pulling
-			. += clamp(O.w_class, 0, ITEM_SIZE_GARGANTUAN) / 5
-		else if(istype(pulling, /mob))
-			var/mob/M = pulling
-			. += max(0, M.mob_size) / MOB_MEDIUM
-		else
-			. += 1
-
 /mob/proc/encumbrance()
 	. = 0
 	if(pulling)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -388,7 +388,7 @@
 	var/disp_mod = dispersion[min(burst, length(dispersion))]
 	var/stood_still = last_handled
 	//Not keeping gun active will throw off aim (for non-Masters)
-	stood_still = max(user.l_move_time, last_handled)
+	stood_still = min(user.l_move_time, last_handled)
 
 	stood_still = max(0,round((world.time - stood_still)/10) - 1)
 	if(stood_still)
@@ -404,10 +404,6 @@
 	if(dual_wield)
 		acc_mod -= dual_wield_penalty/2
 		disp_mod += dual_wield_penalty*0.5
-
-	if(burst > 1)
-		acc_mod -= 1
-		disp_mod += 0.5
 
 	//accuracy bonus from aiming
 	if (aim_targets && (target in aim_targets))


### PR DESCRIPTION
Everyone told me pull speed was too slow and accuracy was worse and I didn't believe them...

Turns out the pull slowdown was being double-applied and everyone was shooting like they had no skills.

A burst-fire penalty was also removed. It was an adopted skill check that is an unnecessary nerf since burst fire already confers a penalty.