### PR TITLE
FBP buffs: Eject MMI verb, eating food for charge

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -74,14 +74,14 @@
 		if(I_HELP)
 			if(MUTATION_FERAL in M.mutations)
 				return 0
-			
+
 			# ifdef INCLUDE_URIST_CODE
 			if(urist_status_flags & STATUS_UNDEAD)
 				return 0
 			# endif
-			
+
 			if(H != src && istype(H) && (is_asystole() || (status_flags & FAKEDEATH) || failed_last_breath) && !(H.zone_sel.selecting == BP_R_ARM || H.zone_sel.selecting == BP_L_ARM))
-				
+
 				if (!cpr_time)
 					return 0
 
@@ -108,10 +108,10 @@
 						resuscitate()
 
 				if(!H.check_has_mouth())
-					to_chat(H, SPAN_WARNING("You don't have a mouth, you cannot do mouth-to-mouth resuscitation!"))
+					to_chat(H, SPAN_WARNING("You've done chest compressions, but you don't have a mouth to do mouth-to-mouth resuscitation!"))
 					return
 				if(!check_has_mouth())
-					to_chat(H, SPAN_WARNING("They don't have a mouth, you cannot do mouth-to-mouth resuscitation!"))
+					to_chat(H, SPAN_WARNING("You've done chest compressions, but they don't have a mouth to do mouth-to-mouth resuscitation!"))
 					return
 				if((H.head && (H.head.body_parts_covered & FACE)) || (H.wear_mask && (H.wear_mask.body_parts_covered & FACE)))
 					to_chat(H, SPAN_WARNING("You need to remove your mouth covering for mouth-to-mouth resuscitation!"))

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -114,3 +114,23 @@
 		return
 	var/list/rgb = rgb2num(new_skin)
 	change_skin_color(rgb[1], rgb[2], rgb[3])
+
+//fbp verbs
+
+/mob/living/carbon/human/proc/eject_mmi()
+	set name = "Eject MMI"
+	set desc = "Eject your MMI from its prosthetic housing."
+	set category = "Abilities"
+	set src = usr
+	if(ishuman(usr))
+		eject_my_mmi(usr)
+
+/mob/living/carbon/human/proc/eject_my_mmi()
+	var/obj/item/organ/internal/mmi_holder/internalmmi = internal_organs_by_name[BP_BRAIN]
+	var/input = alert(usr, "Are you sure you want to eject your MMI?", "Safety Check", "Yes", "No")
+	if(input != "Yes")
+		return
+	internalmmi.removed()
+	internalmmi.transfer_and_delete()
+	usr.visible_message(SPAN_NOTICE("\The [usr] opens up, ejecting \his MMI."), SPAN_NOTICE("You eject your MMI."))
+	usr.verbs -= /mob/living/carbon/human/proc/eject_mmi

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -154,6 +154,8 @@
 	stored_mmi.update_icon()
 	icon_state = stored_mmi.icon_state
 
+	owner.verbs += /mob/living/carbon/human/proc/eject_mmi
+
 	if(owner && owner.stat == DEAD)
 		owner.set_stat(CONSCIOUS)
 		owner.switch_from_dead_to_living_mob_list()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1,3 +1,5 @@
+#define ENERGY_PER_NUTRIMENT 30
+
 /obj/item/reagent_containers/food/snacks
 	name = "snack"
 	desc = "Yummy!"
@@ -114,10 +116,15 @@
 			if(eat_sound)
 				playsound(M, pick(eat_sound), rand(10, 50), 1)
 			if(reagents.total_volume)
+				var/obj/item/organ/internal/cell/potato = C.internal_organs_by_name[BP_CELL]
 				if(reagents.total_volume > bitesize)
 					reagents.trans_to_mob(M, bitesize, CHEM_INGEST)
+					if(potato)
+						potato.cell.give((reagents.get_reagent_amount(/datum/reagent/nutriment) / reagents.total_volume) * bitesize * ENERGY_PER_NUTRIMENT)
 				else
 					reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
+					if(potato)
+						potato.cell.give(reagents.get_reagent_amount(/datum/reagent/nutriment) * ENERGY_PER_NUTRIMENT)
 				bitecount++
 				OnConsume(M, user)
 			return 1
@@ -4146,3 +4153,5 @@
 	name = "taco"
 	desc = "Interestingly, the shell has gone soft and the contents have gone stale."
 	icon_state = "ancient_taco"
+
+#undef ENERGY_PER_NUTRIMENT

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -117,13 +117,14 @@
 				playsound(M, pick(eat_sound), rand(10, 50), 1)
 			if(reagents.total_volume)
 				var/obj/item/organ/internal/cell/potato = C.internal_organs_by_name[BP_CELL]
+				var/mob/living/carbon/human/H = M
 				if(reagents.total_volume > bitesize)
 					reagents.trans_to_mob(M, bitesize, CHEM_INGEST)
-					if(potato)
+					if(potato && H.isFBP())
 						potato.cell.give((reagents.get_reagent_amount(/datum/reagent/nutriment) / reagents.total_volume) * bitesize * ENERGY_PER_NUTRIMENT)
 				else
 					reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
-					if(potato)
+					if(potato && H.isFBP())
 						potato.cell.give(reagents.get_reagent_amount(/datum/reagent/nutriment) * ENERGY_PER_NUTRIMENT)
 				bitecount++
 				OnConsume(M, user)


### PR DESCRIPTION
- All Full Body Prosthetics should be able to eject their MMI from their bodies. Think pez dispensers. You'll need someone else to put you back into yourself.
- FBPs (that can eat) can eat nutriment-containing food for charge. They can't drink for charge (including drinking nutriment), and they won't benefit from animal protein (eating meat). Congrats on your Skrellian diet. Rechargers are still your main source of charge but you won't collapse in the bar.
- For reference, you get around 200 charge for most (vegetarian) meals. Protein bars give 190.
- CPR messages without a mouth have been clarified so it is more obvious that you are still being useful even if you have no mouth.