### PR TITLE
Holomaps + Nerva tweaks

### DIFF
--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -1143,7 +1143,11 @@
 	icon_state = "handrail"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 9;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "cH" = (
 /obj/structure/table/steel_reinforced,
@@ -1156,7 +1160,11 @@
 	},
 /obj/structure/handrail,
 /obj/random_multi/single_item/boombox,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "cI" = (
 /obj/structure/cable/cyan{
@@ -1164,7 +1172,11 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable/preset/nerva/shuttle,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "cJ" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -1631,7 +1643,11 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 9;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "dv" = (
 /obj/structure/cable/cyan{
@@ -1645,10 +1661,14 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 1;
+	icon_state = "techfloor_corners"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "dw" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "dx" = (
 /obj/machinery/power/terminal{
@@ -1667,7 +1687,11 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "dy" = (
 /obj/effect/paint/hull,
@@ -1685,15 +1709,27 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/computer/ship/helm,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue/three_quarters{
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "dA" = (
 /obj/machinery/computer/shuttle_control/explore/trajan,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "dB" = (
 /obj/machinery/computer/ship/engines,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue/three_quarters{
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "dC" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -2067,7 +2103,11 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 10;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "eg" = (
 /obj/structure/cable/cyan{
@@ -2080,7 +2120,8 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "eh" = (
 /obj/machinery/recharge_station,
@@ -2089,7 +2130,8 @@
 	dir = 1;
 	icon_state = "camera"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "ei" = (
 /obj/machinery/power/port_gen/pacman{
@@ -2097,7 +2139,11 @@
 	sheets = 50
 	},
 /obj/structure/cable/yellow,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 6;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "ej" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -2110,7 +2156,11 @@
 /obj/item/storage/box/survivalkit,
 /obj/structure/table/standard,
 /obj/item/device/binoculars,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "ek" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -2118,12 +2168,16 @@
 	dir = 1;
 	icon_state = "shuttle_chair_preview"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "el" = (
 /obj/effect/overmap/visitable/ship/landable/trajan,
 /obj/machinery/hologram/holopad/longrange,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 4;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "em" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2429,7 +2483,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/power)
 "eT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2449,7 +2503,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "eU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2461,7 +2519,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "eV" = (
 /obj/structure/bed/chair/shuttle/blue,
@@ -2470,7 +2528,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "eW" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2629,16 +2687,24 @@
 	dir = 4;
 	icon_state = "shuttle_chair_preview"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/blue{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain/blue{
+	icon_state = "spline_plain";
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
 "fm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2654,9 +2720,6 @@
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/main)
 "fn" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2674,6 +2737,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/main)
 "fo" = (
@@ -2691,6 +2758,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/main)
 "fp" = (
@@ -2711,6 +2779,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/fadeblue/full,
 /turf/simulated/floor/tiled,
 /area/exploration_shuttle/cockpit)
 "fq" = (
@@ -2737,7 +2806,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue/three_quarters,
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "fr" = (
 /obj/machinery/power/apc{
@@ -2755,7 +2825,11 @@
 	dir = 1;
 	icon_state = "camera"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "fs" = (
 /obj/machinery/computer/ship/sensors{
@@ -2766,7 +2840,11 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "ft" = (
 /obj/machinery/light{
@@ -3088,7 +3166,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/blue{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
 "fX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3122,7 +3204,15 @@
 /obj/random/medical,
 /obj/structure/table/steel_reinforced,
 /obj/item/bodybag/cryobag,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/paleblue{
+	icon_state = "spline_plain";
+	dir = 9
+	},
+/obj/effect/floor_decal/spline/plain/paleblue{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/exploration_shuttle/main)
 "ga" = (
 /obj/effect/paint/hull,
@@ -3258,7 +3348,11 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/blue{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
 "gn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3272,7 +3366,15 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/paleblue{
+	icon_state = "spline_plain";
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/plain/paleblue{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
 /area/exploration_shuttle/main)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3281,7 +3383,11 @@
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 9;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "gq" = (
 /obj/machinery/light/small{
@@ -3294,7 +3400,11 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "gr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -3312,15 +3422,23 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "gs" = (
 /obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "gt" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -3527,7 +3645,11 @@
 	dir = 4;
 	icon_state = "camera"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/blue{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
 "gT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3613,7 +3735,7 @@
 	dir = 9;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/exploration_shuttle/atmos)
 "gX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3628,7 +3750,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "gY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3640,7 +3766,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "gZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -3653,18 +3779,22 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "ha" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "hb" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -3856,7 +3986,11 @@
 	name = "west bump";
 	pixel_x = -25
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/blue{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
 "hu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3911,7 +4045,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor{
+	dir = 10;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "hz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -3927,7 +4065,8 @@
 	dir = 1;
 	icon_state = "camera"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "hA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
@@ -3940,14 +4079,19 @@
 	dir = 1;
 	icon_state = "handrail"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "hB" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
 	},
+/obj/effect/floor_decal/techfloor{
+	dir = 6;
+	icon_state = "techfloor_edges"
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/atmos)
 "hD" = (
 /obj/structure/table/steel_reinforced,
@@ -4311,24 +4455,35 @@
 /area/exploration_shuttle/main)
 "iq" = (
 /obj/structure/handrail,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "ir" = (
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 1
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "is" = (
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 1
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "it" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
@@ -4341,14 +4496,23 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "iu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/freezer/rations,
 /obj/item/material/knife/kitchen/cleaver,
 /obj/item/beartrap,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "iv" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -4401,7 +4565,7 @@
 	dir = 8;
 	icon_state = "corner_white_three_quarters"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "iC" = (
 /obj/structure/table/glass,
@@ -4411,7 +4575,7 @@
 /obj/effect/floor_decal/corner/red/three_quarters{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "iD" = (
 /obj/structure/disposalpipe/segment,
@@ -4634,7 +4798,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "iZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -4646,7 +4814,7 @@
 	dir = 10;
 	icon_state = "intact-supply"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "ja" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -4654,7 +4822,7 @@
 	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4662,13 +4830,17 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/floodlight,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "jc" = (
+/obj/item/roller_bed,
+/obj/item/roller_bed,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/roller_bed,
-/obj/item/roller_bed,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "jd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4793,7 +4965,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "jm" = (
 /obj/structure/bed/chair/office/light{
@@ -4802,7 +4974,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "jn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -5142,18 +5314,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "jQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "jR" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "jS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "jT" = (
 /turf/simulated/floor/tiled/dark/monotile,
@@ -5277,7 +5453,7 @@
 	icon_state = "computer";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "kd" = (
 /obj/structure/cable{
@@ -5300,7 +5476,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "ke" = (
 /obj/structure/cable{
@@ -5761,26 +5937,34 @@
 /obj/machinery/conveyor_switch{
 	id = "Trajanmain"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "kM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "kN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "kO" = (
 /obj/structure/handrail{
 	dir = 8;
 	icon_state = "handrail"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "kP" = (
 /obj/machinery/camera/network/fourth_deck{
@@ -5815,7 +5999,7 @@
 /obj/structure/table/glass,
 /obj/item/device/camera,
 /obj/item/device/camera_film,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "kT" = (
 /obj/structure/cable{
@@ -5829,7 +6013,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "kU" = (
 /obj/machinery/camera/network/security{
@@ -6005,6 +6189,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "lq" = (
@@ -6111,7 +6299,11 @@
 /obj/machinery/conveyor{
 	id = "Trajanmain"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "lB" = (
 /obj/machinery/light/small{
@@ -6119,7 +6311,11 @@
 	luminosity = 2
 	},
 /obj/machinery/conveyor,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "lC" = (
 /obj/machinery/light/spot{
@@ -6146,6 +6342,7 @@
 	pixel_y = 25
 	},
 /obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "lF" = (
@@ -6155,9 +6352,6 @@
 /area/logistics/genprep)
 "lG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	dir = 2;
@@ -6168,10 +6362,17 @@
 /obj/machinery/camera/network/fourth_deck{
 	c_tag = "General Expedition Prep Port"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor{
+	icon_state = "techfloor_edges";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "lH" = (
 /obj/machinery/suit_storage_unit/explorer,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "lI" = (
@@ -6416,6 +6617,7 @@
 	dir = 1;
 	icon_state = "corner_white"
 	},
+/obj/machinery/ship_map,
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "mh" = (
@@ -6682,27 +6884,34 @@
 /obj/machinery/conveyor{
 	id = "Trajanmain"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "mw" = (
 /obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/spline/plain/black,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "mx" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
 /obj/machinery/camera/network/trajan{
 	c_tag = "Trajan Cargo Bay";
 	dir = 1;
 	icon_state = "camera"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "my" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/ore_box,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "mz" = (
 /obj/machinery/disposal/deliveryChute{
@@ -6710,7 +6919,12 @@
 	name = "disposal inlet"
 	},
 /obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
 "mA" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -6739,16 +6953,20 @@
 /area/logistics/genprep)
 "mE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "mF" = (
 /obj/machinery/suit_storage_unit/explorer,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
@@ -7126,6 +7344,10 @@
 	dir = 1;
 	icon_state = "camera"
 	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/centralfourth)
 "nh" = (
@@ -7466,6 +7688,7 @@
 	pixel_y = 0;
 	req_access = list("ACCESS_EXPEDITION")
 	},
+/obj/effect/floor_decal/spline/plain/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "nD" = (
@@ -7476,6 +7699,22 @@
 "nE" = (
 /turf/simulated/wall/prepainted,
 /area/civilian/freezer)
+"nG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/logistics/genprep)
 "nH" = (
 /obj/structure/closet,
 /obj/structure/cable,
@@ -7498,6 +7737,12 @@
 /obj/machinery/light/small/red,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
+"nJ" = (
+/obj/machinery/mining/brace,
+/obj/effect/floor_decal/spline/plain/yellow,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/logistics/genprep)
 "nK" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/trash/candy,
@@ -7848,7 +8093,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor{
+	dir = 9;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "ou" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -7861,7 +8110,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "ov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7877,7 +8130,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7893,25 +8150,33 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor{
+	dir = 1;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "ox" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	icon_state = "intact-supply"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "oy" = (
 /obj/machinery/suit_storage_unit/pilot,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "oz" = (
@@ -8344,28 +8609,38 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "pr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1;
 	icon_state = "map_scrubber_on"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "ps" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor/corner{
+	icon_state = "techfloor_corners";
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "pt" = (
 /obj/machinery/suit_cycler/exploration,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "pu" = (
@@ -9067,6 +9342,8 @@
 /obj/item/net_shell,
 /obj/item/net_shell,
 /obj/item/net_shell,
+/obj/item/gun/projectile/flare,
+/obj/item/storage/box/ammo/flashshells,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "qz" = (
@@ -9076,6 +9353,9 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
@@ -9853,15 +10133,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "rF" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/high;
 	dir = 2;
 	name = "south bump";
 	pixel_y = -24
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
@@ -9871,6 +10156,9 @@
 /obj/item/tank/jetpack/oxygen,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/genprep)
 "rH" = (
@@ -10723,9 +11011,6 @@
 	dir = 4;
 	icon_state = "shuttle_chair_preview"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -10736,7 +11021,14 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/blue{
+	icon_state = "spline_plain";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
 "td" = (
 /obj/machinery/door/airlock/maintenance{
@@ -11394,6 +11686,10 @@
 	icon_state = "map-supply"
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "uy" = (
@@ -12161,6 +12457,21 @@
 "vT" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"vU" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/logistics/hangar)
 "vV" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4;
@@ -12905,7 +13216,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/fabwork)
 "xl" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -12918,7 +13229,7 @@
 	dir = 6;
 	icon_state = "intact-scrubbers"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/fabwork)
 "xm" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -12927,7 +13238,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/fabwork)
 "xn" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -12944,7 +13255,7 @@
 	dir = 10;
 	icon_state = "intact-supply"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/fabwork)
 "xo" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -12954,7 +13265,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/modular/preset/nervasupply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/fabwork)
 "xp" = (
 /obj/structure/disposalpipe/segment,
@@ -13997,6 +14308,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
+"yR" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/rotating_alarm/security_alarm,
+/turf/simulated/floor/plating,
+/area/logistics/hangar)
 "yV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15507,7 +15828,7 @@
 	dir = 8;
 	icon_state = "corner_white_three_quarters"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "BQ" = (
 /obj/machinery/suit_storage_unit/mining,
@@ -15517,7 +15838,7 @@
 /obj/machinery/camera/network/cargo{
 	c_tag = "Cargo Expedition Prep"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "BR" = (
 /obj/machinery/suit_cycler/mining,
@@ -15527,14 +15848,14 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "BS" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "BT" = (
 /obj/effect/paint_stripe/beige,
@@ -15777,7 +16098,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "Cq" = (
 /obj/structure/cable{
@@ -15789,7 +16110,7 @@
 	dir = 6;
 	icon_state = "intact-scrubbers"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "Cr" = (
 /obj/structure/cable{
@@ -15805,7 +16126,7 @@
 	dir = 6;
 	icon_state = "intact-supply"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "Cs" = (
 /obj/structure/cable{
@@ -15824,7 +16145,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "Ct" = (
 /obj/machinery/door/airlock/mining{
@@ -16172,27 +16493,27 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "CY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1;
 	icon_state = "map_scrubber_on"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "CZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	icon_state = "map_vent_out"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "Da" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "Db" = (
 /obj/machinery/door/airlock/mining{
@@ -16245,6 +16566,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/lowercargo)
 "Dh" = (
@@ -16508,7 +16834,7 @@
 /obj/item/clothing/mask/gas/half,
 /obj/item/clothing/mask/gas/half,
 /obj/item/device/scanner/mining,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "DC" = (
 /obj/structure/table/rack,
@@ -16531,7 +16857,7 @@
 /obj/item/carpentry/saw,
 /obj/item/carpentry/axe,
 /obj/item/carpentry/saw,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "DD" = (
 /obj/structure/closet/secure_closet/hunter,
@@ -16546,7 +16872,7 @@
 	dir = 10;
 	icon_state = "corner_white"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "DE" = (
 /obj/structure/closet/secure_closet/hunter,
@@ -16561,7 +16887,7 @@
 	dir = 4;
 	icon_state = "corner_white_three_quarters"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/logistics/prep)
 "DF" = (
 /obj/machinery/power/apc{
@@ -18457,6 +18783,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
+"GV" = (
+/obj/machinery/mining/drill,
+/obj/effect/floor_decal/spline/plain/yellow{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/logistics/genprep)
 "GX" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -19652,6 +19987,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
+"Ji" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/logistics/hangar)
 "Jm" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -20428,6 +20773,20 @@
 "LR" = (
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/extstorage)
+"LS" = (
+/obj/effect/floor_decal/spline/plain/black{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/exploration_shuttle/cargo)
+"LW" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/logistics/genprep)
 "LY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
@@ -20502,6 +20861,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/command)
+"Mk" = (
+/obj/machinery/mining/brace,
+/obj/effect/floor_decal/spline/plain/yellow{
+	icon_state = "spline_plain";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/logistics/genprep)
 "Mm" = (
 /obj/effect/paint/silver,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -20548,6 +20916,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemlab)
+"MC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/spline/plain/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/logistics/genprep)
 "MG" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -20602,6 +20975,14 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/bdportengine)
+"MU" = (
+/obj/structure/stasis_cage,
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/logistics/genprep)
 "MY" = (
 /obj/effect/paint_stripe/paleblue,
 /turf/simulated/wall/prepainted,
@@ -20761,6 +21142,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"NU" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 1;
+	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm,
+/turf/simulated/floor/tiled,
+/area/hallway/centralfourth)
 "Oa" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -20787,7 +21176,7 @@
 	dir = 4;
 	icon_state = "map_vent_out"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/fabwork)
 "Oh" = (
 /obj/structure/cable{
@@ -21005,7 +21394,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue/three_quarters{
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "Pi" = (
 /obj/effect/decal/cleanable/spiderling_remains,
@@ -21239,7 +21632,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/fabwork)
 "Qc" = (
 /obj/machinery/door/firedoor,
@@ -21283,7 +21676,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "Qq" = (
 /obj/structure/catwalk,
@@ -21653,7 +22050,11 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/fadeblue/three_quarters{
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/exploration_shuttle/cockpit)
 "Rn" = (
 /obj/structure/disposalpipe/segment{
@@ -21669,6 +22070,10 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/command/aiupload)
+"Rr" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/logistics/genprep)
 "Rs" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21705,7 +22110,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 1;
+	icon_state = "techfloor_corners"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "Rz" = (
 /obj/structure/disposalpipe/segment,
@@ -21734,6 +22143,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
+"RG" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 10;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/logistics/genprep)
 "RI" = (
 /obj/machinery/computer/ship/engines,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -22744,7 +23160,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "Wu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23017,7 +23433,11 @@
 /area/maintenance/fourth_deck/fp)
 "XC" = (
 /obj/structure/stasis_cage,
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/techfloor{
+	dir = 9;
+	icon_state = "techfloor_edges"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
 "XF" = (
 /obj/structure/catwalk,
@@ -23120,6 +23540,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/extstorage)
+"Yb" = (
+/obj/machinery/mining/brace,
+/obj/effect/floor_decal/spline/plain/yellow{
+	icon_state = "spline_plain";
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/logistics/genprep)
 "Yf" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/old_tile,
@@ -23611,7 +24040,7 @@
 	icon_state = "corner_white"
 	},
 /obj/item/tape_roll,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
 "ZP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -41150,7 +41579,7 @@ YH
 ST
 iM
 iM
-me
+NU
 nn
 oa
 pc
@@ -43979,7 +44408,7 @@ fj
 kH
 nx
 mp
-nx
+vU
 nx
 fj
 qh
@@ -46182,7 +46611,7 @@ aD
 aq
 QZ
 bh
-bj
+yR
 bE
 ca
 cK
@@ -46399,7 +46828,7 @@ hB
 hU
 iu
 jc
-jR
+LS
 kO
 lB
 mz
@@ -47617,7 +48046,7 @@ lD
 pp
 nC
 ot
-pp
+RG
 kQ
 Qj
 Uo
@@ -47817,9 +48246,9 @@ jW
 kQ
 lE
 mC
-mC
+MC
 ou
-pp
+Rr
 kQ
 kQ
 kQ
@@ -48019,7 +48448,7 @@ jX
 kQ
 lF
 mD
-mD
+nJ
 ov
 pq
 Wb
@@ -48219,9 +48648,9 @@ ix
 je
 jY
 kQ
-lF
-mD
-mD
+GV
+Mk
+Yb
 ow
 pr
 qx
@@ -48422,10 +48851,10 @@ je
 jZ
 kQ
 XC
-XC
-pp
+MU
+LW
 Ry
-pp
+Rr
 qy
 rE
 kQ
@@ -48619,7 +49048,7 @@ UV
 UV
 Ww
 SF
-UV
+Ji
 ji
 ND
 kQ
@@ -48628,7 +49057,7 @@ mE
 mE
 ox
 ps
-ps
+nG
 rF
 kQ
 sY

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -4429,7 +4429,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "ait" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4443,7 +4443,7 @@
 	dir = 5;
 	icon_state = "corner_white"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "aiu" = (
 /obj/machinery/camera/network/command{
@@ -4461,7 +4461,7 @@
 	dir = 5;
 	icon_state = "corner_white"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "aiv" = (
 /obj/machinery/power/apc{
@@ -4477,7 +4477,7 @@
 	dir = 5;
 	icon_state = "corner_white"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "aiw" = (
 /obj/structure/closet/emcloset,
@@ -4490,7 +4490,7 @@
 	dir = 1;
 	icon_state = "corner_white_three_quarters"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "aix" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -5578,17 +5578,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "ajX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	icon_state = "map_vent_out"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "ajY" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "ajZ" = (
 /obj/structure/cable{
@@ -5596,7 +5596,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "aka" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
@@ -6152,7 +6152,7 @@
 	icon_state = "1-8";
 	pixel_x = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "ali" = (
 /obj/structure/cable{
@@ -6165,7 +6165,7 @@
 	dir = 10;
 	icon_state = "corner_white"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "alj" = (
 /obj/machinery/light,
@@ -6184,7 +6184,7 @@
 /obj/structure/shipweapons/hardpoint/nerva{
 	attached = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "all" = (
 /obj/structure/cable/yellow{
@@ -6831,7 +6831,7 @@
 /area/hallway/commandport)
 "amq" = (
 /obj/structure/ladder/updown,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "amr" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -7433,6 +7433,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
@@ -10040,6 +10044,7 @@
 	dir = 1;
 	icon_state = "map-scrubbers"
 	},
+/obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
 "arJ" = (
@@ -10094,6 +10099,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	icon_state = "extinguisher_closed";
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -10192,9 +10202,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/ship_map,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "arR" = (
@@ -10360,6 +10368,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "arZ" = (
@@ -10587,6 +10596,7 @@
 	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
+/obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "asj" = (
@@ -10852,6 +10862,7 @@
 	dir = 8;
 	icon_state = "pipe-j2"
 	},
+/obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "ast" = (
@@ -11308,6 +11319,10 @@
 	icon_state = "intercom";
 	pixel_y = -28
 	},
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
 "asX" = (
@@ -11474,6 +11489,7 @@
 	dir = 10;
 	icon_state = "corner_white"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "atp" = (
@@ -11808,9 +11824,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
 "atV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers"
@@ -11827,6 +11840,13 @@
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 4;
 	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/valve/shutoff/supply{
+	dir = 8;
+	icon_state = "map_vclamp0"
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandport)
@@ -12267,6 +12287,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
 "auF" = (
@@ -12600,6 +12624,10 @@
 "avq" = (
 /obj/machinery/computer/modular/preset/engineering{
 	autorun_program = /datum/computer_file/program/power_monitor;
+	dir = 4
+	},
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -14607,7 +14635,6 @@
 "azF" = (
 /obj/machinery/hologram/holopad/longrange,
 /obj/effect/floor_decal/corner/fadeblue/full,
-/obj/effect/overmap/visitable/ship/combat/nerva,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -14765,6 +14792,7 @@
 	icon_state = "map-supply"
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/rotating_alarm/supermatter,
 /turf/simulated/floor/plating,
 /area/engineering/lobby)
 "azR" = (
@@ -16010,11 +16038,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "aCf" = (
@@ -16458,6 +16481,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
 "aCX" = (
@@ -16564,6 +16591,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -16968,7 +16999,8 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
 /area/hallway/aft/third_deck)
 "aDO" = (
 /obj/structure/disposalpipe/segment{
@@ -17246,9 +17278,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aEq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers"
@@ -17260,6 +17289,13 @@
 	pixel_x = 0
 	},
 /obj/effect/floor_decal/corner/fadeblue,
+/obj/machinery/atmospherics/valve/shutoff/supply{
+	dir = 8;
+	icon_state = "map_vclamp0"
+	},
+/obj/effect/floor_decal/industrial/shutoff{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/commandstarboard)
 "aEr" = (
@@ -17492,6 +17528,10 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
 "aEM" = (
@@ -17599,6 +17639,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -17812,6 +17856,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -18058,6 +18106,10 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFt" = (
@@ -18172,6 +18224,10 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
 "aFD" = (
@@ -18473,6 +18529,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6;
 	level = 2
+	},
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -20757,6 +20817,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandstarboard)
 "aKx" = (
@@ -20860,6 +20924,10 @@
 	dir = 9
 	},
 /obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
 "aKK" = (
@@ -21454,7 +21522,7 @@
 /area/security/starboardgun)
 "aLF" = (
 /obj/structure/ladder/updown,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/starboardgun)
 "aLG" = (
 /obj/machinery/light{
@@ -22244,7 +22312,7 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/starboardgun)
 "aMQ" = (
 /obj/machinery/power/apc{
@@ -22864,6 +22932,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/plating,
 /area/hallway/commandoffices)
 "aNO" = (
@@ -24695,6 +24764,10 @@
 /obj/item/book/manual/supermatter_engine,
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/yellow/three_quarters,
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
 "aQK" = (
@@ -27615,6 +27688,15 @@
 /obj/item/stamp/cargo,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
+"bEE" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
 "bFA" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/r_wall/prepainted,
@@ -27853,7 +27935,7 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "dmy" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -27882,9 +27964,6 @@
 	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/fadeblue/full,
 /obj/structure/cable{
 	d1 = 4;
@@ -27894,6 +27973,9 @@
 	},
 /obj/structure/noticeboard{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -28277,6 +28359,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/walnut,
 /area/rnd/dorms)
+"eIB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/third_deck)
 "eJz" = (
 /obj/effect/floor_decal/corner/fadeblue{
 	dir = 6;
@@ -28621,6 +28716,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "gxQ" = (
@@ -29552,6 +29651,21 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/airless,
 /area/maintenance/third_deck/fp)
+"lWD" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
 "lXq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29610,6 +29724,10 @@
 	icon_state = "corner_white";
 	dir = 1
 	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "mlv" = (
@@ -29663,7 +29781,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "mvm" = (
 /obj/structure/disposalpipe/segment,
@@ -29992,6 +30110,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/security/evidence)
+"oxV" = (
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine)
 "oxZ" = (
 /obj/structure/closet,
 /obj/item/device/flashlight,
@@ -30254,7 +30379,7 @@
 	dir = 4;
 	icon_state = "corner_white_three_quarters"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/security/portgun)
 "qiD" = (
 /obj/machinery/camera/network/third_deck{
@@ -30926,6 +31051,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
+"uqW" = (
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/commandoffices)
 "urB" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb{
@@ -31009,6 +31142,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/portexternalgun)
+"uEJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/hallway/aft/third_deck)
 "uIr" = (
 /obj/effect/floor_decal/corner/red/half{
 	dir = 1;
@@ -44466,7 +44606,7 @@ asN
 auh
 avg
 aoY
-avj
+oxV
 ayQ
 azI
 aAF
@@ -50320,7 +50460,7 @@ aod
 apr
 aqO
 arR
-aDP
+uEJ
 jkN
 avF
 auA
@@ -50330,7 +50470,7 @@ ayb
 auA
 aCd
 vZc
-aDK
+eIB
 aFa
 soi
 aHr
@@ -50522,7 +50662,7 @@ aoe
 aps
 aqO
 arR
-aDP
+uEJ
 etW
 dEu
 auA
@@ -50532,7 +50672,7 @@ ayb
 auA
 vRN
 cSX
-aDK
+eIB
 aFa
 soi
 sXq
@@ -50724,7 +50864,7 @@ aof
 apt
 qBa
 sGn
-aDP
+uEJ
 cUF
 mjF
 auA
@@ -60218,7 +60358,7 @@ aoN
 aqd
 mdX
 asy
-atD
+lWD
 auR
 awl
 atC
@@ -60228,7 +60368,7 @@ aAv
 atC
 aCG
 auR
-aEb
+bEE
 aFH
 aGO
 aIe
@@ -60639,7 +60779,7 @@ aIg
 aJs
 aKt
 aGO
-aMB
+uqW
 aNW
 mAz
 aQz

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -2839,6 +2839,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/plating,
 /area/hallway/aft/second_deck)
 "fJ" = (
@@ -3486,6 +3487,10 @@
 "gp" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "gq" = (
@@ -5146,6 +5151,10 @@
 /obj/effect/floor_decal/corner/yellow/full,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "jQ" = (
@@ -8433,6 +8442,10 @@
 	},
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/rotating_alarm/supermatter{
+	icon_state = "alarm";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "qs" = (
@@ -8521,6 +8534,10 @@
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 10;
 	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8842,6 +8859,10 @@
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 10;
 	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -14344,6 +14365,13 @@
 /obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
+"Ey" = (
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/fore/second_deck)
 "Ez" = (
 /obj/machinery/light/small/red{
 	dir = 4;
@@ -14545,6 +14573,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel)
+"Fv" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/second_deck)
 "Fx" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor/plating,
@@ -15283,6 +15319,17 @@
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
+"Jl" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "Jm" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -15306,6 +15353,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"JE" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm,
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "JG" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -16839,6 +16894,12 @@
 /obj/item/clothing/accessory/badge/press,
 /turf/simulated/floor/wood/walnut,
 /area/civilian/journalist)
+"Qx" = (
+/obj/machinery/ship_map{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/aft/second_deck)
 "Qz" = (
 /obj/structure/flora/pottedplant/unusual,
 /obj/machinery/alarm{
@@ -17731,6 +17792,7 @@
 	dir = 5;
 	icon_state = "corner_white"
 	},
+/obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
 "VX" = (
@@ -39316,7 +39378,7 @@ dN
 ey
 fe
 fO
-eC
+Qx
 hH
 io
 jk
@@ -40326,7 +40388,7 @@ aX
 bB
 eB
 fJ
-Az
+Jl
 hH
 ip
 jk
@@ -40336,7 +40398,7 @@ ma
 ma
 nO
 hH
-EZ
+JE
 qE
 rr
 CU
@@ -42952,7 +43014,7 @@ dV
 eE
 fi
 gb
-gZ
+Ey
 be
 be
 be
@@ -46790,7 +46852,7 @@ AE
 cR
 fi
 ge
-gZ
+Ey
 hJ
 eM
 eL
@@ -46800,7 +46862,7 @@ eL
 eL
 km
 hJ
-PQ
+Fv
 qJ
 rz
 rz

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -32,7 +32,7 @@
 	locked = 1;
 	name = "Docking Port Airlock"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "aj" = (
 /obj/machinery/door/airlock/external{
@@ -43,7 +43,7 @@
 	name = "Docking Port Airlock"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "ak" = (
 /obj/structure/sign/warning/docking_area{
@@ -63,7 +63,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
 	id_tag = "merchant_shuttle_station_pump"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "am" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -77,7 +77,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "ao" = (
 /obj/machinery/door/airlock/external{
@@ -91,7 +91,7 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "ap" = (
 /obj/machinery/door/airlock/external{
@@ -105,7 +105,7 @@
 	dir = 4;
 	icon_state = "map"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "aq" = (
 /obj/effect/shuttle_landmark/skipjack/deck1,
@@ -120,6 +120,10 @@
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "at" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9;
+	icon_state = "corner_white"
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
@@ -139,6 +143,10 @@
 	tag_interior_door = "merchant_shuttle_station_interior"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
@@ -192,15 +200,27 @@
 /area/hallway/centralfirst)
 "aC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "aD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "aE" = (
 /obj/machinery/alarm{
 	pixel_y = 24
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -213,11 +233,19 @@
 	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "aG" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -230,6 +258,10 @@
 	pixel_x = 23;
 	pixel_y = 23;
 	req_access = list("ACCESS_EXTERNAL")
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -246,7 +278,7 @@
 	name = "External Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "aJ" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -268,7 +300,7 @@
 	dir = 9;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "aK" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -279,7 +311,7 @@
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "aL" = (
 /obj/machinery/door/airlock/external{
@@ -289,7 +321,7 @@
 	locked = 1;
 	name = "External Access"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "aM" = (
 /obj/structure/catwalk,
@@ -305,6 +337,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/centralfirst)
@@ -358,6 +394,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4;
 	icon_state = "intact"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	icon_state = "extinguisher_closed";
+	pixel_y = -28
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -447,7 +488,7 @@
 	dir = 4;
 	icon_state = "map"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "aZ" = (
 /obj/machinery/airlock_sensor{
@@ -463,7 +504,7 @@
 	dir = 10;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "ba" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -473,7 +514,7 @@
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "bb" = (
 /obj/machinery/access_button{
@@ -518,6 +559,10 @@
 /area/hallway/centralfirst)
 "bh" = (
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "bi" = (
@@ -580,6 +625,10 @@
 "bs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4;
+	icon_state = "borderfloor_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -671,6 +720,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "bE" = (
@@ -763,6 +816,10 @@
 	hitstaken = 1;
 	pixel_x = 28;
 	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -939,6 +996,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "ci" = (
@@ -1046,6 +1107,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8;
 	id_tag = null
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -1176,6 +1241,14 @@
 "cK" = (
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Port Hallway - Checkpoint";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -1337,6 +1410,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -1631,6 +1708,10 @@
 	dir = 8;
 	icon_state = "map_vent_out"
 	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "dE" = (
@@ -1871,6 +1952,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
 	pixel_y = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -2284,7 +2369,7 @@
 	dir = 9;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "eY" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -2295,7 +2380,7 @@
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "eZ" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -2416,6 +2501,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4;
+	icon_state = "borderfloor_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -2642,7 +2731,7 @@
 	dir = 10;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "fG" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -2652,7 +2741,7 @@
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "fH" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -2796,6 +2885,10 @@
 	dir = 8;
 	icon_state = "deck-1";
 	pixel_x = 32
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -3140,7 +3233,7 @@
 	pixel_y = -6
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "gw" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -3211,7 +3304,9 @@
 	pixel_x = 28;
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/corner/lightgrey/full,
 /obj/effect/floor_decal/corner/gold/border,
+/obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "gF" = (
@@ -3626,6 +3721,10 @@
 	dir = 1;
 	icon_state = "nerva4"
 	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "hD" = (
@@ -4026,11 +4125,19 @@
 	dir = 8;
 	id_tag = null
 	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 4;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "ij" = (
 /obj/machinery/atm{
 	pixel_x = 30
+	},
+/obj/effect/floor_decal/corner/lightgrey/three_quarters{
+	icon_state = "corner_white_three_quarters";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -4747,6 +4854,10 @@
 	pixel_x = 28;
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "jz" = (
@@ -4878,6 +4989,10 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -5185,6 +5300,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/afs)
 "km" = (
@@ -5213,6 +5329,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/lightgrey,
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "ko" = (
@@ -5222,10 +5339,14 @@
 	pixel_x = 24
 	},
 /obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/lightgrey/three_quarters{
+	icon_state = "corner_white_three_quarters";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "kp" = (
@@ -5256,6 +5377,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	icon_state = "extinguisher_closed";
+	pixel_y = -28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "ks" = (
@@ -5374,6 +5500,10 @@
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -5671,6 +5801,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4;
+	icon_state = "borderfloor_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "lc" = (
@@ -5882,7 +6016,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/first_deck_storage)
 "lv" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -5890,14 +6024,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/first_deck_storage)
 "lw" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/first_deck_storage)
 "lx" = (
 /obj/machinery/alarm{
@@ -5914,7 +6048,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/first_deck_storage)
 "ly" = (
 /obj/machinery/door/firedoor,
@@ -6311,7 +6445,7 @@
 	name = "Engineering Access"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/first_deck_storage)
 "lW" = (
 /obj/structure/cable{
@@ -6460,7 +6594,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/first_deck_storage)
 "mo" = (
 /obj/structure/cable{
@@ -6468,20 +6602,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/first_deck_storage)
 "mp" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/first_deck_storage)
 "mq" = (
 /obj/machinery/computer/modular/preset/engineering{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/engineering/first_deck_storage)
 "mr" = (
 /obj/structure/cable{
@@ -6494,6 +6628,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "ms" = (
@@ -6867,6 +7005,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "ne" = (
@@ -7161,6 +7303,10 @@
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Starboard Hallway - Engineering";
 	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -7666,6 +7812,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4;
+	icon_state = "borderfloor_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "oL" = (
@@ -7846,6 +7996,10 @@
 "pf" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -8177,6 +8331,10 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "pE" = (
@@ -8319,6 +8477,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated,
+/obj/machinery/rotating_alarm/security_alarm{
+	icon_state = "code green";
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
 "pR" = (
@@ -8330,6 +8492,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	icon_state = "map_vent_out"
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -8385,6 +8551,10 @@
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Starboard Hallway - Docking";
 	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -8442,6 +8612,10 @@
 	dir = 4;
 	icon_state = "intact"
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4;
+	icon_state = "borderfloor_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "qe" = (
@@ -8491,6 +8665,10 @@
 	tag_exterior_door = "skipjack_shuttle_dock_outer";
 	tag_interior_door = "skipjack_shuttle_dock_inner"
 	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "qk" = (
@@ -8520,7 +8698,7 @@
 	dir = 8;
 	icon_state = "map"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "qo" = (
 /obj/machinery/door/airlock/external{
@@ -8534,7 +8712,7 @@
 	dir = 10;
 	icon_state = "intact"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "qp" = (
 /obj/structure/cable/orange{
@@ -8571,7 +8749,7 @@
 	id_tag = "skipjack_shuttle_dock_pump"
 	},
 /obj/effect/floor_decal/industrial/warning/full,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "qs" = (
 /obj/effect/floor_decal/industrial/warning/full,
@@ -8586,7 +8764,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "qt" = (
 /obj/machinery/door/airlock/external{
@@ -8597,7 +8775,7 @@
 	name = "Docking Port Airlock"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/centralfirst)
 "qu" = (
 /obj/structure/sign/warning/docking_area,
@@ -8613,19 +8791,35 @@
 	},
 /turf/space,
 /area/space)
+"ut" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 4;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
 "uv" = (
 /obj/effect/urist/projectile_landmark/ship{
 	shipid = "nerva"
 	},
 /turf/space,
 /area/space)
+"vu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4;
+	icon_state = "borderfloor_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
 "wD" = (
 /obj/effect/shuttle_landmark/nerva/docking/north,
 /turf/space,
 /area/space)
-"xT" = (
-/turf/simulated/wall/prepainted,
-/area/engineering/bluespace)
+"xe" = (
+/obj/effect/overmap/visitable/ship/combat/nerva,
+/turf/simulated/wall/r_wall/prepainted,
+/area/security/topgun)
 "AB" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8676,6 +8870,35 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/engineering/bluespace)
+"Ei" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	icon_state = "map_vent_out"
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
+"Et" = (
+/obj/effect/floor_decal/urist/nervalogo{
+	dir = 1;
+	icon_state = "nerva3"
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
+"ET" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
 "Fd" = (
 /obj/item/material/shard{
 	icon_state = "small"
@@ -8696,6 +8919,17 @@
 	location = "Deck 1 Starboard Docks"
 	},
 /turf/simulated/floor/plating,
+/area/hallway/centralfirst)
+"Id" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8;
+	id_tag = null
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "II" = (
 /obj/effect/landmark{
@@ -8733,6 +8967,13 @@
 /obj/effect/shuttle_landmark/nerva/docking/south,
 /turf/space,
 /area/space)
+"Tq" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
 "Tu" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/orange{
@@ -8747,10 +8988,43 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/solar/auxaft)
+"TU" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/space)
+"Vo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor_white"
+	},
+/turf/simulated/floor/tiled,
+/area/space)
+"VY" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
 "Xf" = (
 /obj/structure/shipweapons/hardpoint/nerva,
 /turf/simulated/floor/reinforced,
 /area/security/topgun)
+"XP" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
+	},
+/obj/machinery/ship_map,
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
 
 (1,1,1) = {"
 aa
@@ -27232,7 +27506,7 @@ cr
 cr
 cr
 cr
-ff
+XP
 fN
 gB
 hd
@@ -28227,8 +28501,8 @@ ai
 al
 ao
 at
-aB
-aB
+VY
+VY
 aO
 bg
 br
@@ -28430,7 +28704,7 @@ am
 ap
 au
 aC
-aC
+ut
 aP
 bh
 bs
@@ -28442,12 +28716,12 @@ cK
 de
 dD
 ec
-aB
+ET
 bh
 fi
 fT
-aB
-hh
+ET
+Et
 hC
 ii
 iW
@@ -28457,14 +28731,14 @@ kn
 kC
 lb
 bh
-aB
-aB
-jw
+ET
+ET
+Ei
 nd
 nF
-aB
-ii
-aB
+ET
+Id
+ET
 oK
 bh
 pf
@@ -28632,7 +28906,7 @@ qk
 qk
 qk
 qk
-aB
+Tq
 aQ
 bi
 bt
@@ -28652,13 +28926,13 @@ gE
 hi
 hD
 ij
-aB
+vu
 jx
 jM
 ko
 bi
 lc
-xT
+nG
 lz
 lz
 lz
@@ -28834,7 +29108,7 @@ aa
 aa
 aa
 as
-aB
+Tq
 aR
 bi
 bu
@@ -28860,7 +29134,7 @@ bi
 bi
 bi
 lA
-xT
+nG
 ni
 mt
 mH
@@ -29062,7 +29336,7 @@ bI
 kp
 bE
 ld
-xT
+nG
 mH
 mt
 mH
@@ -29264,7 +29538,7 @@ jN
 kq
 kD
 lf
-xT
+nG
 mt
 le
 mt
@@ -29437,7 +29711,7 @@ aa
 aa
 aa
 aa
-aa
+TU
 aa
 qk
 aF
@@ -29466,7 +29740,7 @@ jO
 kr
 bE
 lg
-xT
+nG
 mH
 mt
 mH
@@ -29639,10 +29913,10 @@ aa
 aa
 aa
 aa
-aa
+Vo
 aa
 qk
-aB
+Tq
 aV
 bi
 bu
@@ -29668,7 +29942,7 @@ jP
 ks
 bE
 lg
-xT
+nG
 Rh
 mu
 nI
@@ -29870,10 +30144,10 @@ jQ
 bW
 bE
 lg
-xT
 nG
 nG
-xT
+nG
+nG
 nG
 nG
 lX
@@ -39762,7 +40036,7 @@ gX
 hw
 hZ
 iP
-ib
+xe
 jH
 kf
 kx

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -7620,6 +7620,13 @@
 "oj" = (
 /turf/simulated/floor/plating,
 /area/engineering/bluespace)
+"ok" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
+	},
+/obj/machinery/ship_map,
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
 "ol" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1;
@@ -8791,10 +8798,13 @@
 	},
 /turf/space,
 /area/space)
-"ut" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
+"ue" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8;
+	id_tag = null
+	},
 /obj/effect/floor_decal/corner/lightgrey{
-	dir = 4;
+	dir = 6;
 	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
@@ -8805,21 +8815,18 @@
 	},
 /turf/space,
 /area/space)
-"vu" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4;
-	icon_state = "borderfloor_white"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/centralfirst)
 "wD" = (
 /obj/effect/shuttle_landmark/nerva/docking/north,
 /turf/space,
 /area/space)
-"xe" = (
-/obj/effect/overmap/visitable/ship/combat/nerva,
-/turf/simulated/wall/r_wall/prepainted,
-/area/security/topgun)
+"yT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 4;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
 "AB" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8870,35 +8877,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/engineering/bluespace)
-"Ei" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8;
-	icon_state = "map_vent_out"
-	},
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 6;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/centralfirst)
-"Et" = (
-/obj/effect/floor_decal/urist/nervalogo{
-	dir = 1;
-	icon_state = "nerva3"
-	},
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 6;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/centralfirst)
-"ET" = (
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 6;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/centralfirst)
 "Fd" = (
 /obj/item/material/shard{
 	icon_state = "small"
@@ -8920,14 +8898,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
-"Id" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8;
-	id_tag = null
-	},
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 6;
-	icon_state = "corner_white"
+"Hj" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4;
+	icon_state = "borderfloor_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -8942,6 +8916,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
+/area/hallway/centralfirst)
+"Og" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 "Rh" = (
 /obj/machinery/camera/network/engineering{
@@ -8967,9 +8948,9 @@
 /obj/effect/shuttle_landmark/nerva/docking/south,
 /turf/space,
 /area/space)
-"Tq" = (
+"Ts" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	dir = 5;
+	dir = 6;
 	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
@@ -8988,41 +8969,41 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/solar/auxaft)
-"TU" = (
+"Xf" = (
+/obj/structure/shipweapons/hardpoint/nerva,
+/turf/simulated/floor/reinforced,
+/area/security/topgun)
+"Ym" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 5;
 	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
-/area/space)
-"Vo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
+/area/hallway/centralfirst)
+"YL" = (
+/obj/effect/floor_decal/urist/nervalogo{
 	dir = 1;
-	icon_state = "borderfloor_white"
+	icon_state = "nerva3"
 	},
-/turf/simulated/floor/tiled,
-/area/space)
-"VY" = (
 /obj/effect/floor_decal/corner/lightgrey{
-	dir = 9;
+	dir = 6;
 	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
-"Xf" = (
-/obj/structure/shipweapons/hardpoint/nerva,
-/turf/simulated/floor/reinforced,
+"YT" = (
+/obj/effect/overmap/visitable/ship/combat/nerva,
+/turf/simulated/wall/r_wall/prepainted,
 /area/security/topgun)
-"XP" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
+"Zf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	icon_state = "map_vent_out"
 	},
-/obj/machinery/ship_map,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
 
@@ -27506,7 +27487,7 @@ cr
 cr
 cr
 cr
-XP
+ok
 fN
 gB
 hd
@@ -28501,8 +28482,8 @@ ai
 al
 ao
 at
-VY
-VY
+Og
+Og
 aO
 bg
 br
@@ -28704,7 +28685,7 @@ am
 ap
 au
 aC
-ut
+yT
 aP
 bh
 bs
@@ -28716,12 +28697,12 @@ cK
 de
 dD
 ec
-ET
+Ts
 bh
 fi
 fT
-ET
-Et
+Ts
+YL
 hC
 ii
 iW
@@ -28731,14 +28712,14 @@ kn
 kC
 lb
 bh
-ET
-ET
-Ei
+Ts
+Ts
+Zf
 nd
 nF
-ET
-Id
-ET
+Ts
+ue
+Ts
 oK
 bh
 pf
@@ -28906,7 +28887,7 @@ qk
 qk
 qk
 qk
-Tq
+Ym
 aQ
 bi
 bt
@@ -28926,7 +28907,7 @@ gE
 hi
 hD
 ij
-vu
+Hj
 jx
 jM
 ko
@@ -29108,7 +29089,7 @@ aa
 aa
 aa
 as
-Tq
+Ym
 aR
 bi
 bu
@@ -29711,7 +29692,7 @@ aa
 aa
 aa
 aa
-TU
+aa
 aa
 qk
 aF
@@ -29913,10 +29894,10 @@ aa
 aa
 aa
 aa
-Vo
+aa
 aa
 qk
-Tq
+Ym
 aV
 bi
 bu
@@ -40036,7 +40017,7 @@ gX
 hw
 hZ
 iP
-xe
+YT
 jH
 kf
 kx

--- a/maps/nerva/nerva_areas.dm
+++ b/maps/nerva/nerva_areas.dm
@@ -11,6 +11,7 @@
 /area/command
 	icon_state = "head_quarters"
 	req_access = list(access_bridge)
+	holomap_color = HOLOMAP_AREACOLOR_COMMAND
 
 /area/command/bridge
 	name = "\improper ICS Nerva Bridge"
@@ -133,6 +134,7 @@
 
 /area/civilian
 	icon_state = "green"
+	holomap_color = HOLOMAP_AREACOLOR_CREW
 
 /area/civilian/observatory
 	name = "\improper Starboard Observatory"
@@ -492,6 +494,8 @@
 
 /area/solar
 	req_access = list(access_maint_tunnels)
+	area_flags = AREA_FLAG_EXTERNAL
+	has_gravity = FALSE
 
 /area/solar/main
 	name = "\improper Main Solar Array"
@@ -505,11 +509,13 @@
 	name = "\improper Solar Maintenance - Main"
 	icon_state = "SolarcontrolS"
 	sound_env = SMALL_ENCLOSED
+	holomap_color = HOLOMAP_AREACOLOR_AIRLOCK
 
 /area/maintenance/aftsolar
 	name = "\improper Solar Maintenance - Aft Auxiliary"
 	icon_state = "SolarcontrolA"
 	sound_env = SMALL_ENCLOSED
+	holomap_color = HOLOMAP_AREACOLOR_AIRLOCK
 
 //////////////////////////////////////
 //			MEDICAL					//
@@ -587,6 +593,7 @@
 /area/logistics
 	icon_state = "yellow"
 	req_access = list(access_cargo)
+	holomap_color = HOLOMAP_AREACOLOR_CARGO
 
 /area/logistics/qm
 	name = "\improper Quartermaster's Office"
@@ -635,6 +642,7 @@
 	name = "\improper General Expedition Prep"
 	icon_state = "exploration"
 	req_access = list(access_expedition)
+	holomap_color = HOLOMAP_AREACOLOR_EXPLORATION
 
 /area/logistics/robotics
 	name = "\improper Robotics Lab"
@@ -649,6 +657,7 @@
 /area/logistics/hangar
 	name = "\improper Hangar"
 	req_access = list()
+	holomap_color = HOLOMAP_AREACOLOR_EXPLORATION
 
 /area/supply/dock
 	name = "Supply Shuttle"
@@ -839,6 +848,7 @@
 	dynamic_lighting = 0
 	requires_power = 0
 	sound_env = LARGE_ENCLOSED
+	holomap_color = HOLOMAP_AREACOLOR_CREW
 
 /area/holodeck/source_battle_arena
 	name = "\improper Holodeck - Battle Arena"

--- a/maps/nerva/nerva_overmap.dm
+++ b/maps/nerva/nerva_overmap.dm
@@ -14,6 +14,7 @@
 	evac_x = 143
 	evac_y = 97
 	evac_z = 3
+	base = TRUE
 
 	initial_generic_waypoints = list(
 		"nerva_north_dock",

--- a/maps/nerva/nerva_shuttles.dm
+++ b/maps/nerva/nerva_shuttles.dm
@@ -6,7 +6,7 @@
 	name = "\improper Trajan"
 	icon_state = "shuttlered"
 	base_turf = /turf/simulated/floor/plating
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
 
 /area/exploration_shuttle/cockpit
 	name = "\improper Trajan - Cockpit"
@@ -114,7 +114,7 @@
 	icon_state = "shuttlered"
 	requires_power = 1
 	dynamic_lighting = 1
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
 	req_access = list(access_expedition_shuttle_helm)
 
 /obj/machinery/computer/shuttle_control/explore/antonine
@@ -172,7 +172,7 @@
 	icon_state = "shuttlered"
 	requires_power = 1
 	dynamic_lighting = 1
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
 	req_access = list(access_research)
 
 /area/hadrian/main
@@ -348,18 +348,21 @@
 
 /area/shuttle/escape_pod1/station
 	name = "Escape Pod One"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
 	base_turf = /turf/simulated/floor/reinforced/airless
+	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 
 /area/shuttle/escape_pod2/station
 	name = "Escape Pod Two"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
 	base_turf = /turf/simulated/floor/plating
+	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 
 /area/shuttle/escape_pod3/station
 	name = "Escape Pod Three"
-	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_IS_NOT_PERSISTENT
 	base_turf = /turf/simulated/floor/plating
+	holomap_color = HOLOMAP_AREACOLOR_ESCAPE
 
 //Admin
 


### PR DESCRIPTION
configures the holomaps for nerva, and adds some to the map
further beautifies nerva
adds security level and supermatter alarms to nerva
moves the nerva overmap thing to the top deck because it was causing issues with the holomap

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->