### PR TITLE
Noctis burn chamber OSHA compliance

### DIFF
--- a/maps/away/noctis/noctis-1.dmm
+++ b/maps/away/noctis/noctis-1.dmm
@@ -7997,7 +7997,7 @@ aa
 aa
 aa
 aa
-hC
+al
 at
 at
 at
@@ -8099,7 +8099,7 @@ aa
 aa
 aa
 aa
-hC
+al
 eM
 eU
 eU
@@ -8201,7 +8201,7 @@ aa
 aa
 aa
 aa
-hC
+al
 al
 al
 al

--- a/maps/away/noctis/noctis-1.dmm
+++ b/maps/away/noctis/noctis-1.dmm
@@ -1184,7 +1184,7 @@
 /area/noctis/fairlock)
 "cs" = (
 /obj/effect/paint/black,
-/turf/simulated/wall/titanium,
+/turf/simulated/wall/r_wall,
 /area/noctis/combust)
 "ct" = (
 /obj/effect/floor_decal/borderfloor{
@@ -1691,15 +1691,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/noctis/fairlock)
 "dt" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 4;
-	icon_state = "nozzle"
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/turf/simulated/floor/plating,
+/obj/effect/paint/red,
+/turf/simulated/wall/titanium,
 /area/noctis/combust)
 "du" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2187,7 +2180,6 @@
 /turf/simulated/floor/reinforced/airless,
 /area/noctis/combust)
 "ej" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8;
 	icon_state = "borderfloor_white"
@@ -2195,6 +2187,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "danger"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/noctis/combust)
@@ -2786,10 +2781,6 @@
 /turf/simulated/floor/tiled,
 /area/noctis/afth)
 "fg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 4;
-	icon_state = "map"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8;
 	icon_state = "borderfloor_white"
@@ -2798,6 +2789,7 @@
 	dir = 8;
 	icon_state = "danger"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/reinforced/airless,
 /area/noctis/combust)
 "fh" = (
@@ -7823,8 +7815,8 @@ aa
 aa
 fy
 aa
-ai
 aa
+ai
 aa
 aa
 aa
@@ -7903,8 +7895,8 @@ aa
 aa
 aa
 aa
-aa
 ai
+aa
 aa
 aa
 aa
@@ -7925,9 +7917,9 @@ aa
 aa
 aa
 aa
+aa
 gb
 fy
-aa
 aa
 aa
 aa
@@ -8005,8 +7997,8 @@ aa
 aa
 aa
 aa
-aa
-al
+hC
+at
 at
 at
 at
@@ -8026,9 +8018,9 @@ PN
 PN
 PN
 PN
+PN
 hC
 gb
-aa
 aa
 aa
 aa
@@ -8107,9 +8099,9 @@ aa
 aa
 aa
 aa
-aa
-al
+hC
 eM
+eU
 eU
 eU
 eU
@@ -8127,10 +8119,10 @@ mN
 mN
 mN
 mN
+mN
 fz
 hC
 gd
-aa
 aa
 aa
 aa
@@ -8209,7 +8201,7 @@ aa
 aa
 aa
 aa
-aa
+hC
 al
 al
 al
@@ -8231,8 +8223,8 @@ hC
 hC
 hC
 hC
+hC
 ge
-aa
 aa
 aa
 aa
@@ -8333,8 +8325,8 @@ iJ
 ju
 jJ
 aa
-ai
 aa
+ai
 aa
 aa
 aa

--- a/maps/away/noctis/noctis-2.dmm
+++ b/maps/away/noctis/noctis-2.dmm
@@ -6838,8 +6838,8 @@ aa
 aa
 aa
 aa
-aa
 ab
+eb
 eb
 eb
 eb
@@ -6855,8 +6855,8 @@ Gm
 Gm
 Gm
 Gm
+Gm
 ib
-aa
 aa
 eq
 aa
@@ -6941,8 +6941,8 @@ aa
 aa
 ab
 ab
-ab
 aS
+cb
 bw
 cb
 cb
@@ -6956,8 +6956,8 @@ dS
 gI
 hc
 hc
+hc
 hM
-ib
 ib
 ib
 eq


### PR DESCRIPTION
Upgrades the interior walls of the Noctis burn chamber to plasteel and moves some of the thrusters so that the point of failure vents into space and not the halls, giving the crew a slightly larger margin of error.
The three thrusters were moved to the sides with 1 added for symmetry.
![burn chart](https://github.com/UristMcStation/UristMcStation/assets/107084118/6e3c2366-5518-41f3-a013-e67770db0855)
