### PR TITLE
Adjusts Forensic Kit Items

### DIFF
--- a/code/modules/detectivework/tools/crimekit.dm
+++ b/code/modules/detectivework/tools/crimekit.dm
@@ -40,5 +40,9 @@
 		/obj/item/storage/csi_markers,
 		/obj/item/device/scanner,
 		/obj/item/modular_computer/tablet,
-		/obj/item/evidencebag
+		/obj/item/evidencebag,
+		/obj/item/taperoll,
+		/obj/item/device/camera_film,
+		/datum/uplink_item/item/tools/ductape,
+		/obj/item/reagent_containers/food/drinks/flask/
 		)

--- a/code/modules/detectivework/tools/crimekit.dm
+++ b/code/modules/detectivework/tools/crimekit.dm
@@ -44,5 +44,5 @@
 		/obj/item/taperoll,
 		/obj/item/device/camera_film,
 		/datum/uplink_item/item/tools/ductape,
-		/obj/item/reagent_containers/food/drinks/flask/
+		/obj/item/reagent_containers/food/drinks/flask
 		)


### PR DESCRIPTION
**Allows the forensic kit to fit**

- Any type of tape (police type, engi, whatever)
- Camera Film
- Duct Tape
- Flasks (For sufficent booze drinking)