### PR TITLE
Fuck buckets

### DIFF
--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -168,26 +168,4 @@ if(Datum.is_processing) {\
 * SStimer
 ****/
 
-/// Create a hash from the timer's configuration and don't run it if one already exists.
-#define TIMER_UNIQUE FLAG(0)
-
-/// For timers with TIMER_UNIQUE, do not include the timer's delay as part of its uniquenes.
-#define TIMER_NO_HASH_WAIT FLAG(4)
-
-/// For timers with TIMER_UNIQUE, replace the old timer instead of discarding the new one.
-#define TIMER_OVERRIDE FLAG(1)
-
-/// Use real world time instead of server time. More expensive and should be reserved for client display like animations and sounds.
-#define TIMER_CLIENT_TIME FLAG(2)
-
-/// The call to addtimer() will return a timer ID which may be passed to deltimer() to stop it if it still exists.
-#define TIMER_STOPPABLE FLAG(3)
-
-/// Repeat the timer until it's deleted or the parent is destroyed.
-#define TIMER_LOOP FLAG(5)
-
-/// The default timer ID.
-#define TIMER_ID_NULL -1
-
-/// Automatically adding filename and line to the timer's arguments for debugging purposes.
-#define addtimer(args...) _addtimer(args, file = __FILE__, line = __LINE__)
+#define addtimer(args...) _addtimer(args, source ="[__FILE__]#[__LINE__]")

--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -61,9 +61,6 @@
 /proc/cmp_ruincost_priority(datum/map_template/ruin/A, datum/map_template/ruin/B)
 	return initial(A.spawn_cost) - initial(B.spawn_cost)
 
-/proc/cmp_timer(datum/timedevent/a, datum/timedevent/b)
-	return a.timeToRun - b.timeToRun
-
 /proc/cmp_clientcolor_priority(datum/client_color/A, datum/client_color/B)
 	return B.priority - A.priority
 

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -1,661 +1,103 @@
-/// Controls how many buckets should be kept, each representing a tick. (1 minutes worth)
-#define BUCKET_LEN (world.fps * 60)
-/// Helper for getting the correct bucket for a given timer
-#define BUCKET_POS(timer) (((ROUND_UP((timer.timeToRun - SStimer.head_offset) / world.tick_lag) + 1) % BUCKET_LEN) || BUCKET_LEN)
-/// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
-#define TIMER_MAX(timer_ss) (world.time + (min(BUCKET_LEN - (timer_ss.practical_offset - (world.time - timer_ss.head_offset) / world.tick_lag)-1, BUCKET_LEN - 1)) * world.tick_lag)
-/// Max float with integer precision
-#define TIMER_ID_MAX (2**24)
+/// Looping timers automatically re-queue themselves after firing, assuming they are still valid
+var/global/const/TIMER_LOOP = FLAG(0)
 
-/**
-  * # Timer Subsystem
-  *
-  * Handles creation, callbacks, and destruction of timed events.
-  *
-  * It is important to understand the buckets used in the timer subsystem are just a series of doubly-linked
-  * lists. The object at a given index in bucket_list is a /datum/timedevent, the head of a list, which has prev
-  * and next references for the respective elements in that bucket's list.
-  */
+/// Stoppable timers produce a hash that can be given to deltimer() to unqueue them
+var/global/const/TIMER_STOPPABLE = FLAG(1)
+
+/// Two of the same timer signature cannot be queued at once when they are unique
+var/global/const/TIMER_UNIQUE = FLAG(2)
+
+/// Attempting to add a unique timer will re-queue the event instead of being ignored
+var/global/const/TIMER_OVERRIDE = FLAG(3)
+
+/// Skips adding the wait to the timer hash, allowing for uniques with variable wait times
+var/global/const/TIMER_NO_HASH_WAIT = FLAG(4)
+
+
+/datum/timer
+	var/datum/callback/callback
+	var/wait
+	var/flags
+	var/source
+	var/hash
+	var/fire_time
+
+
 SUBSYSTEM_DEF(timer)
 	name = "Timer"
-	wait = 1 //SS_TICKER subsystem, so wait is in ticks
-	priority = SS_PRIORITY_TIMER
-
 	flags = SS_NO_INIT | SS_TICKER
+	priority = SS_PRIORITY_TIMER
+	wait = 1
 
-	/// Queue used for storing timers that do not fit into the current buckets
-	var/list/datum/timedevent/second_queue = list()
-	/// A hashlist dictionary used for storing unique timers
-	var/list/hashes = list()
-	/// world.time of the first entry in the bucket list, effectively the 'start time' of the current buckets
-	var/head_offset = 0
-	/// Index of the wrap around pivot for buckets. buckets before this are later running buckets wrapped around from the end of the bucket list.
-	var/practical_offset = 1
-	/// world.tick_lag the bucket was designed for
-	var/bucket_resolution = 0
-	/// How many timers are in the buckets
-	var/bucket_count = 0
-	/// List of buckets, each bucket holds every timer that has to run that byond tick
-	var/list/bucket_list = list()
-	/// List of all active timers associated to their timer ID (for easy lookup)
-	var/list/timer_id_dict = list()
-	/// Special timers that run in real-time, not BYOND time; these are more expensive to run and maintain
-	var/list/clienttime_timers = list()
-	/// Contains the last time that a timer's callback was invoked, or the last tick the SS fired if no timers are being processed
-	var/last_invoke_tick = 0
-	/// Keeps track of the next index to work on for client timers
-	var/next_clienttime_timer_index = 0
-	/// Contains the last time that a warning was issued for not invoking callbacks
-	var/static/last_invoke_warning = 0
-	/// Boolean operator controlling if the timer SS will automatically reset buckets if it fails to invoke callbacks for an extended period of time
-	var/static/bucket_auto_reset = TRUE
-	/// How many times bucket was reset
-	var/bucket_reset_count = 0
+	var/list/datum/timer/queue = list()
 
-
-/datum/controller/subsystem/timer/PreInit()
-	LIST_RESIZE(bucket_list, BUCKET_LEN)
-	head_offset = world.time
-	bucket_resolution = world.tick_lag
+	var/list/datum/timer/timers_by_hash = list()
 
 
 /datum/controller/subsystem/timer/UpdateStat(time)
 	if (PreventUpdateStat(time))
 		return ..()
-	..({"\
-		Buckets [bucket_count] \
-		Queue2 [length(second_queue)] \
-		Hashes [length(hashes)] \
-		Client Timers [length(clienttime_timers)] \
-		Size [length(timer_id_dict)] \
-		Resets [bucket_reset_count]\
-	"})
+	..("Queue: [length(queue)]")
 
 
-/datum/controller/subsystem/timer/proc/dump_timer_buckets(full = TRUE)
-	var/list/to_log = list("Timer bucket reset. world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
-	if (full)
-		for (var/i in 1 to length(bucket_list))
-			var/datum/timedevent/bucket_head = bucket_list[i]
-			if (!bucket_head)
-				continue
-
-			to_log += "Active timers at index [i]:"
-			var/datum/timedevent/bucket_node = bucket_head
-			var/anti_loop_check = 1
-			do
-				to_log += get_timer_debug_string(bucket_node)
-				bucket_node = bucket_node.next
-				anti_loop_check--
-			while(bucket_node && bucket_node != bucket_head && anti_loop_check)
-
-		to_log += "Active timers in the second_queue queue:"
-		for(var/I in second_queue)
-			to_log += get_timer_debug_string(I)
-
-	// Dump all the logged data to the world log
-	log_ss(name, to_log.Join("\n"))
-
-/datum/controller/subsystem/timer/fire(resumed = FALSE)
-	// Store local references to datum vars as it is faster to access them
-	var/lit = last_invoke_tick
-	var/list/bucket_list = src.bucket_list
-	var/last_check = world.time - BUCKET_LEN * 1.5 * world.tick_lag
-
-	// If there are no timers being tracked, then consider now to be the last invoked time
-	if(!bucket_count)
-		last_invoke_tick = world.time
-
-	// Check that we have invoked a callback in the last 1.5 minutes of BYOND time,
-	// and throw a warning and reset buckets if this is true
-	if(lit && lit < last_check && head_offset < last_check && last_invoke_warning < last_check)
-		last_invoke_warning = world.time
-		var/msg = "No regular timers processed in the last [BUCKET_LEN * 1.5] ticks[bucket_auto_reset ? ", resetting buckets" : ""]!"
-		message_admins(msg)
-		WARNING(msg)
-		if(bucket_auto_reset)
-			bucket_resolution = 0
-		dump_timer_buckets(config.log_timers_on_bucket_reset)
-
-	// Process client-time timers
-	if (next_clienttime_timer_index)
-		clienttime_timers.Cut(1, next_clienttime_timer_index+1)
-		next_clienttime_timer_index = 0
-	for (next_clienttime_timer_index in 1 to length(clienttime_timers))
-		if (MC_TICK_CHECK)
-			next_clienttime_timer_index--
-			break
-		var/datum/timedevent/ctime_timer = clienttime_timers[next_clienttime_timer_index]
-		if (ctime_timer.timeToRun > Uptime())
-			next_clienttime_timer_index--
-			break
-
-		var/datum/callback/callBack = ctime_timer.callBack
-		if (!callBack)
-			CRASH("Invalid timer: [get_timer_debug_string(ctime_timer)] world.time: [world.time], \
-				head_offset: [head_offset], practical_offset: [practical_offset], Uptime(): [Uptime()]")
-
-		ctime_timer.spent = Uptime()
-		invoke_async(callBack)
-
-		if(ctime_timer.flags & TIMER_LOOP)
-			ctime_timer.spent = 0
-			ctime_timer.timeToRun = Uptime() + ctime_timer.wait
-			BINARY_INSERT(ctime_timer, clienttime_timers, /datum/timedevent, ctime_timer, timeToRun, COMPARE_KEY)
-		else
-			qdel(ctime_timer)
-
-	// Remove invoked client-time timers
-	if (next_clienttime_timer_index)
-		clienttime_timers.Cut(1, next_clienttime_timer_index+1)
-		next_clienttime_timer_index = 0
-
-	// Check for when we need to loop the buckets, this occurs when
-	// the head_offset is approaching BUCKET_LEN ticks in the past
-	if (practical_offset > BUCKET_LEN)
-		head_offset += BUCKET_LEN * world.tick_lag
-		practical_offset = 1
-		resumed = FALSE
-
-	// Check for when we have to reset buckets, typically from auto-reset
-	if ((length(bucket_list) != BUCKET_LEN) || (world.tick_lag != bucket_resolution))
-		reset_buckets()
-		bucket_list = src.bucket_list
-		resumed = FALSE
-
-
-	// Iterate through each bucket starting from the practical offset
-	while (practical_offset <= BUCKET_LEN && head_offset + ((practical_offset - 1) * world.tick_lag) <= world.time)
-		var/datum/timedevent/timer
-		while ((timer = bucket_list[practical_offset]))
-			var/datum/callback/callBack = timer.callBack
-			if (!callBack)
-				stack_trace("Invalid timer: [get_timer_debug_string(timer)] world.time: [world.time], \
-					head_offset: [head_offset], practical_offset: [practical_offset], bucket_joined: [timer.bucket_joined]")
-				if (!timer.spent)
-					bucket_resolution = null // force bucket recreation
-					return
-
-			timer.bucketEject() //pop the timer off of the bucket list.
-
-			// Invoke callback if possible
-			if (!timer.spent)
-				timer.spent = world.time
-				invoke_async(callBack)
-				last_invoke_tick = world.time
-
-			if (timer.flags & TIMER_LOOP) // Prepare looping timers to re-enter the queue
-				timer.spent = 0
-				timer.timeToRun = world.time + timer.wait
-				timer.bucketJoin()
-			else
-				qdel(timer)
-
-			if (MC_TICK_CHECK)
-				break
-
-		if (!bucket_list[practical_offset])
-			// Empty the bucket, check if anything in the secondary queue should be shifted to this bucket
-			bucket_list[practical_offset] = null // Just in case
-			practical_offset++
-			var/i = 0
-			for (i in 1 to length(second_queue))
-				timer = second_queue[i]
-				if (timer.timeToRun >= TIMER_MAX(src))
-					i--
-					break
-
-				// Check for timers that are scheduled to run in the past
-				if (timer.timeToRun < head_offset)
-					bucket_resolution = null // force bucket recreation
-					stack_trace("[i] Invalid timer state: Timer in long run queue with a time to run less then head_offset. \
-						[get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
-					break
-
-				// Check for timers that are not capable of being scheduled to run without rebuilding buckets
-				if (timer.timeToRun < head_offset + (practical_offset - 1) * world.tick_lag)
-					bucket_resolution = null // force bucket recreation
-					stack_trace("[i] Invalid timer state: Timer in long run queue that would require a backtrack to transfer to \
-						short run queue. [get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
-					break
-
-				timer.bucketJoin()
-			if (i)
-				second_queue.Cut(1, i+1)
-		if (MC_TICK_CHECK)
-			break
-
-/**
-  * Generates a string with details about the timed event for debugging purposes
-  */
-/datum/controller/subsystem/timer/proc/get_timer_debug_string(datum/timedevent/TE)
-	. = "Timer: [TE]"
-	. += "Prev: [TE.prev ? TE.prev : "NULL"], Next: [TE.next ? TE.next : "NULL"]"
-	if(TE.spent)
-		. += ", SPENT([TE.spent])"
-	if(QDELETED(TE))
-		. += ", QDELETED"
-	if(!TE.callBack)
-		. += ", NO CALLBACK"
-
-/**
-  * Destroys the existing buckets and creates new buckets from the existing timed events
-  */
-/datum/controller/subsystem/timer/proc/reset_buckets()
-	log_debug("Timer buckets has been reset, this may cause timer to lag")
-	bucket_reset_count++
-
-	var/list/bucket_list = src.bucket_list // Store local reference to datum var, this is faster
-	var/list/alltimers = list()
-
-	// Get all timers currently in the buckets
-	for (var/bucket_head in bucket_list)
-		if (!bucket_head) // if bucket is empty for this tick
-			continue
-		var/datum/timedevent/bucket_node = bucket_head
-		do
-			alltimers += bucket_node
-			bucket_node = bucket_node.next
-		while(bucket_node && bucket_node != bucket_head)
-
-	// Empty the list by zeroing and re-assigning the length
-	bucket_list.Cut()
-	LIST_RESIZE(bucket_list, BUCKET_LEN)
-
-	// Reset values for the subsystem to their initial values
-	practical_offset = 1
-	bucket_count = 0
-	head_offset = world.time
-	bucket_resolution = world.tick_lag
-
-	// Add all timed events from the secondary queue as well
-	alltimers += second_queue
-
-	for (var/datum/timedevent/t as anything in alltimers)
-		t.timer_subsystem = src // Recovered timers need to be reparented
-		t.bucket_joined = FALSE
-		t.bucket_pos = -1
-		t.prev = null
-		t.next = null
-
-	// If there are no timers being tracked by the subsystem,
-	// there is no need to do any further rebuilding
-	if (!length(alltimers))
+/datum/controller/subsystem/timer/fire(resume, no_mc_tick)
+	if (!length(queue))
 		return
-
-	// Sort all timers by time to run
-	sortTim(alltimers, .proc/cmp_timer)
-
-	// Get the earliest timer, and if the TTR is earlier than the current world.time,
-	// then set the head offset appropriately to be the earliest time tracked by the
-	// current set of buckets
-	var/datum/timedevent/head = alltimers[1]
-	if (head.timeToRun < head_offset)
-		head_offset = head.timeToRun
-
-	// Iterate through each timed event and insert it into an appropriate bucket,
-	// up unto the point that we can no longer insert into buckets as the TTR
-	// is outside the range we are tracking, then insert the remainder into the
-	// secondary queue
-	var/new_bucket_count
-	var/i = 1
-	for (i in 1 to length(alltimers))
-		var/datum/timedevent/timer = alltimers[i]
-		if (!timer)
-			continue
-
-		// Check that the TTR is within the range covered by buckets, when exceeded we've finished
-		if (timer.timeToRun >= TIMER_MAX(src))
-			i--
-			break
-
-		// Check that timer has a valid callback and hasn't been invoked
-		if (!timer.callBack || timer.spent)
-			WARNING("Invalid timer: [get_timer_debug_string(timer)] world.time: [world.time], \
-				head_offset: [head_offset], practical_offset: [practical_offset]")
-			if (timer.callBack)
-				qdel(timer)
-			continue
-
-		// Insert the timer into the bucket, and perform necessary doubly-linked list operations
-		new_bucket_count++
-		var/bucket_pos = BUCKET_POS(timer)
-		timer.bucket_pos = bucket_pos
-		timer.bucket_joined = TRUE
-
-		var/datum/timedevent/bucket_head = bucket_list[bucket_pos]
-		if (!bucket_head)
-			bucket_list[bucket_pos] = timer
-			timer.next = null
-			timer.prev = null
-			continue
-
-		bucket_head.prev = timer
-		timer.next = bucket_head
-		timer.prev = null
-		bucket_list[bucket_pos] = timer
-
-	// Cut the timers that are tracked by the buckets from the secondary queue
-	if (i)
-		alltimers.Cut(1, i + 1)
-	second_queue = alltimers
-	bucket_count = new_bucket_count
+	var/datum/timer/timer
+	var/datum/target
+	var/size = length(queue)
+	for (var/i = 1 to size)
+		timer = queue[i]
+		if (world.time < timer.fire_time)
+			if (i > 1)
+				queue.Cut(1, i)
+			return
+		target = timer.callback.target
+		if (target == GLOBAL_PROC || !QDELETED(target))
+			invoke_async(timer.callback)
+			if (timer.flags & TIMER_LOOP)
+				_addtimer(timer, subsystem = src)
+		else if (timer.hash)
+			timers_by_hash -= timer.hash
+		if (no_mc_tick)
+			CHECK_TICK
+		else if (MC_TICK_CHECK)
+			queue.Cut(1, i + 1)
+			return
+	queue.Cut(1, size + 1)
 
 
-/datum/controller/subsystem/timer/Recover()
-	// Find the current timer sub-subsystem in global and recover its buckets etc
-	var/datum/controller/subsystem/timer/timerSS = null
-	for(var/global_var in global.vars)
-		if (istype(global.vars[global_var],src.type))
-			timerSS = global.vars[global_var]
-
-	hashes = timerSS.hashes
-	timer_id_dict = timerSS.timer_id_dict
-
-	bucket_list = timerSS.bucket_list
-	second_queue = timerSS.second_queue
-
-	// The buckets are FUBAR
-	reset_buckets()
-
-/**
-  * # Timed Event
-  *
-  * This is the actual timer, it contains the callback and necessary data to maintain
-  * the timer.
-  *
-  * See the documentation for the timer subsystem for an explanation of the buckets referenced
-  * below in next and prev
-  */
-/datum/timedevent
-	/// ID used for timers when the TIMER_STOPPABLE flag is present
-	var/id
-	/// The callback to invoke after the timer completes
-	var/datum/callback/callBack
-	/// The time at which the callback should be invoked at
-	var/timeToRun
-	/// The length of the timer
-	var/wait
-	/// Unique hash generated when TIMER_UNIQUE flag is present
-	var/hash
-	/// The source of the timedevent, whatever called addtimer
-	var/source
-	/// Flags associated with the timer, see _DEFINES/subsystems.dm
-	var/list/flags
-	/// Time at which the timer was invoked or destroyed
-	var/spent = 0
-	/// An informative name generated for the timer as its representation in strings, useful for debugging
-	var/name
-	/// Next timed event in the bucket
-	var/datum/timedevent/next
-	/// Previous timed event in the bucket
-	var/datum/timedevent/prev
-	/// The timer subsystem this event is associated with
-	var/datum/controller/subsystem/timer/timer_subsystem
-	/// Boolean indicating if timer joined into bucket
-	var/bucket_joined = FALSE
-	/// Initial bucket position
-	var/bucket_pos = -1
-
-/datum/timedevent/New(datum/callback/callBack, wait, flags, datum/controller/subsystem/timer/timer_subsystem, hash, source)
-	var/static/nextid = 1
-	id = TIMER_ID_NULL
-	src.callBack = callBack
-	src.wait = wait
-	src.flags = flags
-	src.hash = hash
-	src.source = source
-	src.timer_subsystem = timer_subsystem || SStimer
-
-	// Determine time at which the timer's callback should be invoked
-	timeToRun = (flags & TIMER_CLIENT_TIME ? Uptime() : world.time) + wait
-
-	// Include the timer in the hash table if the timer is unique
-	if (flags & TIMER_UNIQUE)
-		timer_subsystem.hashes[hash] = src
-
-	// Generate ID for the timer if the timer is stoppable, include in the timer id dictionary
-	if (flags & TIMER_STOPPABLE)
-		id = num2text(nextid, 100)
-		if (nextid >= SHORT_REAL_LIMIT)
-			nextid += min(1, 2 ** round(nextid / SHORT_REAL_LIMIT))
-		else
-			nextid++
-		timer_subsystem.timer_id_dict[id] = src
-
-	if ((timeToRun < world.time || timeToRun < timer_subsystem.head_offset) && !(flags & TIMER_CLIENT_TIME))
-		CRASH("Invalid timer state: Timer created that would require a backtrack to run (addtimer would never let this happen): [SStimer.get_timer_debug_string(src)]")
-
-	if (callBack.target != FALSE && !QDESTROYING(callBack.target))
-		LAZYADD(callBack.target.active_timers, src)
-
-	bucketJoin()
-
-/datum/timedevent/Destroy()
-	..()
-	if (flags & TIMER_UNIQUE && hash)
-		timer_subsystem.hashes -= hash
-
-	if (callBack && callBack.target && callBack.target != FALSE && callBack.target.active_timers)
-		callBack.target.active_timers -= src
-		UNSETEMPTY(callBack.target.active_timers)
-
-	callBack = null
-
-	if (flags & TIMER_STOPPABLE)
-		timer_subsystem.timer_id_dict -= id
-
-	if (flags & TIMER_CLIENT_TIME)
-		if (!spent)
-			spent = world.time
-			timer_subsystem.clienttime_timers -= src
-		return QDEL_HINT_IWILLGC
-
-	if (!spent)
-		spent = world.time
-		bucketEject()
-	else
-		if (prev && prev.next == src)
-			prev.next = next
-		if (next && next.prev == src)
-			next.prev = prev
-	next = null
-	prev = null
-	return QDEL_HINT_IWILLGC
-
-/**
-  * Removes this timed event from any relevant buckets, or the secondary queue
-  */
-/datum/timedevent/proc/bucketEject()
-	// Store local references for the bucket list and secondary queue
-	// This is faster than referencing them from the datum itself
-	var/list/bucket_list = timer_subsystem.bucket_list
-	var/list/second_queue = timer_subsystem.second_queue
-
-	// Attempt to get the head of the bucket
-	var/datum/timedevent/buckethead
-	if(bucket_pos > 0)
-		buckethead = bucket_list[bucket_pos]
-
-	// Decrement the number of timers in buckets if the timed event is
-	// the head of the bucket, or has a TTR less than TIMER_MAX implying it fits
-	// into an existing bucket, or is otherwise not present in the secondary queue
-	if(buckethead == src)
-		bucket_list[bucket_pos] = next
-		timer_subsystem.bucket_count--
-	else if(bucket_joined)
-		timer_subsystem.bucket_count--
-	else
-		var/l = length(second_queue)
-		second_queue -= src
-		if(l == length(second_queue))
-			timer_subsystem.bucket_count--
-
-	// Remove the timed event from the bucket, ensuring to maintain
-	// the integrity of the bucket's list if relevant
-	if (prev && prev.next == src)
-		prev.next = next
-	if (next && next.prev == src)
-		next.prev = prev
-	prev = next = null
-	bucket_pos = -1
-	bucket_joined = FALSE
-
-/**
-  * Attempts to add this timed event to a bucket, will enter the secondary queue
-  * if there are no appropriate buckets at this time.
-  *
-  * Secondary queueing of timed events will occur when the timespan covered by the existing
-  * buckets is exceeded by the time at which this timed event is scheduled to be invoked.
-  * If the timed event is tracking client time, it will be added to a special bucket.
-  */
-/datum/timedevent/proc/bucketJoin()
-	var/static/list/bitfield_flags = list("TIMER_UNIQUE", "TIMER_OVERRIDE", "TIMER_CLIENT_TIME", "TIMER_STOPPABLE", "TIMER_NO_HASH_WAIT", "TIMER_LOOP")
-
-	name = "Timer: [id] (\ref[src]), TTR: [timeToRun], wait:[wait] Flags: [jointext(bitfield2list(flags, bitfield_flags), ", ")], \
-		callBack: \ref[callBack], target: [callBack.identity], callable:[callBack.callable]([callBack.params ? callBack.params.Join(", ") : ""]), source: [source]"
-
-	if (bucket_joined)
-		stack_trace("Bucket already joined! [name]")
-
-	// Check if this timed event should be diverted to the client time bucket, or the secondary queue
-	var/list/L
-	if (flags & TIMER_CLIENT_TIME)
-		L = timer_subsystem.clienttime_timers
-	else if (timeToRun >= TIMER_MAX(timer_subsystem))
-		L = timer_subsystem.second_queue
-	if(L)
-		BINARY_INSERT(src, L, /datum/timedevent, src, timeToRun, COMPARE_KEY)
+/proc/deltimer(datum/timer/timer, datum/controller/subsystem/timer/subsystem = SStimer)
+	if (istext(timer))
+		timer = subsystem.timers_by_hash[timer]
+	if (!timer)
 		return
-
-	// Get a local reference to the bucket list, this is faster than referencing the datum
-	var/list/bucket_list = timer_subsystem.bucket_list
-
-	// Find the correct bucket for this timed event
-	bucket_pos = BUCKET_POS(src)
-
-	if (bucket_pos < timer_subsystem.practical_offset && timeToRun < (timer_subsystem.head_offset + BUCKET_LEN * world.tick_lag))
-		WARNING("Bucket pos in past: bucket_pos = [bucket_pos] < practical_offset = [timer_subsystem.practical_offset] \
-			&& timeToRun = [timeToRun] < [timer_subsystem.head_offset + BUCKET_LEN * world.tick_lag], Timer: [name]")
-		bucket_pos = timer_subsystem.practical_offset // Recover bucket_pos to avoid timer blocking queue
-
-	var/datum/timedevent/bucket_head = bucket_list[bucket_pos]
-	timer_subsystem.bucket_count++
-
-	// If there is no timed event at this position, then the bucket is 'empty'
-	// and we can just set this event to that position
-	if (!bucket_head)
-		bucket_joined = TRUE
-		bucket_list[bucket_pos] = src
-		return
-
-	// Otherwise, we merely add this timed event into the bucket, which is a
-	// doubly-linked list
-	bucket_joined = TRUE
-	bucket_head.prev = src
-	next = bucket_head
-	prev = null
-	bucket_list[bucket_pos] = src
+	if (timer.hash)
+		subsystem.timers_by_hash -= timer.hash
+	subsystem.queue -= timer
 
 
-/**
- * Create a new timer and insert it in the queue.
- * You should not call this directly, and should instead use the addtimer macro, which includes source information.
- *
- * Arguments:
- * * callback the callback to call on timer finish
- * * wait deciseconds to run the timer for
- * * flags flags for this timer, see: code\__DEFINES\subsystems.dm
- */
-/proc/_addtimer(datum/callback/callback, wait = 0, flags = 0, datum/controller/subsystem/timer/timer_subsystem, file, line)
-	if (!callback)
-		CRASH("addtimer called without a callback")
-
-	if (wait < 0)
-		stack_trace("addtimer called with a negative wait. Converting to [world.tick_lag]")
-
-	if (callback.target != FALSE && QDELETED(callback.target) && !QDESTROYING(callback.target))
-		stack_trace("addtimer called with a callback assigned to a qdeleted object. In the future such timers will not \
-			be supported and may refuse to run or run with a 0 wait")
-
-	wait = max(Ceilm(wait, world.tick_lag), world.tick_lag)
-
-	if(wait >= INFINITY)
-		CRASH("Attempted to create timer with INFINITY delay")
-
-	timer_subsystem = timer_subsystem || SStimer
-
-	// Generate hash if relevant for timed events with the TIMER_UNIQUE flag
-	var/hash
-	if (flags & TIMER_UNIQUE)
-		var/list/hashlist = list(callback.target, "(\ref[callback.target])", callback.callable, flags & TIMER_CLIENT_TIME)
-		if(!(flags & TIMER_NO_HASH_WAIT))
-			hashlist += wait
-		hashlist += callback.params
-		hash = hashlist.Join("|||||||")
-
-		var/datum/timedevent/hash_timer = timer_subsystem.hashes[hash]
-		if(hash_timer)
-			if (hash_timer.spent) // it's pending deletion, pretend it doesn't exist.
-				hash_timer.hash = null // but keep it from accidentally deleting us
-			else
-				if (flags & TIMER_OVERRIDE)
-					hash_timer.hash = null // no need having it delete it's hash if we are going to replace it
-					qdel(hash_timer)
-				else
-					if (hash_timer.flags & TIMER_STOPPABLE)
-						. = hash_timer.id
-					return
-	else if(flags & TIMER_OVERRIDE)
-		stack_trace("TIMER_OVERRIDE used without TIMER_UNIQUE")
-
-	var/datum/timedevent/timer = new(callback, wait, flags, timer_subsystem, hash, file && "[file]:[line]")
-	return timer.id
-
-/**
- * Delete a timer
- *
- * Arguments:
- * * id a timerid or a /datum/timedevent
- */
-/proc/deltimer(id, datum/controller/subsystem/timer/timer_subsystem)
-	if (!id)
-		return FALSE
-	if (id == TIMER_ID_NULL)
-		CRASH("Tried to delete a null timerid. Use TIMER_STOPPABLE flag")
-	if (istype(id, /datum/timedevent))
-		qdel(id)
-		return TRUE
-	timer_subsystem = timer_subsystem || SStimer
-	//id is string
-	var/datum/timedevent/timer = timer_subsystem.timer_id_dict[id]
-	if (timer && !timer.spent)
-		qdel(timer)
-		return TRUE
-	return FALSE
-
-/**
- * Get the remaining deciseconds on a timer
- *
- * Arguments:
- * * id a timerid or a /datum/timedevent
- */
-/proc/timeleft(id, datum/controller/subsystem/timer/timer_subsystem)
-	if (!id)
-		return null
-	if (id == TIMER_ID_NULL)
-		CRASH("Tried to get timeleft of a null timerid. Use TIMER_STOPPABLE flag")
-	if (istype(id, /datum/timedevent))
-		var/datum/timedevent/timer = id
-		return timer.timeToRun - world.time
-	timer_subsystem = timer_subsystem || SStimer
-	//id is string
-	var/datum/timedevent/timer = timer_subsystem.timer_id_dict[id]
-	if(!timer || timer.spent)
-		return null
-	return timer.timeToRun - (timer.flags & TIMER_CLIENT_TIME ? Uptime() : world.time)
-
-#undef BUCKET_LEN
-#undef BUCKET_POS
-#undef TIMER_MAX
-#undef TIMER_ID_MAX
+/proc/_addtimer(datum/callback/callback, wait, flags, datum/controller/subsystem/timer/subsystem = SStimer, source)
+	var/datum/timer/timer = callback
+	if (!istype(timer))
+		timer = new
+		timer.callback = callback
+		timer.wait = wait
+		timer.flags = flags
+		timer.source = source
+		if (flags & (TIMER_STOPPABLE | TIMER_UNIQUE))
+			var/hash = "[flags][callback.identity]"
+			if (!(flags & TIMER_NO_HASH_WAIT))
+				hash = "[hash][wait]"
+			hash = sha1(hash)
+			if (flags & TIMER_UNIQUE)
+				var/datum/timer/match = subsystem.timers_by_hash[hash]
+				if (match)
+					if (!(flags & TIMER_OVERRIDE))
+						return
+					subsystem.timers_by_hash[hash] = timer
+					subsystem.queue -= match
+			timer.hash = hash
+	timer.fire_time = timer.wait + world.time
+	BINARY_INSERT(timer, subsystem.queue, /datum/timer, timer, fire_time, COMPARE_KEY)
+	return timer.hash

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -1,7 +1,6 @@
 /datum
 	var/gc_destroyed //Time when this object was destroyed.
 	var/is_processing = FALSE
-	var/list/active_timers  //for SStimer
 
 #ifdef TESTING
 	var/running_find_references
@@ -19,16 +18,8 @@
 	weakref = null // Clear this reference to ensure it's kept for as brief duration as possible.
 
 	SSnano && SSnano.close_uis(src)
-
-	var/list/timers = active_timers
-	active_timers = null
-	for(var/datum/timedevent/timer as anything in timers)
-		if (timer.spent)
-			continue
-		qdel(timer)
-
-	if(extensions)
-		for(var/expansion_key in extensions)
+	if (extensions)
+		for (var/expansion_key in extensions)
 			var/list/extension = extensions[expansion_key]
 			if(islist(extension))
 				extension.Cut()

--- a/code/game/objects/effects/particles/particles.dm
+++ b/code/game/objects/effects/particles/particles.dm
@@ -189,7 +189,7 @@
 /obj/particle_emitter/burst/Initialize(mapload, time)
 	. = ..()
 	//Burst emitters turn off after 1 tick
-	addtimer(new Callback(src, .proc/enable, FALSE), 1, TIMER_CLIENT_TIME)
+	addtimer(new Callback(src, .proc/enable, FALSE), 1)
 /obj/particle_emitter/burst/rocks
 	particles = new/particles/debris
 

--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -60,9 +60,6 @@ var/global/list/ticket_panels = list()
 
 	update_ticket_panels()
 
-	for (var/datum/timedevent/T as anything in active_timers)
-		deltimer(T.id)
-
 	return 1
 
 /datum/ticket/proc/take(datum/client_lite/assigned_admin)

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -156,7 +156,7 @@ var/global/list/ghost_traps
 		return
 	P.visible_message(SPAN_ITALIC("The [P] chimes quietly."), range = 3)
 	deltimer(P.searching)
-	P.searching = TIMER_ID_NULL
+	P.searching = null
 	P.update_icon()
 
 /datum/ghosttrap/positronic/set_new_name(mob/target)

--- a/code/modules/holomap/ship_holomap.dm
+++ b/code/modules/holomap/ship_holomap.dm
@@ -137,7 +137,7 @@
 		if(watching_mob.client)
 			animate(holomap_datum.station_map, alpha = 0, time = 5, easing = LINEAR_EASING)
 			var/mob/M = watching_mob
-			addtimer(new Callback(src, .proc/clear_image, M, holomap_datum.station_map), 5, TIMER_CLIENT_TIME)//we give it time to fade out
+			addtimer(new Callback(src, .proc/clear_image, M, holomap_datum.station_map),  0.5 SECONDS)//we give it time to fade out
 		GLOB.moved_event.unregister(watching_mob, src)
 		GLOB.destroyed_event.unregister(watching_mob, src)
 	watching_mob = null

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -21,7 +21,7 @@
 
 	var/mob/living/silicon/sil_brainmob/brainmob = null
 
-	var/searching = TIMER_ID_NULL
+	var/searching = null
 	var/last_search = 0
 
 	req_access = list(access_robotics)
@@ -64,7 +64,7 @@
 	if (damage)
 		to_chat(user, SPAN_WARNING("\The [src] is damaged and requires repair first."))
 		return
-	if (searching != TIMER_ID_NULL)
+	if (searching)
 		visible_message("\The [user] flicks the activation switch on \the [src]. The lights go dark.", range = 3)
 		cancel_search()
 		return
@@ -97,9 +97,9 @@
 
 /obj/item/organ/internal/posibrain/proc/cancel_search()
 	visible_message(SPAN_ITALIC("\The [src] buzzes quietly and returns to an idle state."), range = 3)
-	if (searching != TIMER_ID_NULL)
+	if (searching)
 		deltimer(searching)
-	searching = TIMER_ID_NULL
+	searching = null
 	if (brainmob && brainmob.key)
 		if (brainmob.mind && brainmob.mind.special_role)
 			var/sneaky = sanitizeSafe(input(brainmob, "You're safe. Pick a new name as cover? Leave blank to skip.", "Get Sneaky?", brainmob.real_name) as text, MAX_NAME_LEN)
@@ -114,7 +114,7 @@
 	update_icon()
 
 /obj/item/organ/internal/posibrain/attack_ghost(mob/observer/ghost/user)
-	if (searching == TIMER_ID_NULL)
+	if (!searching)
 		return
 	if (!brainmob)
 		return
@@ -156,7 +156,7 @@
 		else if (damage)
 			msg += SPAN_ITALIC("The red integrity fault indicator pulses slowly.")
 		else
-			msg += SPAN_ITALIC("The golden ready indicator [searching != TIMER_ID_NULL ? "flickers quickly as it tries to generate a personality" : "pulses lazily"].")
+			msg += SPAN_ITALIC("The golden ready indicator [searching ? "flickers quickly as it tries to generate a personality" : "pulses lazily"].")
 	if (msg)
 		to_chat(user, msg)
 

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -279,7 +279,7 @@
 		animate(filters[1], time = 0, loop = 1, radius = 0, flags=ANIMATION_PARALLEL)
 		animate(time = 2 SECONDS, radius = _radius)
 		animating_ripple = TRUE
-		addtimer(new Callback(src, .proc/ResetRipple), 2 SECONDS, TIMER_CLIENT_TIME)
+		addtimer(new Callback(src, .proc/ResetRipple), 2 SECONDS)
 
 /obj/effect/fusion_em_field/proc/ResetRipple()
 	animating_ripple = FALSE

--- a/code/unit_tests/~unit_test_subsystems.dm
+++ b/code/unit_tests/~unit_test_subsystems.dm
@@ -49,7 +49,7 @@ SUBSYSTEM_DEF(unit_tests)
 			report_progress("Skipping template '[map_template]' ([map_template.type]): Is an Away Site")
 			continue
 
-		if (istype(map_template, /datum/map_template/deepmaint_template))
+		if (istype(map_template, /datum/map_template/deepmaint_template) || istype(map_template, /datum/map_template/ruin/deepmaint_wfc))
 			report_progress("Skipping template '[map_template]' ([map_template.type]): Is a Deepmaint submap.")
 			continue
 

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -6122,7 +6122,6 @@
 "FJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/access_button{
-	active_timers = "interior access button";
 	command = "cycle_exterior";
 	frequency = 1379;
 	master_tag = "oldlab_airlock";


### PR DESCRIPTION
Death to buckets. Fixes #1280 

Cherry-pick of the updated bay timer system used upstream and tweaked to work here (fuck bay for bundling different features/bug fixes all into a SINGLE commit. Multiple times). I've tested this locally and noticed no issues at all, but obviously that's a small sample. Opened a branch here for easy playtesting if we want to switch the live server over to it and see how it fares.

Also includes a small tweak that excludes the new deepmaint template introduced in #1189 from spawning during unit testing.