### PR TITLE
Significantly shifts spillover damage chances

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -139,7 +139,7 @@
 	if(!damage_amt)
 		return FALSE
 
-	var/organ_damage_threshold = 10
+	var/organ_damage_threshold = 5
 	if(damage_flags & DAMAGE_FLAG_SHARP)
 		organ_damage_threshold *= 0.5
 	if(laser)
@@ -153,7 +153,6 @@
 	for(var/obj/item/organ/internal/I in internal_organs)
 		if(I.damage < I.max_damage)
 			victims[I] = I.relative_size
-			organ_hit_chance += I.relative_size
 
 	//No damageable organs
 	if(!length(victims))


### PR DESCRIPTION
Shifts the chance of an attack causing internal organ damage from being the sum of organ relative_size + damage threshold to strictly damage threshold. The choice to halve the threshold is arbitrary and may need to be reduced further. 

In terms of gameplay effects this will be a massive nerf to fast firing and (relatively) low damage weapons being able to kill quickly.
Lasers in general will also be more likely to kill via blood loss or infection than organ disintegration. Higher caliber bullets retain a decent chance of penetration per hit.

