### PR TITLE
Fixes Noctis Thrusters

### DIFF
--- a/maps/away/noctis/noctis.dm
+++ b/maps/away/noctis/noctis.dm
@@ -30,6 +30,7 @@
 	color = "#666666"
 	vessel_mass = 4000
 	burn_delay = 2 SECONDS
+	fore_dir = EAST
 	initial_restricted_waypoints = list(
 		"Raptor" = list("nav_noctis_raptor")
 	)


### PR DESCRIPTION
For some reason Bay decided Thrusters on ships should silently break if they're not facing the same way this one specific variable says.
See `code\modules\overmap\ships\engines\gas_thruster.dm` line 96