### PR TITLE
NPC bugfixes

### DIFF
--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -122,23 +122,24 @@
 
 			if (L.status_flags & NOTARGET)
 				return FALSE
+
+		else if (istype(the_target, /mob/living/exosuit))	//Exosuits are living??? This check needs to go in here now
+			var/mob/living/exosuit/M = the_target
+			var/will_attack = FALSE
+			for (var/mob/pilot in M.pilots)
+				will_attack =  will_attack || can_attack(pilot)
+			return length(M.pilots) ? will_attack : destructive // Empty mechs are 'neutral'.
+
 		if (L.stat)
 			if (L.stat == DEAD && !handle_corpse) // Leave dead things alone
 				return FALSE
 			if (L.stat == UNCONSCIOUS)	// Do we have mauling? Yes? Then maul people who are sleeping but not SSD
-				if (mauling)
-					return TRUE
-				else
-					return FALSE
+				return mauling
+
 		if (holder.IIsAlly(L))
 			return FALSE
 		return TRUE
 
-	if (istype(the_target, /mob/living/exosuit))
-		var/mob/living/exosuit/M = the_target
-		for (var/mob/pilot in M.pilots)
-			return can_attack(pilot)
-		return destructive // Empty mechs are 'neutral'.
 
 	if (istype(the_target, /obj/machinery/porta_turret))
 		var/obj/machinery/porta_turret/P = the_target

--- a/code/modules/culture_descriptor/culture/cultures_human.dm
+++ b/code/modules/culture_descriptor/culture/cultures_human.dm
@@ -5,6 +5,7 @@
 /singleton/cultural_info/culture/human
 	name = CULTURE_HUMAN
 	description = "You are from one of various planetary cultures of humankind."
+	default_language = LANGUAGE_GALCOM
 	secondary_langs = list(
 		LANGUAGE_GALCOM,
 		LANGUAGE_SOL_COMMON,


### PR DESCRIPTION
Couple of small NPC bufixes

- Hostile AIs now respect `destructive` and don't always attack exosuits, regardless of if they're empty (Fixes #1302 ). Caused by the fact exosuits are indeed "living", so the second type check was essentially unreachable.
- Tweaked the aforementioned targeting logic. Previously the AI would pick the first pilot of the exosuit and decide to attack or not based off of them. This has been reworked slightly to check if the AI can attack _any_ of the pilots, weighted towards attacking.
- NPCs no longer speak in rune speak in floating text (Fixes #1279 ). Caused the NPCs actually having no language. As this is auto-generated from the NPC's species' default language during `New()`, humankind's default has been set to GalCom. I don't _think_ this will cause any unintended side-effects. But might need another pair of eyes to verify.