### PR TITLE
Fixes various formatting issues

### DIFF
--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -85,7 +85,7 @@
 		to_chat(user, "Escape procedures already in progress.")
 		return
 	if (evacuation_controller.call_evacuation(user, 1))
-		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has initiated abandonment of the spacecraft.")
+		log_and_message_admins("has initiated abandonment of the spacecraft.", user)
 
 /datum/evacuation_option/bluespace_jump
 	option_text = "Initiate bluespace jump"
@@ -107,7 +107,7 @@
 		to_chat(user, "Jump preparation already in progress.")
 		return
 	if (evacuation_controller.call_evacuation(user, 0))
-		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has initiated bluespace jump preparation.")
+		log_and_message_admins("has initiated bluespace jump preparation.", user)
 
 /datum/evacuation_option/cancel_abandon_ship
 	option_text = "Cancel abandonment"
@@ -118,7 +118,7 @@
 
 /datum/evacuation_option/cancel_abandon_ship/execute(mob/user)
 	if (evacuation_controller && evacuation_controller.cancel_evacuation())
-		log_and_message_admins("[key_name(user)] has cancelled abandonment of the spacecraft.")
+		log_and_message_admins("has cancelled abandonment of the spacecraft.", user)
 
 /datum/evacuation_option/cancel_bluespace_jump
 	option_text = "Cancel bluespace jump"
@@ -129,7 +129,7 @@
 
 /datum/evacuation_option/cancel_bluespace_jump/execute(mob/user)
 	if (evacuation_controller && evacuation_controller.cancel_evacuation())
-		log_and_message_admins("[key_name(user)] has cancelled the bluespace jump.")
+		log_and_message_admins("has cancelled the bluespace jump.", user)
 
 #undef EVAC_OPT_ABANDON_SHIP
 #undef EVAC_OPT_BLUESPACE_JUMP

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -173,7 +173,7 @@ SUBSYSTEM_DEF(jobs)
 			return FALSE
 		else
 			// Let the staff know, in case the person complains about dying due to this later. They've been warned.
-			log_and_message_admins("User [spawner] spawned at spawn point with dangerous atmosphere.")
+			log_and_message_admins("spawned at spawn point with dangerous atmosphere.", spawner)
 	return TRUE
 
 /datum/controller/subsystem/jobs/proc/assign_role(mob/new_player/player, rank, latejoin = 0, datum/game_mode/mode = SSticker.mode)

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -478,7 +478,7 @@
 					crystals = input("Amount of telecrystals for [key]","Operative uplink", crystals) as null|num
 					if (!isnull(crystals) && !QDELETED(suplink))
 						suplink.uses = crystals
-						log_and_message_admins("set the telecrystals for [key] to [crystals]")
+						log_and_message_admins("set the telecrystals for [key_name(src)] to [crystals]")
 
 	else if (href_list["obj_announce"])
 		var/obj_count = 1

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -72,7 +72,7 @@ AI MODULES
 /obj/item/aiModule/proc/log_law_changes(mob/living/silicon/target, mob/sender)
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	GLOB.lawchanges.Add("[time] <B>:</B> [sender.name]([sender.key]) used [src.name] on [target.name]([target.key])")
-	log_and_message_admins("used [src.name] on [target.name]([target.key])")
+	log_and_message_admins("used [src.name] on [key_name(target)])")
 
 /obj/item/aiModule/proc/addAdditionalLaws(mob/living/silicon/ai/target, mob/sender)
 

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -120,7 +120,7 @@
 	playsound(loc, 'sound/items/countdown.ogg', 75, 1, -3)
 	if(ismob(imp_in))
 		imp_in.audible_message(SPAN_WARNING("Something beeps inside [imp_in][part ? "'s [part.name]" : ""]!"))
-		log_and_message_admins("Explosive implant triggered in [imp_in] ([imp_in.key]). (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[imp_in.x];Y=[imp_in.y];Z=[imp_in.z]'>JMP</a>) ")
+		log_and_message_admins("Explosive implant triggered in [key_name(imp_in)]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[imp_in.x];Y=[imp_in.y];Z=[imp_in.z]'>JMP</a>) ")
 	else
 		audible_message(SPAN_WARNING("[src] beeps omniously!"))
 		log_and_message_admins("Explosive implant triggered in [T.loc]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>) ")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -762,7 +762,7 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 		return
 	GLOB.skip_allow_lists = !GLOB.skip_allow_lists
 	var/outcome = GLOB.skip_allow_lists ? "disabled" : "enabled"
-	log_and_message_admins("[key_name(usr)] [outcome] allow lists.")
+	log_and_message_admins("[outcome] allow lists.")
 
 
 /datum/admins/proc/toggleooc()
@@ -909,7 +909,7 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 		to_world("<B>New players may no longer enter the game.</B>")
 	else
 		to_world("<B>New players may now enter the game.</B>")
-	log_and_message_admins("[key_name_admin(usr)] toggled new player game entering.")
+	log_and_message_admins("toggled new player game entering.")
 	world.update_status()
 
 /datum/admins/proc/toggleaban()

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -229,13 +229,13 @@
 		if(!target)
 			to_chat(usr, "Your callproc target no longer exists.")
 			return
-		log_and_message_admins("[key_name(C)] called \the [target]'s [procname]() with [LAZYLEN(arguments) ? "the arguments [list2params(arguments)]" : "no arguments"].", location = get_turf(target))
+		log_and_message_admins("called \the [target]'s [procname]() with [LAZYLEN(arguments) ? "the arguments [list2params(arguments)]" : "no arguments"].", C, location = get_turf(target))
 		if(LAZYLEN(arguments))
 			returnval = call(target, procname)(arglist(arguments))
 		else
 			returnval = call(target, procname)()
 	else
-		log_and_message_admins("[key_name(C)] called [procname]() with [LAZYLEN(arguments)? "the arguments [list2params(arguments)]" : "no arguments"].", location = get_turf(target))
+		log_and_message_admins("called [procname]() with [LAZYLEN(arguments)? "the arguments [list2params(arguments)]" : "no arguments"].", C, location = get_turf(target))
 
 		var/P = text2path("/proc/[procname]")
 		returnval = call(P)(arglist(arguments))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -846,7 +846,7 @@
 		var/t = href_list["removejobban"]
 		if(t)
 			if((alert("Do you want to unjobban [t]?","Unjobban confirmation", "Yes", "No") == "Yes") && t) //No more misclicks! Unless you do it twice.
-				log_and_message_admins("[key_name_admin(usr)] removed [t]")
+				log_and_message_admins("removed [t]")
 				jobban_remove(t)
 				href_list["ban"] = 1 // lets it fall through and refresh
 				var/t_split = splittext(t, " - ")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -939,7 +939,7 @@ Ccomp's first proc.
 			mob.AdjustWeakened(2)
 			mob.AdjustStunned(2)
 			++floored
-	log_and_message_admins("[key_name_admin(user)] simulated a distant explosion, affecting [affected] players and flooring [floored] on levels [levels.Join(", ")].")
+	log_and_message_admins("simulated a distant explosion, affecting [affected] players and flooring [floored] on levels [levels.Join(", ")].", user)
 
 
 /client/proc/bombard_zlevel()

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -364,7 +364,7 @@ var/global/last_message_id = 0
 		return
 
 	if(evacuation_controller.call_evacuation(user, _emergency_evac = emergency))
-		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has called the shuttle.")
+		log_and_message_admins("has called the shuttle.", user)
 
 /proc/init_autotransfer()
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -230,9 +230,9 @@
 			var/turf/turf = get_turf(src)
 			if(turf)
 				var/area/area = turf.loc || "*unknown area*"
-				log_and_message_admins("[key_name_admin(Proj.firer)] shot a fuel tank in \the [area].")
+				log_and_message_admins("shot a fuel tank in \the [area].", Proj.firer)
 			else
-				log_and_message_admins("shot a fuel tank outside the world.")
+				log_and_message_admins("shot a fuel tank outside the world.", Proj.firer)
 
 		if(!istype(Proj ,/obj/item/projectile/beam/lastertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
 			explode()

--- a/code/modules/urist/antagonist/revenant/revenant_slaps.dm
+++ b/code/modules/urist/antagonist/revenant/revenant_slaps.dm
@@ -204,7 +204,7 @@ var/global/list/revenant_slaps = (typesof(/datum/power/revenant/bs_slap) - /datu
 	M.Stun(100)
 	M.Weaken(100)
 
-	log_and_message_admins("[M] has summoned Nar'Sie due to neglecting his Bluespace Revenant Distortion!")
+	log_and_message_admins("has summoned Nar'Sie due to neglecting his Bluespace Revenant Distortion!", M)
 	var/obj/singularity/narsie/large/narnar = new(T)
 
 	if(!istype(narnar))
@@ -242,11 +242,10 @@ var/global/list/revenant_slaps = (typesof(/datum/power/revenant/bs_slap) - /datu
 	if(isnull(H))
 		// We'll gib non-humanoids so that they don't get a free pass
 		M.gib()
-		log_and_message_admins("[M] has been gibbed through zombification due to neglecting his Bluespace Revenant Distortion *as a non-humanoid*!")
+		log_and_message_admins("has been gibbed through zombification due to neglecting his Bluespace Revenant Distortion *as a non-humanoid*!", M)
 		return TRUE
 
 	H.zombify()
-	log_and_message_admins("[M] has turned into a zombie due to neglecting his Bluespace Revenant Distortion!")
+	log_and_message_admins("has turned into a zombie due to neglecting his Bluespace Revenant Distortion!", M)
 
 	return TRUE
-

--- a/code/modules/urist/modules/newtrading/NPC/NPC_types/colonist.dm
+++ b/code/modules/urist/modules/newtrading/NPC/NPC_types/colonist.dm
@@ -71,43 +71,43 @@
 /datum/say_list/colonist
 	emote_hear = list("coughs","sneezes","sniffs","clears their throat","whistles tunelessly","sighs deeply","yawns")
 	emote_see = list("shifts from side to side.","scratches their arm.","examines their nails.","stares at at the ground aimlessly.","looks bored.","places their hands in their pockets.","stares at you with a blank expression.","scratches their nose.")
-	speak = list("\"Have you heard the latest news from Mars?\"",\
-		"\"I'd love to visit Luna one day.\"",\
-		"\"If you ever want to visit a frontier world, check out the Draetheus V colony.\"",\
-		"\"I hope we don't get hit by pirates again...\"",\
-		"\"The price of starship fuel is insane right now.\"",\
-		"\"Did you hear the rioting worsened on Ryclies I yesterday?\"",\
-		"\"Have you heard the plans for the spaceport upgrade?\"",\
-		"\"Let me tell you, Ryclies made means low quality knockoffs.\"",\
-		"\"I have relatives on Procyon. I should really go visit them.\"",\
-		"\"I hope this damn civil war ends soon.\"",\
-		"\"It'd be nice to visit Mars again without worrying about getting blown up by some UHA terrorists.\"",\
-		"\"Have you heard about the rebellions in the mining colonies?\"",\
-		"\"I thought NanoTrasen would be safe from terrorist violence. After the recent attacks by those rebel miners, nowhere feels safe anymore.\"",\
-		"\"I really need a drink right now.\"",\
-		"\"Anyone here got a smoke?\"",\
-		"\"Fuck, I could use a smoke.\"",\
-		"\"I used to be a spacefarer like you, until I took an EMP to my artificial leg.\"",\
-		"\"I heard there was another Lactera attack in this sector. They tell us the Galactic Crisis is over, but some days, it feels like it's still going on out here.\"",\
-		"\"There's nothing like coffee in the morning, let me tell you, that stuff brings you back from the dead.\"",\
-		"\"Did you hear about those Terran Confederacy marines who murdered those civilians on a Vey-Med ship? With the Confederacy as it is now, I doubt they'll ever see justice.\"",\
-		"\"I've been meaning to visit my uncle on Mars, but the Terran Confederacy scares me these days. Too much power in the hands of the Terran Navy I tell ya.\"",\
-		"\"Have you been following the Terran Confederacy presidential campaign?\"",\
-		"\"Have you heard anything about the rioting on Mars?\"",\
-		"\"I hear the Terran Confederacy Navy is supplying pirate groups in NanoTrasen sectors as payback for NanoTrasen refusing to embargo the United Human Alliance. Probably just a rumour though.\"",\
-		"\"I hear the United Human Alliance is supplying pirate groups in NanoTrasen sectors as payback for NanoTrasen continuing to trade with the Terran Confederacy. Probably just a rumour though.\"",\
-		"\"Strange to think that some folks spend their entire lives in space.\"",\
-		"\"I never should have come to the outer sectors, but getting home is too expensive.\"",\
-		"\"Nothing ever happens in this miserable hellhole.\"",\
-		"\"I hear the UHA has started a new offensive against the Terran Confederacy. With the rebellions in the mining colonies and the constant rioting on Mars, the UHA might actually make some gains this time.\"",\
-		"\"The one nice thing about being out here is not having to worry about terrorist attacks. There's just pirates, lactera, asteroids, and whatever the hell else is out there in the cold void of space... Fuck.\"",\
-		"\"Been seeing a lot more traffic in these parts, I wonder why?\"",\
-		"\"If I were you I wouldn't hang around here too long. Not much to do.\"",\
-		"\"Oh, another visitor.\"",\
-		"\"I have relatives on Mars, I should really go visit them because I haven't heard from them for a while.\"",\
-		"\"Not a lot of Unathi on this station.\"",\
-		"\"Have you ever been to New Earth? I guess it's called Terra now... Apparently it was a beautiful place before the Galactic Crisis and the civil war.\"",\
-		"\"I have a cousin on one of the mining outposts that supposedly rose up, haven't heard from him in months.\""
+	speak = list("Have you heard the latest news from Mars?",
+		"I'd love to visit Luna one day.",
+		"If you ever want to visit a frontier world, check out the Draetheus V colony.",
+		"I hope we don't get hit by pirates again...",
+		"The price of starship fuel is insane right now.",
+		"Did you hear the rioting worsened on Ryclies I yesterday?",
+		"Have you heard the plans for the spaceport upgrade?",
+		"Let me tell you, Ryclies made means low quality knockoffs.",
+		"I have relatives on Procyon. I should really go visit them.",
+		"I hope this damn civil war ends soon.",
+		"It'd be nice to visit Mars again without worrying about getting blown up by some UHA terrorists.",
+		"Have you heard about the rebellions in the mining colonies?",
+		"I thought NanoTrasen would be safe from terrorist violence. After the recent attacks by those rebel miners, nowhere feels safe anymore.",
+		"I really need a drink right now.",
+		"Anyone here got a smoke?",
+		"Fuck, I could use a smoke.",
+		"I used to be a spacefarer like you, until I took an EMP to my artificial leg.",
+		"I heard there was another Lactera attack in this sector. They tell us the Galactic Crisis is over, but some days, it feels like it's still going on out here.",
+		"There's nothing like coffee in the morning, let me tell you, that stuff brings you back from the dead.",
+		"Did you hear about those Terran Confederacy marines who murdered those civilians on a Vey-Med ship? With the Confederacy as it is now, I doubt they'll ever see justice.",
+		"I've been meaning to visit my uncle on Mars, but the Terran Confederacy scares me these days. Too much power in the hands of the Terran Navy I tell ya.",
+		"Have you been following the Terran Confederacy presidential campaign?",
+		"Have you heard anything about the rioting on Mars?",
+		"I hear the Terran Confederacy Navy is supplying pirate groups in NanoTrasen sectors as payback for NanoTrasen refusing to embargo the United Human Alliance. Probably just a rumour though.",
+		"I hear the United Human Alliance is supplying pirate groups in NanoTrasen sectors as payback for NanoTrasen continuing to trade with the Terran Confederacy. Probably just a rumour though.",
+		"Strange to think that some folks spend their entire lives in space.",
+		"I never should have come to the outer sectors, but getting home is too expensive.",
+		"Nothing ever happens in this miserable hellhole.",
+		"I hear the UHA has started a new offensive against the Terran Confederacy. With the rebellions in the mining colonies and the constant rioting on Mars, the UHA might actually make some gains this time.",
+		"The one nice thing about being out here is not having to worry about terrorist attacks. There's just pirates, lactera, asteroids, and whatever the hell else is out there in the cold void of space... Fuck.",
+		"Been seeing a lot more traffic in these parts, I wonder why?",
+		"If I were you I wouldn't hang around here too long. Not much to do.",
+		"Oh, another visitor.",
+		"I have relatives on Mars, I should really go visit them because I haven't heard from them for a while.",
+		"Not a lot of Unathi on this station.",
+		"Have you ever been to New Earth? I guess it's called Terra now... Apparently it was a beautiful place before the Galactic Crisis and the civil war.",
+		"I have a cousin on one of the mining outposts that supposedly rose up, haven't heard from him in months."
 		)
 
 /mob/living/simple_animal/passive/npc/colonist/nanotrasen
@@ -119,7 +119,7 @@
 	if(prob(angryprob))
 		angryspeak = 1
 	if(prob(0.00001))
-		say_list.speak += "\"I saw a mudcrab the other day. Vile creatures they are.\"" //the chances of this being heard are so small, but I had to put it in.
+		say_list.speak += "I saw a mudcrab the other day. Vile creatures they are." //the chances of this being heard are so small, but I had to put it in.
 	..()
 
 

--- a/code/modules/urist/modules/shipbattles/shipweapons/torpedo_warhead.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/torpedo_warhead.dm
@@ -105,7 +105,7 @@
 			A.forceMove(src)
 			attached_device = I
 			A.holder = src
-			log_and_message_admins("[user] has rigged a torpedo IED.")
+			log_and_message_admins("has rigged a torpedo IED.",  user)
 			playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
 			icon_state = "torpedowarhead-open-mod-armed"
 	return


### PR DESCRIPTION
Just a few formatting tweaks

- Fixes formatting issues present in NPC speech, causing a double speech mark (Fixes #1340 )
- Fixes a few doubled up ckeys in admin logs. `log_and_message_admins` already includes the usr's ckey by default.