### PR TITLE
Adds label enforcement

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,23 @@
+name: Enforce Labels
+
+on:
+  pull_request:
+    types: [synchronize, opened, labeled, unlabeled]
+
+jobs:
+  check-labels:
+    name: Enforce Blocking Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce Do Not Merge
+        if: contains(github.event.pull_request.labels.*.name, 'Do Not Merge')
+        run: |
+          echo "Pull request is labeled DNM"
+          echo "The DNM label must be removed before this PR can be merged"
+          exit 1
+      - name: Enforce Play Testing
+        if: success() && (contains(github.event.pull_request.labels.*.name, 'Playtest Required') && !contains(github.event.pull_request.labels.*.name, 'Playtest Passed'))
+        run: |
+          echo "Pull request is labeled as requiring a playtest and has not been marked as passed"
+          echo "The Playtest Passed label must be added, or the Playtest label removed before this PR can be merged"
+          exit 1


### PR DESCRIPTION
Poking the repo, again :D  

Looking through recent PRs, I thought it'd be nice if labels such as Do Not Merge _actually_ prevented merging to prevent it being missed. This workflow is intended to be used alongside branch protection rules/rulesets with the `Require status checks to pass before merging` option enabled and this workflow included.

Very crude, but this 'test' will simply fail if:

- The Do Not Merge label is present OR
- The Playtest Required label is present AND Playtest Passed is not present

The playtest label came to me after we've had several large features added recently that have needed live tests on the server (Such as deepmaint, FoV cone etc). Idea being for large features where extensive playtesting and/or player feedback is required, the PR would be blocked, the server could switch to that branch, then the applicable pass/fail labels added to the PR to keep track and inform the OP of the current status.