### PR TITLE
Bugfixes: cult armor, sunglasses, SMG jamming, and bonus cash bag add

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -402,25 +402,31 @@
 	visible_message(SPAN_WARNING("\The [src] disappears with a flash of red light, and a set of armor appears on \the [user]."), SPAN_WARNING("You are blinded by the flash of red light. After you're able to see again, you see that you are now wearing a set of armor."))
 
 	var/obj/O = user.get_equipped_item(slot_head) // This will most likely kill you if you are wearing a spacesuit, and it's 100% intended
-	if(O && !istype(O, /obj/item/clothing/head/culthood) && user.unEquip(O))
-		user.equip_to_slot_or_del(new /obj/item/clothing/head/culthood/alt(user), slot_head)
+	if(!istype(O, /obj/item/clothing/head/culthood))
+		user.unEquip(O)
+		user.equip_to_slot_or_store_or_drop(new /obj/item/clothing/head/culthood/alt(user), slot_head)
+
 	O = user.get_equipped_item(slot_wear_suit)
-	if(O && !istype(O, /obj/item/clothing/suit/cultrobes) && user.unEquip(O))
-		user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)
+	if(!istype(O, /obj/item/clothing/suit/cultrobes))
+		user.unEquip(O)
+		user.equip_to_slot_or_store_or_drop(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)
 	O = user.get_equipped_item(slot_shoes)
-	if(O && !istype(O, /obj/item/clothing/shoes/cult) && user.unEquip(O))
-		user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)
+	if(!istype(O, /obj/item/clothing/shoes/cult))
+		user.unEquip(O)
+		user.equip_to_slot_or_store_or_drop(new /obj/item/clothing/shoes/cult(user), slot_shoes)
 
 	O = user.get_equipped_item(slot_back)
-	if(istype(O, /obj/item/storage) && !istype(O, /obj/item/storage/backpack/cultpack) && user.unEquip(O)) // We don't want to make the vox drop their nitrogen tank, though
+	if(istype(O, /obj/item/storage) && !istype(O, /obj/item/storage/backpack/cultpack)) // We don't want to make the vox drop their nitrogen tank, though
 		var/obj/item/storage/backpack/cultpack/C = new /obj/item/storage/backpack/cultpack(user)
-		user.equip_to_slot_or_del(C, slot_back)
+		user.unEquip(O)
+		user.equip_to_slot_or_store_or_drop(C, slot_back)
 		if(C)
 			for(var/obj/item/I in O)
 				I.forceMove(C)
 	else if(!O)
 		var/obj/item/storage/backpack/cultpack/C = new /obj/item/storage/backpack/cultpack(user)
-		user.equip_to_slot_or_del(C, slot_back)
+		user.unEquip(O)
+		user.equip_to_slot_or_store_or_drop(C, slot_back)
 
 	user.update_icons()
 

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -103,4 +103,4 @@
 	max_storage_space = 100
 	max_w_class = ITEM_SIZE_HUGE
 	w_class = ITEM_SIZE_SMALL
-	can_hold = list(/obj/item/material/coin,/obj/item/spacecash)
+	can_hold = list(/obj/item/material/coin,/obj/item/spacecash,/obj/item/stack/material/gold,/obj/item/stack/material/silver)

--- a/code/modules/clothing/glasses/sunglasses.dm
+++ b/code/modules/clothing/glasses/sunglasses.dm
@@ -4,7 +4,7 @@
 	icon_state = "sun"
 	item_state = "sunglasses"
 	darkness_view = -1
-	flash_protection = FLASH_PROTECTION_MINOR
+	flash_protection = FLASH_PROTECTION_MODERATE
 
 
 /obj/item/clothing/glasses/sunglasses/prescription

--- a/code/modules/urist/items/guns.dm
+++ b/code/modules/urist/items/guns.dm
@@ -810,6 +810,7 @@ the sprite and make my own projectile -Glloyd*/
 	allowed_magazines = /obj/item/ammo_magazine/hi2521smg9mm
 	one_hand_penalty = 3
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
+	jam_chance = 0
 
 	firemodes = list(
 		list(mode_name="semiauto", burst=1, fire_delay=0, one_hand_penalty = 1, move_delay=null, burst_accuracy=null, dispersion=null),


### PR DESCRIPTION
- You should now always be getting cult robes when you want them. Previously you only got them when the robes were replacing an item.
- HI-2521 SMG no longer jams.
- Normal sunglasses protect you from being flashed. Like they used to.
- Cash bags can additionally hold gold and silver bars.