### PR TITLE
buffs overmap acceleration

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -12,7 +12,7 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 	var/list/known_sectors = list()
 	var/dx		//desitnation
 	var/dy		//coordinates
-	var/speedlimit = 1/(20 SECONDS) //top speed for autopilot, 5
+	var/speedlimit = 1/(10 SECONDS) //top speed for autopilot, 5
 	var/accellimit = 0.001 //manual limiter for acceleration
 	/// The mob currently operating the helm - The last one to click one of the movement buttons and be on the overmap screen. Set to `null` for autopilot or when the mob isn't in range.
 	var/mob/current_operator
@@ -210,9 +210,9 @@ LEGACY_RECORD_STRUCTURE(all_waypoints, waypoint)
 			speedlimit = round(clamp(newlimit, 0, linked.max_autopilot * 1000), 0.1) * 0.001
 
 	if (href_list["accellimit"])
-		var/newlimit = input("Input new acceleration limit (0 ~ 10)", "Acceleration limit", accellimit * 1000) as num|null
+		var/newlimit = input("Input new acceleration limit (0 ~ 20)", "Acceleration limit", accellimit * 1000) as num|null
 		if (!isnull(newlimit))
-			accellimit = round(clamp(newlimit, 0, 10)) * 0.001
+			accellimit = round(clamp(newlimit, 0, 20)) * 0.001
 
 	if (href_list["move"])
 		var/ndir = text2num(href_list["move"])

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -69,11 +69,11 @@ var/global/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 
 //Projected acceleration based on information from engines
 /obj/effect/overmap/visitable/ship/proc/get_acceleration()
-	return round(get_total_thrust()/get_vessel_mass(), SHIP_MOVE_RESOLUTION)
+	return round(2 * (get_total_thrust()/get_vessel_mass()), SHIP_MOVE_RESOLUTION)
 
 //Does actual burn and returns the resulting acceleration
 /obj/effect/overmap/visitable/ship/proc/get_burn_acceleration()
-	return round(burn() / get_vessel_mass(), SHIP_MOVE_RESOLUTION)
+	return round(2 * (burn() / get_vessel_mass()), SHIP_MOVE_RESOLUTION)
 
 /obj/effect/overmap/visitable/ship/proc/get_vessel_mass()
 	. = vessel_mass

--- a/maps/away/abandoned_colony/abandoned_colony_shuttle.dm
+++ b/maps/away/abandoned_colony/abandoned_colony_shuttle.dm
@@ -27,7 +27,8 @@
 	name = "ICS Morning Light"
 	shuttle = "ICS Morning Light"
 	fore_dir = EAST
-	vessel_mass = 1500
+	vessel_mass = 850
+	vessel_size = SHIP_SIZE_SMALL
 
 /area/morninglight
 	name = "\improper ICS Morning Light"

--- a/maps/nerva/nerva_overmap.dm
+++ b/maps/nerva/nerva_overmap.dm
@@ -3,7 +3,7 @@
 	ship_name = "ICS Nerva"
 	classification = "large class vessel"	//???
 	shipid = "nerva"
-	vessel_mass = 20000 //bigger than wyrm, smaller than torch //:fuckbay:
+	vessel_mass = 25000 //bigger than wyrm, smaller than torch //:fuckbay:
 	fore_dir = EAST
 	start_x = 6
 	start_y = 7
@@ -58,13 +58,15 @@
 	name = "Trajan"
 	shuttle = "Trajan"
 	fore_dir = NORTH
-	vessel_mass = 1500
+	vessel_mass = 1000
+	vessel_size = SHIP_SIZE_SMALL
 
 /obj/effect/overmap/visitable/ship/landable/hadrian
 	name = "Hadrian"
 	shuttle = "Hadrian"
 	fore_dir = EAST
-	vessel_mass = 1000
+	vessel_mass = 750
+	vessel_size = SHIP_SIZE_TINY
 
 /obj/effect/overmap/visitable/ship/combat/nerva/pve_mapfire(projectile_type)
 	if(ispath(projectile_type))


### PR DESCRIPTION
buffs ship acceleration, tweaks mass values and also assigns ship_size values for some urist shuttles so they don't get wrecked as hard by meteors.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->