### PR TITLE
Map-based Contracts

### DIFF
--- a/code/controllers/subsystems/factions.dm
+++ b/code/controllers/subsystems/factions.dm
@@ -14,9 +14,7 @@ SUBSYSTEM_DEF(factions)
 				hostile_factions.Add(F)
 
 	if(GLOB.using_map.trading_faction)
-		for(var/datum/factions/F in factions)
-			if(F.type == GLOB.using_map.trading_faction)
-				GLOB.using_map.trading_faction = F
+		GLOB.using_map.trading_faction = get_faction_by_type(GLOB.using_map.trading_faction)
 
 	. = ..()
 
@@ -42,3 +40,8 @@ SUBSYSTEM_DEF(factions)
 
 			else
 				M.faction = "neutral"
+
+/datum/controller/subsystem/factions/proc/get_faction_by_type(var/faction)
+	for(var/datum/factions/F in factions)
+		if(F.type == faction)
+			return F

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -128,6 +128,8 @@
 	icon_state = "sector"
 	anchored = TRUE
 
+	var/list/assigned_contracts = list() //what contracts do we assign on spawning. can be any /datum/contract
+
 	//used by exoplanets and awaymap planetoids
 	var/surface_color = null
 	var/water_color = null
@@ -139,6 +141,8 @@
 	if(known)
 		update_known_connections(TRUE)
 
+	if(assigned_contracts.len)
+		generate_away_contracts()
 
 /obj/effect/overmap/visitable/sector/update_known_connections(notify = FALSE)
 	. = ..()
@@ -176,3 +180,9 @@
 
 	testing("Overmap build complete.")
 	return 1
+
+/obj/effect/overmap/visitable/sector/proc/generate_away_contracts()
+	for(var/C in assigned_contracts)
+		if(ispath(C, /datum/contract))
+			var/datum/contract/contract = new C
+			GLOB.using_map.contracts += contract

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -26,6 +26,7 @@
 	var/list/place_near_main
 
 	var/hidden = FALSE //hidden for the purposes of tooltips. currently only used for the pirate station to avoid cheese
+	var/list/assigned_contracts = list() //what contracts do we assign on spawning. can be any /datum/contract
 
 /obj/effect/overmap/visitable/Initialize()
 	. = ..()
@@ -62,6 +63,9 @@
 
 	LAZYADD(SSshuttle.sectors_to_initialize, src) //Queued for further init. Will populate the waypoint lists; waypoints not spawned yet will be added in as they spawn.
 	SSshuttle.clear_init_queue()
+
+	if(assigned_contracts.len)
+		generate_away_contracts()
 
 //This is called later in the init order by SSshuttle to populate sector objects. Importantly for subtypes, shuttles will be created by then.
 /obj/effect/overmap/visitable/proc/populate_sector_objects()
@@ -122,13 +126,17 @@
 /obj/effect/overmap/visitable/proc/generate_skybox()
 	return
 
+/obj/effect/overmap/visitable/proc/generate_away_contracts()
+	for(var/C in assigned_contracts)
+		if(ispath(C, /datum/contract))
+			var/datum/contract/contract = new C
+			GLOB.using_map.contracts += contract
+
 /obj/effect/overmap/visitable/sector
 	name = "generic sector"
 	desc = "Sector with some stuff in it."
 	icon_state = "sector"
 	anchored = TRUE
-
-	var/list/assigned_contracts = list() //what contracts do we assign on spawning. can be any /datum/contract
 
 	//used by exoplanets and awaymap planetoids
 	var/surface_color = null
@@ -140,9 +148,6 @@
 
 	if(known)
 		update_known_connections(TRUE)
-
-	if(assigned_contracts.len)
-		generate_away_contracts()
 
 /obj/effect/overmap/visitable/sector/update_known_connections(notify = FALSE)
 	. = ..()
@@ -180,9 +185,3 @@
 
 	testing("Overmap build complete.")
 	return 1
-
-/obj/effect/overmap/visitable/sector/proc/generate_away_contracts()
-	for(var/C in assigned_contracts)
-		if(ispath(C, /datum/contract))
-			var/datum/contract/contract = new C
-			GLOB.using_map.contracts += contract

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -64,7 +64,7 @@
 	LAZYADD(SSshuttle.sectors_to_initialize, src) //Queued for further init. Will populate the waypoint lists; waypoints not spawned yet will be added in as they spawn.
 	SSshuttle.clear_init_queue()
 
-	if(assigned_contracts.len)
+	if(assigned_contracts.len && GLOB.using_map.using_new_cargo)
 		generate_away_contracts()
 
 //This is called later in the init order by SSshuttle to populate sector objects. Importantly for subtypes, shuttles will be created by then.

--- a/code/modules/urist/modules/newtrading/NPC/NPC_types/contract_givers.dm
+++ b/code/modules/urist/modules/newtrading/NPC/NPC_types/contract_givers.dm
@@ -54,7 +54,7 @@
 	glove_chance = 100
 
 	angryprob = 0
-	npc_item_amount = 7
+	npc_item_amount = 4
 	randomize_value = 0
 	randomize_quantity = 0
 	no_resell = 1

--- a/code/modules/urist/modules/newtrading/contracts/contract_papers.dm
+++ b/code/modules/urist/modules/newtrading/contracts/contract_papers.dm
@@ -31,12 +31,3 @@
 
 /obj/item/paper/contract/nanotrasen/anomaly
 	contract_type = /datum/contract/nanotrasen/anomaly
-
-/obj/item/paper/contract/nanotrasen/piratehunt
-	contract_type = /datum/contract/shiphunt
-
-/obj/item/paper/contract/nanotrasen/alienhunt
-	contract_type = /datum/contract/shiphunt/alien
-
-/obj/item/paper/contract/nanotrasen/piratestation
-	contract_type = /datum/contract/station_destroy/pirate

--- a/code/modules/urist/modules/newtrading/contracts/contracts.dm
+++ b/code/modules/urist/modules/newtrading/contracts/contracts.dm
@@ -4,10 +4,10 @@
 /datum/contract
 	var/name = null
 	var/desc = null
-	var/datum/factions/faction = null //who are we doing this for
+	var/datum/factions/faction = null //who are we doing this for //if unassigned, this uses GLOB.using_map.trading_faction
 	var/money = 0 //how much money are we getting
-	var/rep_points = 0 //how much rep are we getting
-	var/points_per_unit = 0
+	var/rep_points = 0 //how much rep are we getting //if points_per_unit and amount are set, that will determine this automatically
+	var/points_per_unit = 0 //how much rep per var/amount
 	var/neg_rep_points = 0 //how much rep do we lose
 	var/datum/factions/neg_faction = null //and from who
 	var/amount = 0 //how much of whatever we have to do
@@ -16,25 +16,30 @@
 /datum/contract/New()
 	..()
 
-	if(faction)
-		for(var/datum/factions/F in SSfactions.factions) //maybe turn this into an SSfactions proc?
-			if(F.type == faction)
-				faction = F
-
-	if(neg_faction)
-		for(var/datum/factions/F in SSfactions.factions)
-			if(F.type == neg_faction)
-				neg_faction = F
-
 	if(points_per_unit && amount)
 		rep_points = (points_per_unit * amount)
+
+	assign_factions()
+
+/datum/contract/proc/assign_factions()
+	if(neg_faction)
+		neg_faction = SSfactions.get_faction_by_type(neg_faction)
+
+	if(faction)
+		faction = SSfactions.get_faction_by_type(faction)
+
+	else
+		if(GLOB.using_map.trading_faction) //if we have no faction assigned, we use the trading_faction
+			faction = GLOB.using_map.trading_faction
+
 
 /datum/contract/proc/Complete(number = 0)
 	completed += number
 	if(completed >= amount)
-		SSfactions.update_reputation(faction, rep_points)
+		if(faction && rep_points)
+			SSfactions.update_reputation(faction, rep_points)
 
-		if(neg_faction)
+		if(neg_faction && neg_rep_points)
 			SSfactions.update_reputation(neg_faction, neg_rep_points)
 
 		var/datum/transaction/T = new("[GLOB.using_map.station_name]", "Contract Completion", money, "[faction.name]")
@@ -51,12 +56,12 @@
 	name = "Anomaly Research Contract"
 
 /datum/contract/nanotrasen/anomaly/New()
-	amount = rand(1,3)
-	money = (amount * rand(900,1750))
-	rep_points = amount
-	desc = "The Galactic Crisis has nearly eliminated NanoTrasen's presence in this sector. That's why NanoTrasen has contracted the [GLOB.using_map.station_name] to analyze [amount] of the anomalies in this sector for us. Good luck."
-
 	..()
+
+	amount = rand(1,3)
+	money = (amount * rand(1200,2200))
+	rep_points = amount
+	desc = "The Galactic Crisis has nearly eliminated NanoTrasen's presence in this sector. That's why NanoTrasen has contracted the [GLOB.using_map.station_name] to analyze [amount] of the anomalies in this sector for them. Good luck."
 
 /datum/contract/terran
 	faction = /datum/factions/terran
@@ -66,7 +71,7 @@
 
 //shiphunting
 
-/datum/contract/shiphunt/New()
+/datum/contract/shiphunt/New() //shiphunt contracts are resolved in urist/modules/shipbattles/overmapships/overmapships.dm, in the shipdeath() proc
 	if(!amount)
 		amount = rand(1,3)
 
@@ -78,33 +83,10 @@
 	if(!desc)
 		desc = "This sector is plagued by [neg_faction.factionid]s, [faction.name] needs the [GLOB.using_map.station_name] to hunt down and destroy [amount] [neg_faction.name] ships in this sector."
 
-
 	if(!neg_rep_points)
 		neg_rep_points -= rep_points
 
-//money values are very much in flux
+//station_destroy, see urist/structures/boardingstructures for where these are resolved. these need to have a neg_faction set that matches the station's faction
 
-/datum/contract/shiphunt
-	name = "Pirate Ship Hunt Contract"
-	neg_faction = /datum/factions/pirate
-	points_per_unit = 3
-	money = 4000
-	faction = /datum/factions/nanotrasen
-
-/datum/contract/shiphunt/alien
-	name = "Lactera Ship Hunt Contract"
-	neg_faction = /datum/factions/alien
-	rep_points = 7
+/datum/contract/station_destroy
 	amount = 1
-	money = 8500
-
-//station destroy
-
-/datum/contract/station_destroy/pirate
-	name = "Pirate Hideout Destruction Contract"
-	desc = "This sector is plagued by pirates. We need you to hunt down their hideout and destroy it for good."
-	neg_faction = /datum/factions/pirate
-	rep_points = 10
-	amount = 1
-	money = 20000
-	faction = /datum/factions/nanotrasen

--- a/code/modules/urist/modules/newtrading/trade/trade_items/contracts.dm
+++ b/code/modules/urist/modules/newtrading/trade/trade_items/contracts.dm
@@ -37,9 +37,9 @@
 	item_type = /obj/item/paper/contract/nanotrasen/cargo/ore
 	category = "ntsciencecontract"
 
-//shiphunt
+//shiphunt //moved to awaymap init
 
-/datum/trade_item/contract/ntsec/ntalienhunt
+/*/datum/trade_item/contract/ntsec/ntalienhunt
 	name = "Lactera Ship Hunt Contract"
 	item_type = /obj/item/paper/contract/nanotrasen/alienhunt
 	category = "ntseccontract"
@@ -52,7 +52,7 @@
 /datum/trade_item/contract/ntsec/ntpiratestation
 	name = "Pirate Hideout Destruction Contract"
 	item_type = /obj/item/paper/contract/nanotrasen/piratestation
-	category = "ntseccontract"
+	category = "ntseccontract"*/
 
 //robotics
 

--- a/maps/away/abandoned_colony/abandoned_colony.dm
+++ b/maps/away/abandoned_colony/abandoned_colony.dm
@@ -24,6 +24,7 @@
 	icon_state = "globe"
 	color = "#7f8274"
 	known = FALSE
+	assigned_contracts = list(/datum/contract/shiphunt/graveworld_alien)
 	initial_generic_waypoints = list(
 		"nav_abandoned_colony_1",
 		"nav_abandoned_colony_2"
@@ -70,3 +71,11 @@
 	_input_on = TRUE
 	_output_on = TRUE
 	_fully_charged = TRUE
+
+/datum/contract/shiphunt/graveworld_alien
+	name = "Lactera Ship Hunt Contract"
+	desc = "A lactera ship has been spotted in the local sector near a Graveworld. It's been harrassing local shipping traffic and needs to be eliminated. There's a good reward in it for you if you can get it done."
+	neg_faction = /datum/factions/alien
+	rep_points = 7
+	amount = 1
+	money = 8500

--- a/maps/away/stations/pirate/pirate_station.dm
+++ b/maps/away/stations/pirate/pirate_station.dm
@@ -40,6 +40,7 @@ var/global/const/access_away_pirate_station = "ACCESS_AWAY_PIRATE_STATION"
 	hidden = TRUE
 	spawn_ships = TRUE
 	spawn_types = list(/mob/living/simple_animal/hostile/overmapship/pirate/small, /mob/living/simple_animal/hostile/overmapship/pirate/med)
+	assigned_contracts = list(/datum/contract/shiphunt/pirate, /datum/contract/station_destroy/pirate)
 	initial_generic_waypoints = list(
 		"nav_piratestation_1",
 		"nav_piratestation_2",
@@ -101,3 +102,20 @@ var/global/const/access_away_pirate_station = "ACCESS_AWAY_PIRATE_STATION"
 		color = "#660000"
 		hidden = FALSE
 		make_known(TRUE)
+
+//money values are very much in flux
+
+/datum/contract/shiphunt/pirate
+	name = "Pirate Ship Hunt Contract"
+	neg_faction = /datum/factions/pirate
+	points_per_unit = 3
+	money = 4000
+
+//station destroy
+
+/datum/contract/station_destroy/pirate
+	name = "Pirate Hideout Destruction Contract"
+	desc = "This sector is plagued by pirates, who have set up a base somewhere in the asteroid fields. We need you to hunt down their hideout and destroy it for good. You can probably find more details regarding its location onboard the pirates' vessels."
+	neg_faction = /datum/factions/pirate
+	rep_points = 10
+	money = 30000

--- a/maps/nerva/nerva_setup.dm
+++ b/maps/nerva/nerva_setup.dm
@@ -57,4 +57,4 @@
 		welcome_text += "<hr>"
 
 	post_comm_message("ICS Nerva Sensor Readings", welcome_text)
-	minor_announcement.Announce(message = "New [GLOB.using_map.company_name] Update available at all communication consoles.")
+	minor_announcement.Announce(message = "New [GLOB.using_map.company_name] Update available at all communication consoles. Posted contracts for this sector have also been downloaded to [GLOB.using_map.full_name] computer systems.")

--- a/nano/templates/contract_database.tmpl
+++ b/nano/templates/contract_database.tmpl
@@ -11,7 +11,7 @@
 	<table style="width:100%">
 	<tr><th style="width:15%">Contract<th style="width:50%">Description<th style="width:15%">Issuer<th style="width:10%">Value<th style="width:5%">Required Amount<th style="width:5%">Amount Completed
 	{{for data.existing_contracts}}
-		<tr>
+		<tr class="candystripe">
 		<td>{{:value.name}}
 		<td>{{:value.desc}}
 		<td><center>{{:value.issuer}}</center>


### PR DESCRIPTION
Allows awaymaps to add contracts on a per-map basis. so lactera/pirate contracts only spawn when those maps do. This means that the Nerva will start the round with some other contracts assigned, although trading contracts are still acquired through traders. I like this way of doing it a lot better because it means that the crew doesn't have to go out of their way to engage with contracts beyond the anomaly one. It also means you can create contracts for specific awaymaps, which is the plan. This PR doesn't add any new contracts, but I have one in mind for destroyed_colony as part of my rework of that map, and others in mind for future awaymaps.

Also buffs the value of some contracts, slightly refactors faction/contract code, and tweaks the contract database to be a little more readable with multiple contracts on it.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->