### PR TITLE
restores select equipment to the rightclick menu for admins

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -254,16 +254,18 @@
 	for(var/areatype in areas_without_camera)
 		log_debug("* [areatype]")
 
-/client/proc/cmd_admin_dress()
+/client/proc/cmd_admin_dress(var/mob/living/carbon/human/H in GLOB.human_mobs)
 	set category = "Fun"
 	set name = "Select equipment"
 
 	if(!check_rights(R_FUN))
 		return
 
-	var/mob/living/carbon/human/H = input("Select mob.", "Select equipment.") as null|anything in GLOB.human_mobs
+
 	if(!H)
-		return
+		H = input("Select mob.", "Select equipment.") as null|anything in GLOB.human_mobs
+		if(!H)
+			return
 
 	var/singleton/hierarchy/outfit/outfit = input("Select outfit.", "Select equipment.") as null|anything in outfits()
 	if(!outfit)

--- a/maps/away/destroyed_colony/destroyed_colony.dm
+++ b/maps/away/destroyed_colony/destroyed_colony.dm
@@ -50,7 +50,7 @@
 
 /datum/contract/destroyed_colony
 	name = "Distress Signal Investigation Contract"
-	desc = "A distress signal has been detected on a nearby graveworld. All ships sent to investigate haven't been heard from since. The situation on the planet's surface is unknown, long range scans only detect the ruins of a colony that was destroyed during the Galactic Crisis. We need you to investigate the signal, and disable it if it is fradulent. Good luck, and be safe, graveworlds can be home to all sorts of dangers"
+	desc = "A distress signal has been detected on a nearby graveworld. All ships sent to investigate haven't been heard from since. The situation on the planet's surface is unknown, long range scans only detect the ruins of a colony that was destroyed during the Galactic Crisis. We need you to investigate the signal, and disable it if it is fradulent. Good luck, and be safe, graveworlds can be home to all sorts of dangers."
 	rep_points = 5
 	money = 10000
 	amount = 1


### PR DESCRIPTION
also adds a missing period in the new destroyed colony contract

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->