### PR TITLE
Updated + New issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,12 +1,13 @@
 # Docs - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
 name: Bug Report
 description: File a bug report
+labels: ["Bug", "Needs Triage"]
 
 body:
   - type: markdown
     attributes:
       value: |
-        Make sure to [search for an existing issue report](https://github.com/Baystation12/Baystation12/issues) before making a new one.
+        Make sure to [search for an existing issue report](https://github.com/UristMcStation/UristMcStation/issues) before making a new one.
 
         Your issue will be tagged by a developer with reproduction status and a priority once it has been reviewed and verified.
   - type: textarea
@@ -25,7 +26,7 @@ body:
     id: repro-steps
     attributes:
       label: Steps to reproduce
-      description: Please provide a complete step-by-step method of reproducing the bug, including steps you may think are obvious. Also please make sure you have followed and verified these steps reproduce the bug yourself. Being verbose is better than being vague. If reproduction is unreliable, i.e., it only happens sometimes or only happened once, mention that in the reproduction steps.
+      description: Please provide a complete step-by-step method of reproducing the bug, including steps you may think are obvious. Also please make sure you have followed and verified these steps to reproduce the bug yourself. Being verbose is better than being vague. If reproduction is unreliable, i.e., it only happens sometimes or only happened once, mention that in the reproduction steps.
       placeholder: |
         1.
         2.
@@ -64,4 +65,4 @@ body:
         - label: Issue could be reproduced by different players
         - label: Issue could be reproduced in multiple rounds
         - label: Issue happened in a recent (less than 7 days ago) round
-        - label: "[Couldn't find an existing issue about this](https://github.com/Baystation12/Baystation12/issues)"
+        - label: "[Couldn't find an existing issue about this](https://github.com/UristMcStation/UristMcStation/issues)"

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,24 @@
+# Docs - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+name: Request Feature
+description: Submit a feature request
+labels: ["Request"]
+
+body:
+  - type: textarea
+    id: issue
+    attributes:
+      label: Describe the problem you're trying to solve
+      placeholder: Geese are kinda boring and not as threatening as they should be
+    validations:
+      required: true
+  - type: textarea
+    id: feature
+    attributes:
+      label: Describe the solution you'd like to see
+      description: |
+        Please provide a solution to the problem you've raised; going into as much detail as possible, and explaining your reasoning.
+
+        If you do not have a solution, you should [submit feedback](https://github.com/UristMcStation/UristMcStation/issues/new/choose) instead.
+      placeholder: Give geese the ability to hold guns.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feedback.yaml
+++ b/.github/ISSUE_TEMPLATE/feedback.yaml
@@ -1,0 +1,17 @@
+# Docs - https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+name: Feedback
+description: Provide general feedback for gameplay features
+labels: ["Feedback"]
+
+body:
+  - type: textarea
+    id: feedback
+    attributes:
+      label: Feedback
+      description: |
+        Provide feedback about a gameplay feature. Be sure to include as much detail and reasoning as possible.
+
+        Have a problem but also specific ideas on how to solve it? [Raise a feature request](https://github.com/UristMcStation/UristMcStation/issues/new/choose) instead.
+      placeholder: I feel like geese aren't strong enough, they should be stronger than they are now.
+    validations:
+      required: true


### PR DESCRIPTION
My repo poking continues.

As I earlier suggested in the Discord that we try to use the GitHub issue tracker more, it got me poking around looking at how we could potentially improve it a little. The main thing I saw was a lack of self label assignment to help categorise issues without requiring a maintainer to do it manually.
Another reason for this is as we're using issue forms, there's no flexibility left to the end-user, so it's either submit a bug report or... Jog on.

Adds the following:

- Adds the `Bug` and `Needs Triage` labels to new bug report issues. We already have different priority labels, so adding a label that declares the absence of those can help identify issues that have not yet been looked at. Easy way to filter the list
- Adds the Feature Request template. Does what it says, adds the `Request` label to the issue and a new form better suited for, well, a feature request. This is intended for people who have a problem/issue with the current state of things, but a feature they'd like to see added to remedy it.
- Adds the Feedback template. Again, does what it says, adds the `Feedback` label. This template is more aimed at people who have feedback about game mechanics, but not necessarily their own solution. More of a conversational thread

Writing is not my forte, so I'd greatly appreciate any feedback regarding to the form wording, or even the general idea of course.