### PR TITLE
fix: NT Station NPC fixes

### DIFF
--- a/code/modules/urist/gamemodes/scom/civilian_mobs.dm
+++ b/code/modules/urist/gamemodes/scom/civilian_mobs.dm
@@ -56,6 +56,7 @@
 
 /datum/ai_holder/simple_animal/humanoid/police
 	hostile = FALSE
+	retaliate = TRUE
 	pointblank = TRUE
 
 /datum/say_list/police

--- a/code/modules/urist/modules/newtrading/NPC/npc.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc.dm
@@ -113,7 +113,7 @@
 		p.ai_holder.react_to_attack(attacker)
 
 /mob/living/simple_animal/passive/npc/proc/can_use(mob/M)
-	if(M.stat || M.restrained() || M.lying || !istype(M, /mob/living) || get_dist(M, src) > 1)
+	if(!istype(M, /mob/living) || M.stat || M.restrained() || M.lying || get_dist(M, src) > 1)
 		return 0
 	return 1
 

--- a/code/modules/urist/modules/newtrading/NPC/npc.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc.dm
@@ -104,8 +104,13 @@
 
 /datum/ai_holder/simple_animal/passive/nowandering/react_to_attack(atom/movable/attacker)
 	. = ..()
+
+	if(!attacker)
+		return
+
 	for(var/mob/living/simple_animal/hostile/scom/civ/combat/police/p in orange(7, holder))
-		p.ai_holder.hostile = TRUE
+		p.ai_holder.add_attacker(attacker)
+		p.ai_holder.react_to_attack(attacker)
 
 /mob/living/simple_animal/passive/npc/proc/can_use(mob/M)
 	if(M.stat || M.restrained() || M.lying || !istype(M, /mob/living) || get_dist(M, src) > 1)

--- a/code/modules/urist/modules/newtrading/NPC/npc_interact.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc_interact.dm
@@ -7,23 +7,29 @@
 	attack_hand(usr)
 
 /mob/living/simple_animal/passive/npc/attack_hand(mob/living/user)
-	if(user && istype(user) && can_use(user))
+	if(src.stat != CONSCIOUS)
+		to_chat(user, "[src] doesn't look like he's in any shape to trade right now...")
+		interacting_mob = null
+		return
 
-		if(interacting_mob && !can_use(interacting_mob))
-			interacting_mob = null
+	if(!(user && istype(user) && can_use(user)))
+		return
 
-		if(interacting_mob && interacting_mob != user)
-			to_chat(user, "[src] is already dealing with [interacting_mob]!")
+	if(interacting_mob && !can_use(interacting_mob))
+		interacting_mob = null
 
-		else
-			current_greeting_index = rand(1, length(greetings))
-			say(greetings[current_greeting_index])
-			ai_holder.speak_chance = 0
+	if(interacting_mob && interacting_mob != user)
+		to_chat(user, "[src] is already dealing with [interacting_mob]!")
+		return
 
-			add_fingerprint(user)
-			user.set_machine(src)
-			interacting_mob = user
-			ui_interact(user)
+	current_greeting_index = rand(1, length(greetings))
+	say(greetings[current_greeting_index])
+	ai_holder.speak_chance = 0
+
+	add_fingerprint(user)
+	user.set_machine(src)
+	interacting_mob = user
+	ui_interact(user)
 
 /mob/living/simple_animal/passive/npc/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, var/force_open = 1)
 

--- a/code/modules/urist/modules/newtrading/NPC/npc_interact.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc_interact.dm
@@ -12,7 +12,7 @@
 		interacting_mob = null
 		return
 
-	if(!(user && istype(user) && can_use(user)))
+	if(!can_use(user))
 		return
 
 	if(interacting_mob && !can_use(interacting_mob))


### PR DESCRIPTION
- Stops NPC traders from trading beyond the grave. Dead or unconscious NPCs don't trade anymore.
- Fixed cops going psycho at *everyone*. Instead, they get mad at whoever is going psycho, by name. This has two side-effects:
  1. A clever traitor can disguise themselves as an innocent crewmember before going on a spree. This turns the station hostile _to the framed crewmember_
  2. Unfortunately, cops stop shouting a warning. This is due to Bay AI code check skipping a taunt if the source has an attacker.

This is currently a rough, quick fix. I'm not very happy with the police logic, but a more global solution is a lot more work and I'd rather fix the immediate issues first.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->