### PR TITLE
Configures Stale-bot

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -7,18 +7,33 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry Run"
+        type: boolean
+        default: false
+        required: true
 
 jobs:
   stale:
     permissions:
       issues: write # required to close stale issues
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8
         with:
-          stale-issue-message: 'This issue has not been updated in 30 days, and will close in 5 days from now if no updates are made.'
+          stale-issue-message: 'This issue has not been updated in 30 days, and will close in 5 days from now if no updates are made. Please address any outsanding queries from maintainers. If you have already done this and you are auto-staled anyway, ask a maintainer for an update.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          any-of-issue-labels: 'Awaiting Response'
+          exempt-issue-labels: 'Stale-b-gone'
+          stale-pr-message: 'This pull request has not been updated in 30 days, and will close in 7 days from now if no updates are made. Please address any outstanding review items and ensure your pull request is finished. If you have already done this and you are auto-staled anyway, ask a maintainer for an update.'
+          close-pr-message: 'This pull request was closed because it has been stalled for 7 days with no activity.'
+          exempt-draft-pr: true
+          exempt-pr-labels: 'CALL THE SHUTTLE,fuuuuuuuuuuuuck,Stale-b-gone'
+          exempt-pr-assignees: 'Glloyd'
           days-before-stale: 30
           days-before-close: 5
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
-          only-issue-labels: 'Runtime Error'
+          days-before-pr-close: 7
+          operations-per-run: 50
+          debug-only: ${{ inputs.dry-run }}


### PR DESCRIPTION
Currently we have quite a lot of stale PRs and issues. I noticed while we did have a stale-bot action, it was configured to basically do nothing at all...

Stale bot will now trigger for issues if:
- They have the `Awaiting Response` label AND
- They do not have the `Stale-b-gone` label AND
- They have been stale for a total of 35 days (Warning after 30, closed after 5 more)

The idea here is that issues won't be marked as stale unless the OP has essentially abandoned it. It won't get closed if maintainers just haven't done anything with it. In that case, the onus is on the maintainers to close issues that are no longer issues, old, or whatever; they must be looked at first. The idea is if an issue needs further information before it can be tackled, maintainers can apply the `Awaiting Response` label and then stale-bot will start to track it. That label can be removed if all info is provided, or left and the issue auto-closed by the bot if not.

PRs will be triggered if:
- They do NOT have the `CALL THE SHUTTLE`, `fuuuuuuuuuuuuck`, or `Stale-b-gone` labels - Idea being that critical PRs should kinda be left alone AND
- They have not been assigned to Glloyd AND
- They are not a draft AND
- They have been stale for a total of 37 days (Warning after 30, closed after 7 more)

For PRs it's a little different. It's up to the OP here to keep the PR active, either by addressing reviews with commits, or if maintainers forget about the PR, giving them a little poke.

It's worth noting for both of these, the `Stale` label can be removed to reset the counter, essentially buying more time.
There is also an override label `Stale-b-gone` which essentially exempts the PR/Issue from _any_ stale checks.

If this is accepted, the following labels will need to be added:

- `Stale`
- `Stale-b-gone`
- `Awaiting Response`

As always, happy to hear any feedback! Hopefully this can help clear up some issues/PRs we've got laying around and prompt more activity.