### PR TITLE
cane/coin fixes

### DIFF
--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -86,7 +86,7 @@
 /obj/item/gun/projectile/shotgun/cane/on_update_icon()
 	return
 
-/obj/item/gun/projectile/shotgun/cane/Fire(atom/target, mob/living/user, clickparams, pointblank, reflex, dual_wield=0)
+/*/obj/item/gun/projectile/shotgun/cane/Fire(atom/target, mob/living/user, clickparams, pointblank, reflex, dual_wield=0)
 	if (safety_state)
 		to_chat(user, SPAN_WARNING("You can't fire \the [src] without readying it!"))
 		return
@@ -104,3 +104,4 @@
 /obj/item/gun/projectile/shotgun/cane/get_antag_interactions_info()
 	. = ..()
 	.["CTRL+CLICK"] = "<p>Toggles the concealed trigger, acting in place of a safety.</p>"
+*/

--- a/code/modules/urist/items/miscitems.dm
+++ b/code/modules/urist/items/miscitems.dm
@@ -608,6 +608,7 @@
 	icon = 'icons/urist/items/misc.dmi'
 	icon_state = "oldcoin4"
 	default_material = MATERIAL_COPPER
+	applies_material_name = FALSE
 
 /obj/item/material/coin/challenge/loot/plat
 	name = "\improper old platinum coin"
@@ -615,6 +616,7 @@
 	icon = 'icons/urist/items/misc.dmi'
 	icon_state = "oldcoin1"
 	default_material = MATERIAL_PLATINUM
+	applies_material_name = FALSE
 
 /obj/item/material/coin/challenge/loot/gold
 	name = "\improper old gold coin"
@@ -622,6 +624,7 @@
 	icon = 'icons/urist/items/misc.dmi'
 	icon_state = "oldcoin2"
 	default_material = MATERIAL_GOLD
+	applies_material_name = FALSE
 
 /obj/item/material/coin/challenge/loot/silver
 	name = "\improper old silver coin"
@@ -629,6 +632,7 @@
 	icon = 'icons/urist/items/misc.dmi'
 	icon_state = "oldcoin3"
 	default_material = MATERIAL_SILVER
+	applies_material_name = FALSE
 
 /obj/item/treasure/gem
 	name = "astonishing amethyst"


### PR DESCRIPTION
The traitor caneshotgun is no longer safe, can be fired
removed material name from loot coins