### PR TITLE
restores relays to get long distance relays working again

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -381,7 +381,6 @@
 	else
 		src.listening_levels = GLOB.using_map.contact_levels
 		return 1
-	return 0
 
 // RELAY
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -363,3 +363,49 @@
 	if(issilicon(user) || in_range(user, src))
 		return 1
 	return 0
+
+// Off-Site Relays
+//
+// You are able to send/receive signals from the station's z level (changeable in the STATION_Z #define) if
+// the relay is on the telecomm satellite (changable in the TELECOMM_Z #define)
+
+
+/obj/machinery/telecomms/relay/proc/toggle_level()
+
+	var/turf/position = get_turf(src)
+
+	// Toggle on/off getting signals from the station or the current Z level
+	if(src.listening_levels == GLOB.using_map.contact_levels) // equals the station
+		src.listening_levels = GetConnectedZlevels(position.z)
+		return 1
+	else
+		src.listening_levels = GLOB.using_map.contact_levels
+		return 1
+	return 0
+
+// RELAY
+
+/obj/machinery/telecomms/relay/Options_Menu()
+	var/dat = ""
+	if(src.z == TELECOMM_Z)
+		dat += "<br>Signal Locked to the [station_name()]: <A href='?src=\ref[src];change_listening=1'>[listening_levels == GLOB.using_map.contact_levels ? "TRUE" : "FALSE"]</a>"
+	dat += "<br>Broadcasting: <A href='?src=\ref[src];broadcast=1'>[broadcasting ? "YES" : "NO"]</a>"
+	dat += "<br>Receiving:    <A href='?src=\ref[src];receive=1'>[receiving ? "YES" : "NO"]</a>"
+	return dat
+
+/obj/machinery/telecomms/relay/Options_Topic(href, href_list)
+
+	if(href_list["receive"])
+		receiving = !receiving
+		temp = "<font color = #666633>-% Receiving mode changed. %-</font>"
+	if(href_list["broadcast"])
+		broadcasting = !broadcasting
+		temp = "<font color = #666633>-% Broadcasting mode changed. %-</font>"
+	if(href_list["change_listening"])
+		//Lock to the station OR lock to the current position!
+		//You need at least two receivers and two broadcasters for this to work, this includes the machine.
+		var/result = toggle_level()
+		if(result)
+			temp = "<font color = #666633>-% [src]'s signal has been successfully changed.</font>"
+		else
+			temp = "<font color = #666633>-% [src] could not lock it's signal onto the [station_name()]. Two broadcasters or receivers required.</font>"

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -299,8 +299,14 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 				relay_information(signal, /obj/machinery/telecomms/bus) // Send it to a bus instead, if it's linked to one
 
 /obj/machinery/telecomms/receiver/proc/check_receive_level(datum/signal/signal)
-
 	if(!(signal.data["level"] in listening_levels))
+		for(var/obj/machinery/telecomms/hub/H in links)
+			var/list/connected_levels = list()
+			for(var/obj/machinery/telecomms/relay/R in H.links)
+				if(R.can_receive(signal))
+					connected_levels |= R.listening_levels
+			if(signal.data["level"] in connected_levels)
+				return 1
 		return 0
 	return 1
 
@@ -338,6 +344,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			//If the signal is compressed, send it to the bus.
 			relay_information(signal, /obj/machinery/telecomms/bus, 1) // ideally relay the copied information to bus units
 		else
+			relay_information(signal, /obj/machinery/telecomms/relay, 1) // Get a list of relays that we're linked to, then send the signal to their levels.
 			relay_information(signal, /obj/machinery/telecomms/broadcaster, 1) // Send it to a broadcaster.
 
 /*
@@ -587,3 +594,59 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/name = "data packet (#)"
 	var/garbage_collector = 1 // if set to 0, will not be garbage collected
 	var/input_type = "Speech File"
+
+/*
+	The relay idles until it receives information. It then passes on that information
+	depending on where it came from.
+	The relay is needed in order to send information pass Z levels. It must be linked
+	with a HUB, the only other machine that can send/receive pass Z levels.
+*/
+
+/obj/machinery/telecomms/relay
+	name = "Telecommunication Relay"
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "relay"
+	desc = "A mighty piece of hardware used to send massive amounts of data far away."
+	density = TRUE
+	anchored = TRUE
+	machinetype = 8
+	produces_heat = 0
+//	circuitboard = /obj/item/weapon/stock_parts/circuitboard/telecomms/relay
+	base_type = /obj/machinery/telecomms/relay
+	netspeed = 5
+	long_range_link = 1
+	var/broadcasting = TRUE
+	var/receiving = TRUE
+
+// Relays on ship's Z levels use less power as they don't have to transmit over such large distances.
+/obj/machinery/telecomms/relay/update_power()
+	..()
+	if(z in GLOB.using_map.station_levels)
+		change_power_consumption(2.5 KILOWATTS, POWER_USE_IDLE)
+	else
+		change_power_consumption(100 KILOWATTS, POWER_USE_IDLE)
+
+/obj/machinery/telecomms/relay/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
+
+	// Add our level and send it back
+	if(can_send(signal))
+		signal.data["level"] |= listening_levels
+
+// Checks to see if it can send/receive.
+
+/obj/machinery/telecomms/relay/proc/can(datum/signal/signal)
+	if(!on)
+		return 0
+	if(!is_freq_listening(signal))
+		return 0
+	return 1
+
+/obj/machinery/telecomms/relay/proc/can_send(datum/signal/signal)
+	if(!can(signal))
+		return 0
+	return broadcasting
+
+/obj/machinery/telecomms/relay/proc/can_receive(datum/signal/signal)
+	if(!can(signal))
+		return 0
+	return receiving


### PR DESCRIPTION
Brings relays back, minus being constructable. The reason Bay removed them has never been an issue here, but this prevents it from ever being an issue. 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->