### PR TITLE
IPC/FBP buffs: microbattery health boost, posibrains break instead of being destroyed, robotics mapping

### DIFF
--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -12,6 +12,8 @@
 	//at 0.26 completely depleted after 60ish minutes of constant walking or 130 minutes of standing still
 	var/servo_cost = 0.26
 
+	max_damage = 50
+
 /obj/item/organ/internal/cell/New()
 	robotize()
 	if(ispath(cell))

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -14,9 +14,9 @@
 	throw_range = 5
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 4, TECH_BLUESPACE = 2, TECH_DATA = 4)
 	attack_verb = list("attacked", "slapped", "whacked")
-	max_damage = 90
-	min_bruised_damage = 30
-	min_broken_damage = 60
+	max_damage = 40
+	min_bruised_damage = 10
+	min_broken_damage = 30
 	relative_size = 60
 
 	var/mob/living/silicon/sil_brainmob/brainmob = null
@@ -281,15 +281,11 @@
 
 /obj/item/organ/internal/posibrain/die()
 	damage = max_damage
-	status |= ORGAN_DEAD
+	status |= ORGAN_BROKEN
 	STOP_PROCESSING(SSobj, src)
 	death_time = world.time
-	var/mob/self = owner || brainmob
-	if (self && self.mind)
-		self.visible_message("\The [self] unceremoniously falls lifeless.")
-		var/mob/observer/ghost/G = self.ghostize(FALSE)
-		if (G) // In case of aghosts or keyless mobs
-			G.timeofdeath = world.time
+	if((status & ORGAN_BROKEN) && dead_icon)
+		icon_state = dead_icon
 
 /*
 	This is for law stuff directly. This is how a human mob will be able to communicate with the posi_brainmob in the

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -720,7 +720,7 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 24
 	},
-/obj/machinery/organ_printer/robot/mapped,
+/obj/random/plushie,
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "abP" = (
@@ -19250,12 +19250,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mechbay)
 "aHz" = (
-/obj/structure/table/rack,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/plasteel/fifty,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -19263,9 +19257,8 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
-/obj/item/stack/material/aluminium/fifty,
-/obj/item/stack/material/plastic/fifty,
 /obj/effect/floor_decal/floordetail/tiled,
+/obj/machinery/organ_printer/robot/mapped,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mechbay)
 "aHA" = (
@@ -19286,6 +19279,7 @@
 	pixel_y = 26;
 	req_access = list("ACCESS_ROBOTICS")
 	},
+/obj/item/stack/nanopaste,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
 "aHB" = (
@@ -21859,6 +21853,14 @@
 	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/floordetail/tiled,
+/obj/structure/table/rack,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/plasteel/fifty,
+/obj/item/stack/material/aluminium/fifty,
+/obj/item/stack/material/plastic/fifty,
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mechbay)
 "aMi" = (


### PR DESCRIPTION
- IPC/FBP buff: Getting hit in your microbattery is now closer to a twoshot than a oneshot.
- buff/change: IPCs are the only species with no revival mechanics. To fix this, the positronic brain can no longer be destroyed, only broken (like pre-merge).
How this works ingame: IPCs get shot, it usually (but not always) hits the posibrain first, causing negative effects that get worse with more damage. After breaking, further damage spills over into the microbattery, IPC is crit. Destroying the microbattery kills the IPC (like FBPs) until the battery is replaced. You can still get bad RNG and get hit in the microbattery straight away.
Since the posibrain has more health than an MMI this does end in IPCs being tankier than FBPs (who were very weak in the first place) but in testing still at human levels of resilience, with added penalties from posibrain damage.
- The prosthetic organ printer has been moved from medbay to robotics.
- Adds 1 nanopaste to Robotics.