### PR TITLE
Fixes severely impaired breathing speech

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -32,7 +32,7 @@
 			to_chat(src, SPAN_WARNING("You don't have enough air[L ? " in [L]" : ""] to make a sound!"))
 			return
 		else if(L.breath_fail_ratio > 0.3)
-			return ..(length(message) > 5 ? stars(message) : message, speaking, whispering = TRUE)
+			return ..(length(message) > 5 ? "[copytext_char(message, 1, 2)][stars(copytext_char(message, 2, length_char(message)))]" : message, speaking, whispering = TRUE)
 		else if(L.breath_fail_ratio > 0.15 && length(message) > 10)
 			return ..(message, speaking, whispering = TRUE)
 	return ..(message, speaking = speaking, whispering = whispering)


### PR DESCRIPTION
Not the most elegant fix but this should prevent severe lung damage from causing the first character to become a emote prefix.