### PR TITLE
Fix A22 rifle not accepting it's magazine/Wrong Caliber + Flamethrower Typo

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -173,7 +173,7 @@
 			fire_colour = R.fire_colour
 
 	if(power < REQUIRED_POWER_TO_FIRE_FLAMETHROWER)
-		audible_message(SPAN_DANGER("The [src] sputters."))
+		audible_message(SPAN_DANGER("\The [src] sputters."))
 		playsound(src, 'sound/weapons/guns/flamethrower_empty.ogg', 50, TRUE, -3)
 		return
 	playsound(src, pick('sound/weapons/guns/flamethrower1.ogg','sound/weapons/guns/flamethrower2.ogg','sound/weapons/guns/flamethrower3.ogg' ), 50, TRUE, -3)

--- a/code/modules/urist/gamemodes/infestation/weapons&armour.dm
+++ b/code/modules/urist/gamemodes/infestation/weapons&armour.dm
@@ -196,7 +196,7 @@
 	icon = 'icons/urist/items/guns.dmi'
 	icon_state = "ANFOR-riflemag"
 	mag_type = MAGAZINE
-	caliber = CALIBER_RIFLE
+	caliber = CALIBER_RIFLE_MILITARY
 	origin_tech = "combat=2"
 	matter = list(DEFAULT_WALL_MATERIAL = 3500)
 	ammo_type = /obj/item/ammo_casing/rifle

--- a/code/modules/urist/gamemodes/infestation/weapons&armour.dm
+++ b/code/modules/urist/gamemodes/infestation/weapons&armour.dm
@@ -167,11 +167,12 @@
 	item_state = "ANFOR-rifle"
 	w_class = 4
 	force = 10
-	caliber = CALIBER_RIFLE
+	caliber = CALIBER_RIFLE_MILITARY
 	origin_tech = "combat=6;materials=1;syndicate=4"
 	slot_flags = SLOT_BACK
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/rifle/a22
+	allowed_magazines = /obj/item/ammo_magazine/rifle/a22
 	one_hand_penalty = 5
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
 	wielded_item_state = "ANFOR-rifle-wielded"
@@ -191,7 +192,7 @@
 	return
 
 /obj/item/ammo_magazine/rifle/a22
-	name = "A22 magazine (5.56mm)"
+	name = "A22 magazine"
 	icon = 'icons/urist/items/guns.dmi'
 	icon_state = "ANFOR-riflemag"
 	mag_type = MAGAZINE


### PR DESCRIPTION
Changes:

- Flamethrower no longer gives a double `the the` when it splutters
- A22 ANFOR rifle now uses the caliber listed in it's description, is able to have it's own magazines reinserted, and it's magazines no longer double on mentioning their caliber 