### PR TITLE
Wizard: Summon Random Stuff spell

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3254,6 +3254,7 @@
 #include "code\modules\turbolift\turbolift_turfs.dm"
 #include "code\modules\urist\_helpers.dm"
 #include "code\modules\urist\random.dm"
+#include "code\modules\urist\spells.dm"
 #include "code\modules\urist\_maps\templates.dm"
 #include "code\modules\urist\admin\admin_poll.dm"
 #include "code\modules\urist\admin\verbs.dm"

--- a/code/modules/spells/spellbook/spatial.dm
+++ b/code/modules/spells/spellbook/spatial.dm
@@ -26,6 +26,7 @@
 				/spell/aoe_turf/conjure/forcewall = 			1,
 				/spell/aoe_turf/smoke = 						1,
 				/spell/aoe_turf/conjure/summon/bats = 			3,
+				/spell/aoe_turf/conjure/summonrandomstuff =		1,
 				/spell/noclothes = 								1,
 				/obj/item/dice/d20/cursed = 				1,
 				/obj/structure/closet/wizard/scrying = 			2,

--- a/code/modules/spells/spellbook/standard.dm
+++ b/code/modules/spells/spellbook/standard.dm
@@ -26,6 +26,7 @@
 							/spell/targeted/heal_target = 						1,
 							/spell/aoe_turf/knock = 							1,
 							/spell/noclothes = 									2,
+							/spell/aoe_turf/conjure/summonrandomstuff =			1,
 							/obj/item/gun/energy/staff/focus = 			1,
 							/obj/structure/closet/wizard/souls = 				1,
 							/obj/item/gun/energy/staff/animate = 		1,

--- a/code/modules/urist/items/miscitems.dm
+++ b/code/modules/urist/items/miscitems.dm
@@ -608,28 +608,28 @@
 	icon = 'icons/urist/items/misc.dmi'
 	icon_state = "oldcoin4"
 	default_material = MATERIAL_COPPER
-	
+
 /obj/item/material/coin/challenge/loot/plat
 	name = "\improper old platinum coin"
 	desc = "A platinum coin stamped with the image of a king."
 	icon = 'icons/urist/items/misc.dmi'
 	icon_state = "oldcoin1"
 	default_material = MATERIAL_PLATINUM
-	
+
 /obj/item/material/coin/challenge/loot/gold
 	name = "\improper old gold coin"
 	desc = "A gold coin stamped with the image of a castle."
 	icon = 'icons/urist/items/misc.dmi'
 	icon_state = "oldcoin2"
 	default_material = MATERIAL_GOLD
-	
+
 /obj/item/material/coin/challenge/loot/silver
 	name = "\improper old silver coin"
 	desc = "A silver coin stamped with the image of a dragon."
 	icon = 'icons/urist/items/misc.dmi'
 	icon_state = "oldcoin3"
 	default_material = MATERIAL_SILVER
-	
+
 /obj/item/treasure/gem
 	name = "astonishing amethyst"
 	desc = "An amethyst crystal with the deepest purple."
@@ -766,9 +766,78 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "gift3"
 
-/obj/random/treasure/plush/spawn_choices()
+/obj/random/treasure/portrait/spawn_choices()
 	return list(/obj/item/treasure/portrait,
 				/obj/item/treasure/portrait/queen,
 				/obj/item/treasure/portrait/knight,
 				/obj/item/treasure/portrait/jester,
 				/obj/item/treasure/portrait/squire)
+
+/obj/random/cuteanimal
+	name = "random cute animal"
+	desc = "This is a random cute animal."
+	icon = 'icons/mob/simple_animal/critter.dmi'
+	icon_state = "lizard"
+
+/obj/random/cuteanimal/spawn_choices()
+	return list(/mob/living/simple_animal/passive/corgi/puppy,
+				/mob/living/simple_animal/passive/cat/kitten,
+				/mob/living/simple_animal/passive/lizard
+				)
+
+/obj/random/pen
+	name = "random pen"
+	desc = "This is a random pen."
+	icon = 'icons/obj/bureaucracy.dmi'
+	icon_state = "pen"
+
+/obj/random/pen/spawn_choices()
+	return list(/obj/item/pen,
+				/obj/item/pen/blue,
+				/obj/item/pen/red,
+				/obj/item/pen/fancy,
+				/obj/item/pen/fancy/quill,
+				/obj/item/pen/green,
+				/obj/item/pen/multi,
+				/obj/item/pen/retractable
+				)
+
+/obj/random/utensil
+	name = "random utensil"
+	desc = "This is a random utensil."
+	icon = 'icons/obj/kitchen.dmi'
+	icon_state = "fork"
+
+/obj/random/utensil/spawn_choices()
+	return list(/obj/item/material/kitchen/utensil/fork,
+				/obj/item/material/kitchen/utensil/spoon,
+				/obj/item/material/kitchen/utensil/spork
+				)
+
+/obj/random/officetoy
+	name = "random office toy"
+	desc = "This is a random toy for eggheads."
+	icon = 'icons/obj/toy.dmi'
+	icon_state = "fan"
+
+/obj/random/officetoy/spawn_choices()
+	return list(/obj/item/toy/desk/fan,
+				/obj/item/toy/desk/officetoy,
+				/obj/item/toy/desk/dippingbird,
+				/obj/item/toy/desk/newtoncradle
+				)
+
+/obj/random/dice
+	name = "random dice"
+	desc = "These are random dice."
+	icon = 'icons/obj/dice.dmi'
+	icon_state = "d66"
+
+/obj/random/dice/spawn_choices()
+	return list(/obj/item/dice,
+				/obj/item/dice/d10,
+				/obj/item/dice/d100,
+				/obj/item/dice/d12,
+				/obj/item/dice/d4,
+				/obj/item/dice/d8
+				)

--- a/code/modules/urist/spells.dm
+++ b/code/modules/urist/spells.dm
@@ -1,0 +1,52 @@
+/spell/aoe_turf/conjure/summonrandomstuff
+	name = "Summon Random Items"
+	desc = "This spell summons random, mostly useless items."
+	invocation_type = SpI_EMOTE
+	invocation = "does some jazz hands!"
+	summon_type = list(
+		/obj/item/reagent_containers/food/snacks/sliceable/cheesewheel/fresh,
+		/obj/item/reagent_containers/food/snacks/cheesewedge/fresh,
+		/obj/item/reagent_containers/food/drinks/jar,
+		/obj/item/gun/launcher/foam/revolver,
+		/obj/item/reagent_containers/food/condiment/small/saltshaker,
+		/obj/random/action_figure,
+		/obj/random/toy,
+		/obj/random/soap,
+		/obj/random/pen,
+		/obj/random/cuteanimal,
+		/obj/random/utensil,
+		/obj/random/tool,
+		/obj/random/plushie,
+		/obj/random/snack,
+		/obj/random/mre/dessert,
+		/obj/random/coin,
+		/obj/item/reagent_containers/food/snacks/checker,
+		/obj/item/material/ashtray,
+		/obj/random/dice,
+		/obj/random/single/playing_cards,
+		/obj/random/single/cola,
+		/obj/item/mirror,
+		/obj/item/clothing/accessory/kneepads,
+		/obj/item/book/manual/security_space_law/urist,
+		/obj/random/smokes,
+		/obj/item/papercrafts/airplane,
+		/obj/item/stamp/denied,
+		/obj/item/clothing/gloves/insulated/cheap,
+		/obj/random/drinkbottle,
+		/obj/item/caution,
+		/obj/item/stool/urist/bar
+		)
+	summon_amt = 5
+	range = 3
+	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 0, Sp_POWER = 3)
+	hud_state = "friendly"
+
+/spell/aoe_turf/conjure/summonrandomstuff/empower_spell()
+	if(!..())
+		return 0
+
+	if(spell_levels[Sp_POWER]%2 == 1)
+		summon_amt += 5
+		range += 1
+
+	return "The spell [src] now summons more items at a greater distance."


### PR DESCRIPTION
I did this as a dumb joke for Cara.

Adds a spell that summons random, mostly junk items (like cheese, and jars, and dice). A few possible spawns have some limited utility, but it's mostly a joke slot. Standard and Spatial books can pick it.
Also adds a few more random spawners to improve said spell.
Also fixes a bug with a spawner I found on the way.