### PR TITLE
Ore and gun bugfixes

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -328,6 +328,15 @@ var/global/list/mining_floors = list()
 	if(istype(N))
 		N.overlay_detail = "asteroid[rand(0,9)]"
 		N.updateMineralOverlays(1)
+		if(!N.has_resources || length(N.resources))
+			return
+		for(var/i in random_maps)
+			var/datum/random_map/noise/ore/orenoise = random_maps[i]
+			if(!istype(orenoise))
+				continue
+			if(orenoise.origin_z == N.z)
+				orenoise.generate_tile(N)
+				break
 
 /turf/simulated/mineral/proc/excavate_find(prob_clean = 0, datum/find/F)
 
@@ -517,11 +526,9 @@ var/global/list/mining_floors = list()
 
 	overlays.Cut()
 
-	var/list/step_overlays = list("n" = NORTH, "s" = SOUTH, "e" = EAST, "w" = WEST)
-	for(var/direction in step_overlays)
-
-		if(istype(get_step(src, step_overlays[direction]), /turf/space))
-			var/image/aster_edge = image('icons/turf/flooring/asteroid.dmi', "asteroid_edges", dir = step_overlays[direction])
+	for(var/direction in GLOB.cardinal)
+		if(istype(get_step(src, direction), /turf/space))
+			var/image/aster_edge = image('icons/turf/flooring/asteroid.dmi', "asteroid_edges", dir = direction)
 			aster_edge.turf_decal_layerise()
 			overlays += aster_edge
 
@@ -532,11 +539,9 @@ var/global/list/mining_floors = list()
 		overlays |= floor_decal
 
 	if(update_neighbors)
-		var/list/all_step_directions = list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,SOUTHWEST,WEST,NORTHWEST)
-		for(var/direction in all_step_directions)
-			var/turf/simulated/floor/asteroid/A
-			if(istype(get_step(src, direction), /turf/simulated/floor/asteroid))
-				A = get_step(src, direction)
+		for(var/direction in GLOB.alldirs)
+			var/turf/simulated/floor/asteroid/A = get_step(src, direction)
+			if(istype(A))
 				A.updateMineralOverlays()
 
 /turf/simulated/floor/asteroid/Entered(atom/movable/M as mob|obj)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -168,7 +168,7 @@
 					playsound(loc, mag_insert_sound, 75, 1)
 					update_icon()
 					AM.update_icon()
-					if(!istype(AM, magazine_type))
+					if(jam_chance && !istype(AM, magazine_type))
 						jam_chance += 10
 					return
 				ammo_magazine = AM

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -61,7 +61,9 @@
 			var/tmp_cell
 			TRANSLATE_AND_VERIFY_COORD(x, y)
 
-			if(tmp_cell < rare_val)      // Surface metals.
+			var/mapval = (!isnull(tmp_cell) ? map[tmp_cell] : null)
+
+			if(mapval < rare_val)      // Surface metals.
 				T.resources[MATERIAL_IRON] =     rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
 				T.resources[MATERIAL_ALUMINIUM] =     rand(RESOURCE_MID_MIN, RESOURCE_MID_MAX)
 				T.resources[MATERIAL_GOLD] =     rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
@@ -72,7 +74,7 @@
 				T.resources[MATERIAL_PHORON] =   0
 				T.resources[MATERIAL_OSMIUM] =   0
 				T.resources[MATERIAL_HYDROGEN] = 0
-			else if(tmp_cell < deep_val) // Rare metals.
+			else if(mapval < deep_val) // Rare metals.
 				T.resources[MATERIAL_GOLD] =     rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources[MATERIAL_SILVER] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -54,46 +54,56 @@
 				continue
 			if(!priority_process)
 				CHECK_TICK
-			T.resources = list()
-			T.resources[MATERIAL_SAND] = rand(3,5)
-			T.resources[MATERIAL_GRAPHITE] = rand(3,5)
 
-			var/tmp_cell
-			TRANSLATE_AND_VERIFY_COORD(x, y)
+			generate_tile(T)
 
-			var/mapval = (!isnull(tmp_cell) ? map[tmp_cell] : null)
+/datum/random_map/noise/ore/proc/generate_tile(var/turf/simulated/T)
+	if(!istype(T) || !T.has_resources)
+		return
 
-			if(mapval < rare_val)      // Surface metals.
-				T.resources[MATERIAL_IRON] =     rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
-				T.resources[MATERIAL_ALUMINIUM] =     rand(RESOURCE_MID_MIN, RESOURCE_MID_MAX)
-				T.resources[MATERIAL_GOLD] =     rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_SILVER] =   rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_RUTILE] = 0
-				T.resources[MATERIAL_DIAMOND] =  0
-				T.resources[MATERIAL_PHORON] =   0
-				T.resources[MATERIAL_OSMIUM] =   0
-				T.resources[MATERIAL_HYDROGEN] = 0
-			else if(mapval < deep_val) // Rare metals.
-				T.resources[MATERIAL_GOLD] =     rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_SILVER] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_PHORON] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_OSMIUM] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_RUTILE] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_HYDROGEN] = 0
-				T.resources[MATERIAL_DIAMOND] =  0
-				T.resources[MATERIAL_IRON] =     0
-			else                             // Deep metals.
-				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_DIAMOND] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_PHORON] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
-				T.resources[MATERIAL_OSMIUM] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
-				T.resources[MATERIAL_HYDROGEN] = rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_RUTILE] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
-				T.resources[MATERIAL_IRON] =     0
-				T.resources[MATERIAL_GOLD] =     0
-				T.resources[MATERIAL_SILVER] =   0
+	T.resources = list()
+	T.resources[MATERIAL_SAND] = rand(3,5)
+	T.resources[MATERIAL_GRAPHITE] = rand(3,5)
+
+	var/tmp_cell
+	TRANSLATE_AND_VERIFY_COORD(T.x, T.y)
+
+	if(isnull(tmp_cell))
+		return
+
+	var/mapval = map[tmp_cell]
+
+	if(mapval < rare_val)      // Surface metals.
+		T.resources[MATERIAL_IRON] =		rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+		T.resources[MATERIAL_ALUMINIUM] =	rand(RESOURCE_MID_MIN, RESOURCE_MID_MAX)
+		T.resources[MATERIAL_GOLD] =		rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_SILVER] =		rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_URANIUM] =		rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_RUTILE] =		0
+		T.resources[MATERIAL_DIAMOND] =		0
+		T.resources[MATERIAL_PHORON] =		0
+		T.resources[MATERIAL_PLATINUM] =	0
+		T.resources[MATERIAL_HYDROGEN] =	0
+	else if(mapval < deep_val) // Rare metals.
+		T.resources[MATERIAL_GOLD] =		rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_SILVER] =		rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_URANIUM] =		rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_PHORON] =		rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_PLATINUM] =	rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_RUTILE] =		rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_HYDROGEN] =	0
+		T.resources[MATERIAL_DIAMOND] =		0
+		T.resources[MATERIAL_IRON] =		0
+	else	// Deep metals.
+		T.resources[MATERIAL_URANIUM] =		rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_DIAMOND] =		rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+		T.resources[MATERIAL_PHORON] =		rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+		T.resources[MATERIAL_PLATINUM] =	rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+		T.resources[MATERIAL_HYDROGEN] =	rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_RUTILE] =		rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+		T.resources[MATERIAL_IRON] =		0
+		T.resources[MATERIAL_GOLD] =		0
+		T.resources[MATERIAL_SILVER] =		0
 
 /datum/random_map/noise/ore/get_map_char(value)
 	if(value < rare_val)


### PR DESCRIPTION
A few bugfixes.

- Guns with `jam_chance` of 0 no longer have a change to jam if you load it with ammo that it didn't originally spawn with (Fixes #1310 )
- Corrects ore noise map generation to actually use the map index rather than itself, causing every tile to generate the rarest ores, preventing surface or mid level ores from generating. Thanks to @scrdest for helping figure this one out! (Fixes #1306 )
- Reverts some regressions introduced in #1250 as well as correcting some odd changes. Mined rocks now once again generate ore for the tile underneath. 