### PR TITLE
Reverts GalCom default human language + NPC floating text alternative fix 

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_human.dm
+++ b/code/modules/culture_descriptor/culture/cultures_human.dm
@@ -5,7 +5,7 @@
 /singleton/cultural_info/culture/human
 	name = CULTURE_HUMAN
 	description = "You are from one of various planetary cultures of humankind."
-	default_language = LANGUAGE_GALCOM
+	// default_language = LANGUAGE_GALCOM
 	secondary_langs = list(
 		LANGUAGE_GALCOM,
 		LANGUAGE_SOL_COMMON,

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -228,14 +228,16 @@
 	..()
 	updatehealth()
 
-/mob/living/simple_animal/say(message)
+/mob/living/simple_animal/say(message, var/language)
 	var/verb = "says"
 	if(length(speak_emote))
 		verb = pick(speak_emote)
 
 	message = sanitize(message)
 
-	..(message, species_language, verb)
+	language = all_languages[language] || species_language
+
+	..(message, language, verb)
 
 /mob/living/simple_animal/get_speech_ending(verb, ending)
 	return verb

--- a/code/modules/urist/modules/newtrading/NPC/npc.dm
+++ b/code/modules/urist/modules/newtrading/NPC/npc.dm
@@ -156,3 +156,6 @@
 	M.Turn(90)
 	M.Translate(1,-6)
 	src.transform = M
+
+/mob/living/simple_animal/passive/npc/say(var/message, var/language = LANGUAGE_GALCOM)
+	..(message, language)


### PR DESCRIPTION
As raised in the comments of #1317, GalCom being the default language for humans had some other side effects, namely forcing away map players to adopt GalCom, and essentially forcing human players to lose a language slot.
I personally have no skin in the game, so I don't mind if reverting this is rejected or not.

Tagging @Vakothu & @ggermanicus for their input

Changes:

- Galactic Common removed as human's default language
- `simple_animal`'s `say` proc has been expanded to accept an optional language string. If none is provided, the mob's `species_language` is instead used (this defaults to their culture's default language)
- NPCs speak Galactic Common by default in their `say` proc. This can be overloaded for fun.

Only issue with this is it does unfix something mentioned by @Glloyd in the previous PR , which is that admin-spawned NPCs having no languages will be a thing again