### PR TITLE
Hunger and thirst give slowdown

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -70,6 +70,15 @@
 	if(mRun in mutations)
 		tally = 0
 
+	if(!src.isSynthetic())
+		switch(src.nutrition)
+			if(150 to 250)					tally += 0.2	//quite hungry
+			if(0 to 150)					tally += 0.4	//starving
+
+		switch(src.hydration)
+			if(150 to 250)					tally += 0.2
+			if(0 to 150)					tally += 0.4
+
 	return tally
 
 /mob/living/carbon/human/size_strength_mod()


### PR DESCRIPTION
No effects if you are 'not' or 'a bit' hungry/thirsty, after that being quite hungry/starving and being quite thirsty/dying of thirst each incur their own slowdown penalties.