### PR TITLE
actually fixes xenophage larva faction

### DIFF
--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -7,6 +7,7 @@
 	language = LANGUAGE_XENOPHAGE_GLOBAL
 	maxHealth = 25
 	health = 25
+	faction = "alien"
 
 	var/adult_form = /mob/living/carbon/human
 	var/amount_grown = 0


### PR DESCRIPTION
what #1311 failed to consider is that this code is bad, and xenophage larva don't get their faction from the species datum.