### PR TITLE
Fixes Ore Generation

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -335,7 +335,7 @@ var/global/list/mining_floors = list()
 			if(!istype(orenoise))
 				continue
 			if(orenoise.origin_z == N.z)
-				orenoise.generate_tile(N)
+				orenoise.generate_map_tile(N)
 				break
 
 /turf/simulated/mineral/proc/excavate_find(prob_clean = 0, datum/find/F)

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -47,6 +47,9 @@
 	var/tx = ((origin_x-1)+x)*chunk_size
 	var/ty = ((origin_y-1)+y)*chunk_size
 
+	var/tmp_cell
+	TRANSLATE_AND_VERIFY_COORD(x,y)
+
 	for(var/i=0,i<chunk_size,i++)
 		for(var/j=0,j<chunk_size,j++)
 			var/turf/simulated/T = locate(tx+j, ty+i, origin_z)
@@ -55,18 +58,24 @@
 			if(!priority_process)
 				CHECK_TICK
 
-			generate_tile(T)
+			generate_tile(T, tmp_cell)
 
-/datum/random_map/noise/ore/proc/generate_tile(var/turf/simulated/T)
+/datum/random_map/noise/ore/proc/generate_map_tile(var/turf/simulated/T)
 	if(!istype(T) || !T.has_resources)
 		return
 
+	var/tx = round(((origin_x-1)+T.x)/chunk_size)
+	var/ty = round(((origin_y-1)+T.y)/chunk_size)
+
+	var/tmp_cell
+	TRANSLATE_AND_VERIFY_COORD(tx,ty)
+
+	generate_tile(T, tmp_cell)
+
+/datum/random_map/noise/ore/proc/generate_tile(var/turf/simulated/T, var/tmp_cell)
 	T.resources = list()
 	T.resources[MATERIAL_SAND] = rand(3,5)
 	T.resources[MATERIAL_GRAPHITE] = rand(3,5)
-
-	var/tmp_cell
-	TRANSLATE_AND_VERIFY_COORD(T.x, T.y)
 
 	if(isnull(tmp_cell))
 		return


### PR DESCRIPTION
Fuck mining.

This (hopefully) fixes the remaining issues with mining/ore gen.
The noise map ore is generated from appears to be using _chunk_ X,Y co-ords, and we're currently passing in raw map x,y co-ordinates into it, resulting in a small ore noise map essentially being overlayed over a much larger map but not scaled up. Any tiles that landed outside of this would return a null `tmp_cell` and thus not generate ores.


This PR preserves these translations between map xy and chunk xy. `apply_to_turf` works with chunk xy co-ords and generates for a range of turfs within those, whereas `generate_map_tile` converts map xy coords into their respective chunks. 

Fixes #1336 