### PR TITLE
Removes superfluous mining sites, upgrades drill battery.

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/mining_drill.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/mining_drill.dm
@@ -9,8 +9,8 @@
 		/obj/item/stock_parts/micro_laser = 1)
 	additional_spawn_components = list(
 		/obj/item/stock_parts/power/battery/buildable/stock,
-		/obj/item/cell/standard = 1
-	)	
+		/obj/item/cell/high = 1
+	)
 
 /obj/item/stock_parts/circuitboard/miningdrillbrace
 	name = T_BOARD("mining drill brace")

--- a/maps/nerva/nerva.dm
+++ b/maps/nerva/nerva.dm
@@ -75,8 +75,6 @@
 	#include "../away/noctis/noctis.dm"
 	#include "../away/abandoned_colony/abandoned_colony.dm"
 	#include "../away/meatstation/meatstation.dm"
-	#include "../away/miningstation/miningstation.dm"
-	#include "../away/mininghome/mininghome.dm"
 	#include "../away/scavver_gantry/scavver_gantry.dm"
 
 	/*#include "../../code/datums/music_tracks/chasing_time.dm"


### PR DESCRIPTION
removes mining home and mining station maps from nerva.dm so they dont spawn and take up space from another possible away.

the current 500w power cells are laughably small, they used to be 1000w but at some point that got changed so this puts the high power cells in the drill heads by default.