### PR TITLE
Fixes guns not repsecting initial firemodes

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -115,6 +115,10 @@
 	if(scope_zoom)
 		verbs += /obj/item/gun/proc/scope
 
+	if(length(firemodes))
+		var/datum/firemode/new_mode = firemodes[sel_mode]
+		new_mode.apply_to(src)
+
 /obj/item/gun/update_twohanding()
 	if(one_hand_penalty)
 		update_icon() // In case item_state is set somewhere else.


### PR DESCRIPTION
Currently, weapons do not actually respect their initial firemode selection when spawned in. It's only by chance that the correct various variables (such as projectile type) matches the initial firemode that some guns 'appear' uneffected.

This PR removes that requirement, and instead adds a check during Init that if there are multiple firemodes, it grabs the selected mode and applies it to the gun.
Fixes #1347 