### PR TITLE
fixes #1327

### DIFF
--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -4,6 +4,7 @@ GLOBAL_VAR(planet_repopulation_disabled)
 	name = "exoplanet"
 	icon_state = "globe"
 	in_space = FALSE
+	is_planet = TRUE
 	var/area/planetary_area
 	var/list/seeds = list()
 	var/list/fauna_types = list()		// possible types of mobs to spawn

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -138,6 +138,8 @@
 	icon_state = "sector"
 	anchored = TRUE
 
+	var/is_planet = FALSE //are we a planet for the purposes of solar occlusion
+
 	//used by exoplanets and awaymap planetoids
 	var/surface_color = null
 	var/water_color = null

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -173,8 +173,8 @@ var/global/solar_gen_rate = 1500
 	// On planets, we take fewer steps because the light is mostly up
 	// Also, many planets barely have any spots with enough clear space around
 	if(GLOB.using_map.use_overmap)
-		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
-		if(istype(E))
+		var/obj/effect/overmap/visitable/sector/E = map_sectors["[z]"]
+		if(istype(E) && E.is_planet)
 			steps = 5
 
 	for(var/i = 1 to steps)

--- a/code/modules/urist/modules/jungle/planetoid.dm
+++ b/code/modules/urist/modules/jungle/planetoid.dm
@@ -1,11 +1,11 @@
 /obj/effect/overmap/visitable/sector/planetoid
 	name = "a generic planetoid"
 	in_space = FALSE //can't spacewalk to a planet
+	is_planet = TRUE
 
 	var/static_name = null // if we don't want to generate a name
 	var/atmo_color = COLOR_WHITE //do we have atmos, and if so, what color are the clouds
 	var/has_rings = FALSE //do we have rings?
-
 
 /obj/effect/overmap/visitable/sector/planetoid/New(nloc, max_x, max_y)
 	if(!static_name)


### PR DESCRIPTION
makes an 'is_planet' var for sectors, to allow solar occlusion to be set for non-exoplanet aways.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->