### PR TITLE
Senior Scientist gets a Nanotrasen account card

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -22,10 +22,11 @@
 			to_chat(user, SPAN_WARNING("Access denied!"))
 		else if ((locked = !locked))
 			to_chat(user, SPAN_NOTICE("You lock \the [src]!"))
+			icon_state = icon_locked
 			close_all()
 		else
 			icon_state = icon_closed
-			to_chat(user, SPAN_NOTICE("You lock \the [src]!"))
+			to_chat(user, SPAN_NOTICE("You unlock \the [src]!"))
 		return
 	else if (!broken && istype(I, /obj/item/melee/energy/blade))
 		var/success = emag_act(INFINITY, user, I, null, "You hear metal being sliced and sparks flying.")

--- a/code/modules/economy/_economy_misc.dm
+++ b/code/modules/economy/_economy_misc.dm
@@ -68,6 +68,7 @@
 
 var/global/datum/money_account/vendor_account
 var/global/datum/money_account/station_account
+var/global/datum/money_account/nanotrasen_account
 var/global/list/datum/money_account/department_accounts = list()
 var/global/num_financial_terminals = 1
 var/global/next_account_number = 0

--- a/maps/nerva/datums/nerva_objectives.dm
+++ b/maps/nerva/datums/nerva_objectives.dm
@@ -13,5 +13,6 @@
 		"a second officer's jumpsuit" = /obj/item/clothing/under/urist/nerva/soregular,
 		"the captain's pinpointer" = /obj/item/pinpointer,
 		"the station account card" = /obj/item/card/id/station_account,
-		"an ablative armor vest" = /obj/item/clothing/suit/armor/laserproof
+		"an ablative armor vest" = /obj/item/clothing/suit/armor/laserproof,
+		"the Nanotrasen account card" = /obj/item/card/id/station_account/nanotrasen
 		)

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -13628,7 +13628,7 @@
 	},
 /obj/structure/flora/pottedplant/smelly,
 /obj/machinery/atm{
-	pixel_x = -28
+	pixel_x = -28;
 	pixel_y = 35
 	},
 /obj/machinery/requests_console{

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -12981,7 +12981,7 @@
 /obj/structure/table/rack,
 /obj/machinery/keycard_auth{
 	pixel_x = -25;
-	pixel_y = 0
+	pixel_y = -15
 	},
 /turf/simulated/floor/tiled/white,
 /area/command/seniorntoffice)
@@ -13627,6 +13627,10 @@
 	dir = 8
 	},
 /obj/structure/flora/pottedplant/smelly,
+/obj/machinery/atm{
+	pixel_x = -28
+	pixel_y = 35
+	},
 /obj/machinery/requests_console{
 	pixel_x = -32
 	},

--- a/maps/nerva/nerva_procs.dm
+++ b/maps/nerva/nerva_procs.dm
@@ -4,3 +4,8 @@
 		qdel(nerva)
 		animate(nerva, time = 0.5 SECONDS)
 		animate(alpha = 0, time = 0.5 SECONDS)
+
+/datum/map/nerva/setup_economy()
+	..()
+	if (!nanotrasen_account)
+		nanotrasen_account = create_account("Nanotrasen Company Expense Card", "Nanotrasen Representative", 0, ACCOUNT_TYPE_DEPARTMENT)

--- a/maps/nerva/obj/nerva_closets.dm
+++ b/maps/nerva/obj/nerva_closets.dm
@@ -250,7 +250,8 @@
 		/obj/item/device/flash,
 		/obj/item/material/clipboard,
 		/obj/item/clothing/suit/storage/toggle/labcoat/science/nanotrasen,
-		/obj/item/storage/backpack/satchel/leather
+		/obj/item/storage/backpack/satchel/leather,
+		/obj/item/storage/lockbox/nanotrasen_account
 	)
 
 /obj/structure/closet/secure_closet/nervaquartermaster

--- a/maps/nerva/obj/nerva_items.dm
+++ b/maps/nerva/obj/nerva_items.dm
@@ -169,6 +169,38 @@
 			C.associated_account_number = station_account.account_number
 	..()
 
+//Nanotrasen account card and accompanying box for chief egghead
+/obj/item/card/id/station_account/nanotrasen
+	name = "Nanotrasen account card"
+	desc = "A company banking card with access to the local Nanotrasen budget, for job-related expenses."
+	item_state = "silver_id"
+	detail_color = COLOR_INDIGO
+	var/nanotrasen_money
+
+/obj/item/storage/lockbox/nanotrasen_account
+	name = "Nanotrasen account card lockbox"
+	desc = "A locked box used to store Nanotrasen's company card."
+	icon = 'icons/urist/items/tgitems.dmi'
+	icon_state = "medalbox+l"
+	item_state = "syringe_kit"
+	w_class = 3
+	max_w_class = 2
+	storage_slots = 7
+	icon_locked = "medalbox+l"
+	icon_closed = "medalbox"
+	icon_broken = "medalbox+b"
+	var/linked = FALSE
+	req_access = list(access_seniornt)
+	startswith = list(/obj/item/card/id/station_account/nanotrasen)
+
+/obj/item/storage/lockbox/nanotrasen_account/open(mob/user)
+	if(!linked)
+		linked = TRUE
+		for(var/obj/item/card/id/station_account/nanotrasen/N)
+			N.associated_account_number = nanotrasen_account.account_number
+			nanotrasen_account.money = rand(11000,44000)
+	..()
+
 //ammo boxes
 
 /obj/item/storage/box/nervaammo


### PR DESCRIPTION
Currently has anywhere from 11,000T to 44,000T each round. The lockbox is in the senior's locker, making it pretty hard for anyone but an antag or them to grab it, but it's also an antag objective too, so someone will eventually. Also adds an ATM to their office for ease of use.

Also fixes a bug where the account card lockboxes weren't updating their icons when you locked them again, and fixes them saying you locked the box when you unlocked the box.