### PR TITLE
balance: BSR balance pass.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -456,6 +456,15 @@
 	//       from the POV of the total Distortion spread. It's not exactly equivalent - because the smaller the tickrate, the
 	//       more responsive the Distortion system will be, but it will also drain more resources to run.
 
+	// Probability of triggering a BSR Distortion for a tile depends on the current level of 'irradiation'.
+	// This represents the turf-level value that corresponds to 50% of max_chance_per_turf of triggering.
+	var/static/bluespace_revenant_distortion_maxchance_halfway_point = 500
+
+	// Cutoff max value for the probability of applying a BSR Distortion effect on an affected turf
+	// The actual runtime value is governed by a formula (using the maxchance_halfway_point),
+	// but will NEVER go higher than this.
+	var/static/bluespace_revenant_distortion_max_chance_per_turf = 8
+
 	// Amount of Distortion accumulated to trigger the first radius increase (1 -> 3 tiles across)
 	var/static/bluespace_revenant_radius_three_distortion_threshold = 12000 // 10 mins with 100/50 rates above
 
@@ -469,7 +478,7 @@
 	var/static/bluespace_revenant_radius_zlevel_spread_enabled = TRUE
 
 	// For Equivalent Exchange Hunger: how much does suppression grow per unit of wealth consumed?
-	var/static/bluespace_revenant_wealtheater_suppression_factor = 3
+	var/static/bluespace_revenant_wealtheater_suppression_factor = 1
 
 	// For Catabolic Stabilization Hunger: how much does suppression grow per unit of nutrition consumed?
 	var/static/bluespace_revenant_hongry_suppression_factor = 30
@@ -479,6 +488,12 @@
 
 	// For Rune Wards Hunger: discourages stockpiling/spamming; no more than this much suppression per tick will happen, so more runes is not necessarily more good
 	var/static/bluespace_revenant_runewards_max_suppression_coeff = 2
+
+	// For Bloodburner Hunger: how much does suppression grow per unit of blood/brute burned?
+	var/static/bluespace_revenant_bloodburner_suppression_factor = 300
+
+	// For Bloodthirsty Hunger: how much does suppression grow per sip of blood consumed?
+	var/static/bluespace_revenant_bloodthirsty_suppression_factor = 600
 	# endif
 
 
@@ -961,6 +976,12 @@
 			if ("bluespace_revenant_tickrate")
 				bluespace_revenant_tickrate = max(1, text2num(value))
 
+			if ("bluespace_revenant_distortion_max_chance_per_turf")
+				bluespace_revenant_tickrate = max(1, text2num(value))
+
+			if("bluespace_revenant_distortion_maxchance_halfway_point")
+				bluespace_revenant_distortion_maxchance_halfway_point = max(0, text2num(value))
+
 			if ("bluespace_revenant_radius_three_distortion_threshold")
 				bluespace_revenant_radius_three_distortion_threshold = max(0, text2num(value))
 
@@ -984,6 +1005,12 @@
 
 			if ("bluespace_revenant_runewards_max_suppression_coeff")
 				bluespace_revenant_runewards_max_suppression_coeff = max(0, text2num(value))
+
+			if ("bluespace_revenant_bloodburner_suppression_factor")
+				bluespace_revenant_bloodburner_suppression_factor = max(0, text2num(value))
+
+			if ("bluespace_revenant_runewards_max_suppression_coeff")
+				bluespace_revenant_bloodthirsty_suppression_factor = max(0, text2num(value))
 
 			# endif
 

--- a/code/modules/urist/antagonist/revenant/_defines.dm
+++ b/code/modules/urist/antagonist/revenant/_defines.dm
@@ -27,6 +27,7 @@
 # define BSR_FLAVOR_VAMPIRE "vampire"
 // You know who to blame for this...
 # define BSR_FLAVOR_DENTIST "dentist"
+// note for the future: Psi flavour
 
 # define BSR_ALL_FLAVORS_LIST list(BSR_FLAVOR_BLUESPACE, BSR_FLAVOR_CHIMERA, BSR_FLAVOR_OCCULT, BSR_FLAVOR_DEMONIC, BSR_FLAVOR_VAMPIRE)
 
@@ -34,8 +35,8 @@
 # define TRACKER_KEY_WARDS "wards"
 
 // const-ey things
-# define BSR_DEFAULT_MAXPERC_PER_TURF 10
-# define BSR_DEFAULT_HALFWAY_PER_TURF 200
+# define BSR_DEFAULT_MAXPERC_PER_TURF 5
+# define BSR_DEFAULT_HALFWAY_PER_TURF 500
 # define BSR_DEFAULT_DISTORTION_PER_TICK 100
 # define BSR_DEFAULT_DECISECONDS_PER_TICK 50 // 5 seconds
 

--- a/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
@@ -210,7 +210,7 @@
 		BSR_FLAVOR_FLESH,
 		BSR_FLAVOR_SCIFI,
 	)
-	activate_message = "<span class='notice'>You have an uncanny healing factor. You can heal minor damage and even stop bleeding - all at the low low price of just a little bit of damage to the local laws of physics.</span>"
+	activate_message = "<span class='notice'>You have an uncanny healing factor. You can replenish your blood and regenerate organs - all at the low low price of just a little bit of damage to the local laws of physics.</span>"
 	name = "Fleshmend"
 	isVerb = TRUE
 	verbpath = /mob/proc/bsrevenant_incremental_regen
@@ -331,6 +331,7 @@
 		BSR_FLAVOR_PLAGUE
 	)
 	name = "DISTORTION - Bloody Mess"
+	distortion_threshold = 24000 // 20 mins
 
 
 /datum/power/revenant/distortion/bloodymess/Apply(var/atom/A, var/datum/bluespace_revenant/revenant)

--- a/code/modules/urist/antagonist/revenant/archetypes/generic.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/generic.dm
@@ -5,9 +5,10 @@
 
 /obj/effect/effect/smoke/chill_mist
 	name = "fog"
+	layer = ABOVE_HUMAN_LAYER
 	opacity = 0
-	alpha = 64
-	time_to_live = 1000
+	alpha = 32
+	time_to_live = 1500
 
 
 /obj/effect/effect/smoke/chill_mist/affect(var/mob/living/carbon/M)
@@ -17,7 +18,7 @@
 	if(!istype(M))
 		return 0
 
-	if(prob(20))
+	if(prob(10))
 		// This is always cold enough to be uncomfortable for any species that
 		// has a preference; otherwise 5 Celsius, because barely above freezing.
 		var/mist_temp = ((M?.species?.cold_level_1 || 273) + 5)
@@ -39,7 +40,46 @@
 	smoke_type = /obj/effect/effect/smoke/chill_mist
 
 
-/datum/power/revenant/distortion/fogweaver
+/datum/power/revenant/distortion/fog_cold
+	flavor_tags = list(
+		BSR_FLAVOR_OCCULT,
+		BSR_FLAVOR_CULTIST,
+		BSR_FLAVOR_DEMONIC,
+		BSR_FLAVOR_VAMPIRE,
+		BSR_FLAVOR_GENERIC
+	)
+	name = "DISTORTION: Chill Fog"
+
+
+/datum/power/revenant/distortion/fog_cold/Apply(var/atom/A, var/datum/bluespace_revenant/revenant)
+	if(isnull(A) || !istype(A))
+		return
+
+	var/turf/T = get_turf(A)
+	if(!istype(T))
+		return
+
+	// There's a reason behind this varname and it's horrible. --scr
+	var/datum/effect/effect/system/smoke_spread/chill_mist/funfog = new()
+	funfog.set_up(5, 0, T)
+	funfog.start()
+
+	return TRUE
+
+
+/obj/effect/effect/smoke/spoopyfog
+	name = "fog"
+	layer = ABOVE_HUMAN_LAYER
+	opacity = 0
+	alpha = 32
+	time_to_live = 3000
+
+
+/datum/effect/effect/system/smoke_spread/spoopyfog
+	smoke_type = /obj/effect/effect/smoke/spoopyfog
+
+
+/datum/power/revenant/distortion/fog_plain
 	flavor_tags = list(
 		BSR_FLAVOR_OCCULT,
 		BSR_FLAVOR_CULTIST,
@@ -50,7 +90,7 @@
 	name = "DISTORTION: Fogweaver"
 
 
-/datum/power/revenant/distortion/fogweaver/Apply(var/atom/A, var/datum/bluespace_revenant/revenant)
+/datum/power/revenant/distortion/fog_plain/Apply(var/atom/A, var/datum/bluespace_revenant/revenant)
 	if(isnull(A) || !istype(A))
 		return
 
@@ -59,7 +99,8 @@
 		return
 
 	// There's a reason behind this varname and it's horrible. --scr
-	var/datum/effect/effect/system/smoke_spread/chill_mist/funfog = new()
+	var/datum/effect/effect/system/smoke_spread/spoopyfog/funfog = new()
+	funfog.attach(T)
 	funfog.set_up(5, 0, T)
 	funfog.start()
 

--- a/code/modules/urist/antagonist/revenant/archetypes/occult.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/occult.dm
@@ -311,6 +311,7 @@
 		BSR_FLAVOR_GENERIC
 	)
 	name = "DISTORTION - Veil Tear"
+	distortion_threshold = 36000 // 30 mins
 
 
 /datum/power/revenant/distortion/veil_tear/Apply(var/atom/A, var/datum/bluespace_revenant/revenant)
@@ -418,6 +419,7 @@
 		BSR_FLAVOR_VAMPIRE
 	)
 	name = "DISTORTION - Haunters"
+	distortion_threshold = 24000 // 20 mins
 
 
 /datum/power/revenant/distortion/haunters/Apply(var/atom/A, var/datum/bluespace_revenant/revenant)

--- a/code/modules/urist/antagonist/revenant/distortion.dm
+++ b/code/modules/urist/antagonist/revenant/distortion.dm
@@ -123,7 +123,7 @@
 
 	for(var/turf/simulated/T in block(startTurf, endTurf))
 		// Don't block stuff if this takes a while.
-		sleep(-1)
+		sleep(0)
 
 		// Let's only do simulated turfs for now - potentially less work & won't mess up eventey bits
 		if(!istype(T))

--- a/config/config.txt
+++ b/config/config.txt
@@ -545,3 +545,50 @@ ALLOW_DRONE_SPAWN
 
 ## Max amount of maintenance drones that can spawn. Default is 5
 #MAX_MAINT_DRONES 5
+
+## 
+## Bluespace Revenant antag balance stuff:
+## 
+
+## Personal Distortion growth per tick
+BLUESPACE_REVENANT_DISTORTION_RATE 100
+
+## Decisecond delay between BSR ticks
+BLUESPACE_REVENANT_TICKRATE 50
+
+## Probability of triggering a BSR Distortion effect for a tile depends on the current level of 'irradiation'.
+## This represents the turf-level Distortion that corresponds to 50% of max_chance_per_turf of triggering.
+BLUESPACE_REVENANT_DISTORTION_MAXCHANCE_HALFWAY_POINT 500
+
+## Cutoff max probability value for applying a BSR Distortion effect on an affected turf
+BLUESPACE_REVENANT_DISTORTION_MAX_CHANCE_PER_TURF 8
+
+## Amount of Distortion accumulated to trigger the first radius increase (1 -> 3 tiles across)
+BLUESPACE_REVENANT_RADIUS_THREE_DISTORTION_THRESHOLD 12000
+
+## Amount of Distortion accumulated to trigger the second radius increase (3 -> 5 tiles across)
+BLUESPACE_REVENANT_RADIUS_FIVE_DISTORTION_THRESHOLD 36000
+
+## Amount of Distortion accumulated to trigger the third radius increase (5 -> 7 tiles across)
+BLUESPACE_REVENANT_RADIUS_SEVEN_DISTORTION_THRESHOLD 98000
+
+## Can Distortion spread across adjacent station z-levels? NOTE: more CPU-heavy!
+BLUESPACE_REVENANT_RADIUS_ZLEVEL_SPREAD_ENABLED 1
+
+## For Equivalent Exchange Hunger: how much does suppression grow per unit of wealth consumed?
+BLUESPACE_REVENANT_WEALTHEATER_SUPPRESSION_FACTOR 1
+
+## For Catabolic Stabilization Hunger: how much does suppression grow per unit of nutrition consumed?
+BLUESPACE_REVENANT_HONGRY_SUPPRESSION_FACTOR 30
+
+## For Rune Wards Hunger: how much does suppression grow per rune, in fractions of normal growth/decisecond
+BLUESPACE_REVENANT_RUNEWARDS_SUPPRESSION_PER_WARD_FACTOR 0.2
+
+## For Rune Wards Hunger: discourages stockpiling/spamming; no more than this much suppression per tick will happen, so more runes is not necessarily more good
+BLUESPACE_REVENANT_RUNEWARDS_MAX_SUPPRESSION_COEFF 2
+
+## For Bloodburner Hunger: how much does suppression grow per unit of blood/brute burned?
+BLUESPACE_REVENANT_BLOODBURNER_SUPPRESSION_FACTOR 3000
+
+## For Bloodthirsty Hunger: how much does suppression grow per sip of blood consumed?
+BLUESPACE_REVENANT_BLOODTHIRSTY_SUPPRESSION_FACTOR 600


### PR DESCRIPTION
Generally, meant to throttle the sheer insanity of BSR as-is. 

- Added thresholds for (some) Distortion FX.
- Hostile NPC spawns less likely.
- Tuned down Distortion effect rate significantly; now defaults to 5% chance of effect per tile in the worst case and the slope to that point is much longer. 
- Fixed goldeater Hunger (was using SStrade unnecessarily)
- Fixed vampbites (was too low priority)
- Fixed some strings.
- Configified some stuff.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->