### PR TITLE
Adjusts organ spillover from playtesting

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -139,11 +139,11 @@
 	if(!damage_amt)
 		return FALSE
 
-	var/organ_damage_threshold = 5
+	var/organ_damage_threshold = 10
 	if(damage_flags & DAMAGE_FLAG_SHARP)
-		organ_damage_threshold *= 0.5
+		organ_damage_threshold *= 0.75
 	if(laser)
-		organ_damage_threshold *= 2
+		organ_damage_threshold *= 1.5
 
 	if(!(cur_damage + damage_amt >= max_damage) && !(damage_amt >= organ_damage_threshold))
 		return FALSE
@@ -158,7 +158,7 @@
 	if(!length(victims))
 		return FALSE
 
-	organ_hit_chance += 5 * damage_amt/organ_damage_threshold
+	organ_hit_chance += 10 * (damage_amt/organ_damage_threshold) * (cur_damage/max_damage)
 
 	if(encased && !(status & ORGAN_BROKEN)) //ribs protect
 		organ_hit_chance *= 0.6


### PR DESCRIPTION
The amount of damage over max_damage now increases the chance of hitting organs. Should prevent issues with people racking up 300+ damage with only small to moderate organ damage from luck.
Bullets are shifted down a small amount and most lasers are given a roughly 6% base increase.
The minimum damage amount is reverted with the ratio buffed accordingly, this just prevents very low force items dealing damage.