### PR TITLE
Restores body scanner limb damage detail

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -320,9 +320,9 @@
 			if(E["brute_dam"] + E["burn_dam"] == 0)
 				row += "None</td>"
 			if(E["brute_dam"])
-				row += "<span style='font-weight: bold; color: [COLOR_MEDICAL_BRUTE]'>Damaged</span><br>"
+				row += "<span style='font-weight: bold; color: [COLOR_MEDICAL_BRUTE]'>[get_severity(E["brute_dam"])] trauma ([E["brute_dam"]])</span><br>"
 			if(E["burn_dam"])
-				row += "<span style='font-weight: bold; color: [COLOR_MEDICAL_BURN]'>Burned</span></td>"
+				row += "<span style='font-weight: bold; color: [COLOR_MEDICAL_BURN]'>[get_severity(E["burn_dam"])] burns ([E["burn_dam"]])</span></td>"
 			row += "<td>"
 			row += "<span>[english_list(E["scan_results"], nothing_text="&nbsp;")]</span>"
 			row += "</td>"


### PR DESCRIPTION
Lost feature from pre-baymerge. Body scanners now provide the same severity readings as health scanners along with the actual damage numbers.
![image](https://github.com/UristMcStation/UristMcStation/assets/16085952/bdea6d34-417d-4a08-870f-29ea0b074e8d)
