### PR TITLE
Fixes TC Changes lost in Merge, Adjusts new Bay additions.

### DIFF
--- a/code/datums/uplink/augments.dm
+++ b/code/datums/uplink/augments.dm
@@ -10,14 +10,14 @@
 	desc = "This flexible air sack housed in your torso slowly fills with safe air as you breathe, and can be used as a low-capacity internals source if nothing else is available. \
 	It will automatically filter out the safest air for your species. It has been configured to be undetectable on body scanners. \
 	NOTE: This augment is incompatible with synthetic biologies."
-	item_cost = 24
+	item_cost = 20
 	path = /obj/item/device/augment_implanter/internal_air_system
 
 /datum/uplink_item/item/augment/aug_adaptive_binoculars
 	name = "Adaptive Binoculars CBM (head)"
 	desc = "A pair of ultrathin lenses can be deployed or retracted at will from your eye sockets. They have powerful zoom capabilities, allowing you to see into the distance. \
 	They have been configured to be undetectable on body scanners."
-	item_cost = 30
+	item_cost = 16
 	path = /obj/item/device/augment_implanter/adaptive_binoculars
 
 /datum/uplink_item/item/augment/aug_iatric_monitor
@@ -25,7 +25,7 @@
 	desc = "A small computer system attached to the brain stem that monitors your life signs. It has been configured to be undetectable on body scanners. \
 	It can be activated to gain a simple readout of your current physical state that can be understood regardless of your medical skill. \
 	NOTE: This augment is incompatible with synthetic biologies."
-	item_cost = 20
+	item_cost = 12
 	path = /obj/item/device/augment_implanter/iatric_monitor
 
 /datum/uplink_item/item/augment/aug_wrist_blade

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -118,7 +118,7 @@
 /datum/uplink_item/item/tools/flashdark
 	name = "Flashdark"
 	desc = "A device similar to a flash light that absorbs the surrounding light, casting a shadowy, black mass."
-	item_cost = 32
+	item_cost = 20
 	path = /obj/item/device/flashlight/flashdark
 
 /datum/uplink_item/item/tools/powersink

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -13,7 +13,7 @@
 /datum/uplink_item/item/visible_weapons/shuriken
 	name = "Box of shurikens"
 	desc = "A small box with six shuriken, notably dangerous."
-	item_cost = 18
+	item_cost = 16
 	path = /obj/item/storage/box/syndie_kit/shuriken
 
 /datum/uplink_item/item/visible_weapons/dartgun
@@ -32,7 +32,7 @@
 /datum/uplink_item/item/visible_weapons/pikecube
 	name = "Pike Cube"
 	desc = "While it looks like a normal monkey cube, the animal produced is, instead, a space pike. \ Note: The space pike does not like you."
-	item_cost = 44
+	item_cost = 36
 	path = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/pikecube
 
 /datum/uplink_item/item/visible_weapons/katana
@@ -154,7 +154,7 @@
 /datum/uplink_item/item/visible_weapons/sawnoff
 	name = "Sawnoff Shotgun"
 	desc = "A shortened double-barrel shotgun, able to fire either one, or both, barrels at once."
-	item_cost = 45
+	item_cost = 40
 	path = /obj/item/gun/projectile/shotgun/doublebarrel/sawn
 
 /datum/uplink_item/item/visible_weapons/deagle

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -13,7 +13,7 @@
 /datum/uplink_item/item/medical/combatstim
 	name = "Combat Stimulants"
 	desc = "A single-use medical injector filled with performance enhancing drugs."
-	item_cost = 14
+	item_cost = 10
 	path = /obj/item/reagent_containers/hypospray/autoinjector/combatstim
 
 /datum/uplink_item/item/medical/stabilisation
@@ -25,13 +25,13 @@
 /datum/uplink_item/item/medical/stasis
 	name = "Stasis Bag"
 	desc = "Reusable bag designed to slow down life functions of occupant, especially useful if short on time or in a hostile enviroment."
-	item_cost = 24
+	item_cost = 12
 	path = /obj/item/bodybag/cryobag
 
 /datum/uplink_item/item/medical/defib
 	name = "Combat Defibrillator"
 	desc = "A belt-equipped defibrillator that can be rapidly deployed. Does not have the restrictions or safeties of conventional defibrillators and can revive through space suits."
-	item_cost = 24
+	item_cost = 16
 	path = /obj/item/defibrillator/compact/combat/loaded
 
 /datum/uplink_item/item/medical/advancedmedibag

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -7,13 +7,13 @@
 /datum/uplink_item/item/services/fake_ion_storm
 	name = "Ion Storm Announcement"
 	desc = "A single-use device, that when activated, fakes an announcement, so people think all their electronic readings are wrong."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/device/uplink_service/fake_ion_storm
 
 /datum/uplink_item/item/services/suit_sensor_garble
 	name = "Complete Suit Sensor Jamming"
 	desc = "A single-use device, that when activated, garbles all suit sensor data for 10 minutes."
-	item_cost = 16
+	item_cost = 12
 	path = /obj/item/device/uplink_service/jamming/garble
 
 /datum/uplink_item/item/services/fake_rad_storm
@@ -37,7 +37,7 @@
 /datum/uplink_item/item/services/suit_sensor_shutdown
 	name = "Complete Suit Sensor Shutdown"
 	desc = "A single-use device, that when activated, completely disables all suit sensors for 10 minutes."
-	item_cost = 40
+	item_cost = 32
 	path = /obj/item/device/uplink_service/jamming
 
 /***************

--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -37,7 +37,7 @@
 /datum/uplink_item/item/stealth_items/spy
 	name = "Bug Kit"
 	desc = "For when you want to conduct voyeurism from afar. Comes with 6 bugs to plant, and a monitoring device to pair them with."
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/storage/box/syndie_kit/spy
 
 /datum/uplink_item/item/stealth_items/id


### PR DESCRIPTION
Adjusts some of the old changes to TC lost in the baymerge for specific uplink items - 

Flashdark - 20TC now
Most medicine related things uplink wise
Ion Announcement, Suit Sensor Announcement.
Bug Kit. 6TC
Sawn Off Shotgun - 40 TC

Reduces TC Cost of certain new Bay Additions -

Internal Air CBM - 24TC -> 20TC

Adaptive Binocular 30TC - 16TC - (I don't even think I've seen anyone use this)

Iatric Monitor CBM - 20TC -> 12TC - (The same)

Shruikens - 18TC -> 16TC

Hopefully that's all of them
