### PR TITLE
Fixed landmark regression

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -761,7 +761,9 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 					temp_target_turf.underlays = old_underlays
 					for (var/obj/obj in source_turf)
 						if (!obj.simulated)
-							continue
+							var/obj/effect/landmark/LM = obj	//Check for hologram landmarks
+							if(!istype(LM) || !LM.can_copy)
+								continue
 						copied_movables += clone_atom(obj, TRUE, temp_target_turf)
 					for (var/mob/mob in source_turf)
 						if (!mob.simulated)


### PR DESCRIPTION
Fixes #1286 
Check for the landmark var `can_copy` was removed in the merge from the `copy_contents_to` proc. This var + check was originally introduced in #1062 