### PR TITLE
fix: Fixes Deepmaint death hook not checking if the source area is in Deepmaint

### DIFF
--- a/code/modules/urist/modules/wfc/modules/deepmaint/hooks.dm
+++ b/code/modules/urist/modules/wfc/modules/deepmaint/hooks.dm
@@ -9,6 +9,10 @@
 	return TRUE
 	#endif
 
+	var/area/map_template/deepmaint_wfc/deepmaint_area = get_area(deadman)
+	if(!istype(deepmaint_area))
+		return TRUE
+
 	// check area
 	// if deepmaint, move to station maint
 	// if gibbed, spawn gibspawner


### PR DESCRIPTION
Herp da derp.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->