### PR TITLE
Makes the top loaded smg not jam when loaded with real ammo

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -160,6 +160,7 @@
 	allowed_magazines = /obj/item/ammo_magazine/smg_top
 	accuracy_power = 7
 	one_hand_penalty = 3
+	jam_chance = 0
 
 	//machine pistol, like SMG but easier to one-hand with
 	firemodes = list(


### PR DESCRIPTION
for some reason unknown to me the WT550, the one that can be made from rnd, jams when loaded with non rubber bullets.
Sets the chance to jam to 0 (theoretically).