### PR TITLE
Fixes maintenance light deconstruction

### DIFF
--- a/code/modules/urist/structures/uristlighting.dm
+++ b/code/modules/urist/structures/uristlighting.dm
@@ -6,24 +6,16 @@
 ///////////////////////////////////////////////////////////////////////////
 
 //spoopy red maint lights, Alien-style
-/obj/machinery/light/small/red
+/obj/machinery/light/small/red/maintenance
 	icon_state = "firelight1"
-	construct_type = /obj/machinery/light/small
 	active_power_usage = 2
 	name = "Maintenance light fixture"
 	desc = "A small, low-power lighting fixture used for maintenance lighting."
-	light_type = /obj/item/light/bulb/red
+	light_type = /obj/item/light/bulb/red/maintenance
 
-/obj/machinery/light/small/red/New()
-	..()
-	icon_state = "firelight1"
-
-/obj/item/light/bulb/red
+/obj/item/light/bulb/red/maintenance
 	name = "light bulb (maintenance)"
 	desc = "A replacement light bulb. This one has a red filter and is designed for usage in Maintenance."
-	icon_state = "flight"
-	base_state = "flight"
-	item_state = "contvapour"
 	b_outer_range = 6
 	b_colour = "#b12525"
 

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -1978,7 +1978,7 @@
 /area/maintenance/fourth_deck/afp)
 "dY" = (
 /obj/random/junk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -2014,7 +2014,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "eb" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -2387,7 +2387,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -3062,7 +3062,7 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4137,7 +4137,7 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -5247,7 +5247,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/command/aiupload)
 "jL" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -5963,7 +5963,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -6098,7 +6098,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -7027,7 +7027,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "mL" = (
@@ -7707,7 +7707,7 @@
 /obj/random/bomb_supply,
 /obj/random/tool,
 /obj/random/tech_supply,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
 "nJ" = (
@@ -11248,7 +11248,7 @@
 /area/maintenance/fourth_deck/central)
 "tB" = (
 /obj/structure/closet/firecloset,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/central)
 "tC" = (
@@ -11308,7 +11308,7 @@
 	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/central)
@@ -11582,7 +11582,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -11890,7 +11890,7 @@
 /obj/machinery/computer/modular/preset/medical{
 	autorun_program = /datum/computer_file/program/suit_sensors
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -12070,7 +12070,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -15109,7 +15109,7 @@
 /area/maintenance/fourth_deck/fs)
 "Ap" = (
 /obj/structure/catwalk,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -15167,7 +15167,7 @@
 	pixel_y = 4
 	},
 /obj/item/device/radio,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -16820,7 +16820,7 @@
 	dir = 1;
 	id = "garbage"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -16848,7 +16848,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -17783,7 +17783,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
@@ -18279,7 +18279,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -18418,7 +18418,7 @@
 /obj/machinery/mass_driver{
 	id_tag = "trash"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -19124,7 +19124,7 @@
 "HB" = (
 /obj/structure/table/rack,
 /obj/effect/landmark/costume,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -20166,7 +20166,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -20352,7 +20352,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
@@ -20394,7 +20394,7 @@
 /area/rnd/xenobiology/xenoflora)
 "Kt" = (
 /obj/structure/closet/crate/internals,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -20821,7 +20821,7 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "LR" = (
@@ -21810,7 +21810,7 @@
 	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23264,7 +23264,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -23425,7 +23425,7 @@
 /turf/simulated/floor/tiled/old_tile,
 /area/command/aiupload)
 "WY" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -23797,7 +23797,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/logistics/fabwork)
 "YF" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/table/rack,
 /obj/random/snack,
 /obj/random/tech_supply,
@@ -23823,7 +23823,7 @@
 	autorun_program = /datum/computer_file/program/alarm_monitor;
 	dir = 1
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -504,7 +504,7 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/third_deck/centp)
 "abr" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/centp)
 "abs" = (
@@ -539,7 +539,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/centp)
 "abv" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -853,7 +853,7 @@
 /area/maintenance/third_deck/afp)
 "ach" = (
 /obj/structure/closet/firecloset,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -1119,7 +1119,7 @@
 	dir = 9;
 	icon_state = "intact-supply"
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
 "acJ" = (
@@ -3162,7 +3162,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
 "ago" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fp)
 "agp" = (
@@ -3298,7 +3298,7 @@
 "agz" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/down,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -5595,7 +5595,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -6825,7 +6825,7 @@
 /area/maintenance/third_deck/afp)
 "ams" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -6850,7 +6850,7 @@
 "amv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -7749,7 +7749,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/locker)
 "aoc" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -21701,7 +21701,7 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -24447,7 +24447,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -25280,7 +25280,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aRM" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
 "aRN" = (
@@ -26355,7 +26355,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
 "aTJ" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26679,7 +26679,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/cmo)
 "aUr" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -30503,7 +30503,7 @@
 /turf/simulated/floor/plating,
 /area/security/portexternalgun)
 "qGN" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -31174,7 +31174,7 @@
 /area/logistics/mailing)
 "uzq" = (
 /obj/random/trash,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afp)
 "uBC" = (
@@ -31644,7 +31644,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
 "wSn" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -277,7 +277,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -1442,7 +1442,7 @@
 	pixel_y = 0
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -2344,7 +2344,7 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
@@ -2379,7 +2379,7 @@
 	pixel_y = 0
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -5655,7 +5655,7 @@
 	pixel_y = 0
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -6772,7 +6772,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/central)
 "mX" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -7271,7 +7271,7 @@
 	dir = 6
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -8994,7 +8994,7 @@
 	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -9483,7 +9483,7 @@
 	icon_state = "intact-supply"
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -9631,7 +9631,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -9829,7 +9829,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "sF" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -9919,7 +9919,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9977,7 +9977,7 @@
 /area/maintenance/second_deck/afs)
 "sT" = (
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -12801,7 +12801,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12924,7 +12924,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afs)
 "yJ" = (
@@ -14329,7 +14329,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "Ez" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -14958,7 +14958,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "HA" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -15019,7 +15019,7 @@
 /area/security/boardarmoury)
 "Ia" = (
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -15394,7 +15394,7 @@
 /area/chapel)
 "Ka" = (
 /obj/machinery/power/terminal,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -15436,7 +15436,7 @@
 /area/logistics/primtool)
 "Kg" = (
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -15980,7 +15980,7 @@
 /area/civilian/journalist)
 "MH" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fp)
 "MI" = (
@@ -16183,7 +16183,7 @@
 /area/civilian/counselor)
 "NT" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -17317,7 +17317,7 @@
 /area/civilian/personal)
 "Ty" = (
 /obj/random/junk,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
 "TA" = (
@@ -17584,7 +17584,7 @@
 /turf/simulated/floor/carpet,
 /area/civilian/counselor)
 "US" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
 "UT" = (
@@ -17974,7 +17974,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -18096,7 +18096,7 @@
 /obj/structure/curtain/open/bed,
 /obj/item/bedsheet/clown,
 /obj/item/storage/backpack/duffel/duffel_clown,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/effect/landmark/start{
 	name = "Clown"
 	},

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -652,7 +652,7 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -688,7 +688,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -1807,7 +1807,7 @@
 /area/maintenance/first_deck/fp)
 "dR" = (
 /obj/structure/ladder,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -2028,7 +2028,7 @@
 /area/maintenance/first_deck/fp)
 "en" = (
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -2536,7 +2536,7 @@
 	dir = 10;
 	icon_state = "intact-supply"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -2560,7 +2560,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "fp" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -2926,7 +2926,7 @@
 /area/maintenance/first_deck/central)
 "fY" = (
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -3793,7 +3793,7 @@
 	icon_state = "map"
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -4010,7 +4010,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -5033,7 +5033,7 @@
 /area/maintenance/first_deck/central)
 "jQ" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -5084,7 +5084,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -5989,7 +5989,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -6227,7 +6227,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
 	icon_state = "intact-scrubbers"
@@ -6483,7 +6483,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "lZ" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -6516,7 +6516,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -6737,7 +6737,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "mJ" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
 	},
@@ -6833,7 +6833,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
 "mT" = (
@@ -7250,7 +7250,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -7382,7 +7382,7 @@
 	pixel_y = 4
 	},
 /obj/item/device/radio,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 8;
 	icon_state = "firelight1"
 	},
@@ -7665,7 +7665,7 @@
 	},
 /obj/random/toolbox,
 /obj/random/tool,
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/fs)
 "ot" = (
@@ -8427,7 +8427,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aftsolar)
 "pM" = (
-/obj/machinery/light/small/red,
+/obj/machinery/light/small/red/maintenance,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
@@ -8500,7 +8500,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},
@@ -8522,7 +8522,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/red/maintenance{
 	dir = 4;
 	icon_state = "firelight1"
 	},


### PR DESCRIPTION
Fixes #1319 
This was caused by a duplicate definition of `/obj/machinery/light/small/red` causing some wonk behaviour.
As the bay version of `/obj/machinery/light/small/red` emitted a darker red colour (kind of like the emergency light colour), I've kept both. The red light we were using is now `/obj/machinery/light/small/red/maintenance`.

Currently I've only swapped the Nerva over to use this old colour, everywhere else what used the red light fixture will be using the bay version.

A comparison between the two

### Urist's Colour (Currently in use on the Nerva)
![2023-10-18_22-02](https://github.com/UristMcStation/UristMcStation/assets/54823378/921ddbe1-2b5d-4f20-93e8-ded367c42760)

### Bay's red light
![2023-10-18_22-01](https://github.com/UristMcStation/UristMcStation/assets/54823378/5a9668b4-6ee7-4844-aae0-c0308f036b76)

Again, with this PR the Nerva will be using the Urist red, whereas anywhere else will use the new Bay red. If you want to revert this, or have more maps use the Urist red, let me know!