### PR TITLE
Fixes SMG jamming

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -177,7 +177,7 @@
 					return
 				user.visible_message("[user] inserts [AM] into [src].", SPAN_NOTICE("You insert [AM] into [src]."))
 				playsound(loc, mag_insert_sound, 50, 1)
-				if(!istype(AM, magazine_type))
+				if(jam_chance && !istype(AM, magazine_type))
 					jam_chance += 10
 			if(SPEEDLOADER)
 				if(length(loaded) >= max_shells)


### PR DESCRIPTION
This code is spaghetti.
I previously fixed this but missed a different jam check. Looks like I only fixed it before when speed reloading, not for normal empty reloading. Derp.

Fixes #1310 for realsies this time.