### PR TITLE
Various Payroll Bugfixes + Improvements

### DIFF
--- a/code/controllers/subsystems/payment.dm
+++ b/code/controllers/subsystems/payment.dm
@@ -41,9 +41,9 @@ SUBSYSTEM_DEF(payment_controller)
 	//Don't forget our coporate overlords!
 	var/list/nanotrasen_nags = list(
 		"NanoTrasen staff are reminded that salaries cannot be re-negotiated once employment has commenced",
-		"NanoTrasen would like to remind staff that the Intellectual Property rights of any inventions and/or concepts created during your employment with NanoTrasen are waved in their entirety to NanoTrasen",
+		"NanoTrasen would like to remind staff that the Intellectual Property rights of any inventions and/or concepts created during your employment with NanoTrasen are waived in their entirety to NanoTrasen",
 		"Staff are reminded that unionizing is in direct violation of your employment contract. Dissatisfied staff are to book an appointment with a NanoTrasen Productivity and Morale Advisor, who will arrange an appointment with you within the next 895 working day(s)",
-		"NanoTrasen staff are reminded that minimising overhead and wastage to NanoTrasen is of paramount importance, as well as everyone's joint responsibility",
+		"NanoTrasen staff are reminded that minimising overhead and wastage is of paramount importance to NanoTrasen, and is everyone's joint responsibility",
 		"NanoTrasen would like to remind contracted staff that failure to meet expectations during your annual performance review, can and will result in contract termination (termination fees applicable)",
 		"Staff are reminded that termination of the employment contract will incur a fee of 38.9% of your agreed annual salary for each year you have been employed by NanoTrasen, retrospectively adjusted for current inflation rates",
 		"NanoTrasen reserves the right to reimburse lost productivity caused by staff absence from the workplace for any reason (such as sickness), automatically from staff salary payment(s) until the lost sum is recovered in its entirety",

--- a/code/controllers/subsystems/payment.dm
+++ b/code/controllers/subsystems/payment.dm
@@ -2,63 +2,116 @@ SUBSYSTEM_DEF(payment_controller)
 	name = "Payment"
 	wait = 15 SECONDS
 	var/timerbuffer = 60 MINUTES //buffer for time check
-	var/list/brand = list("Cheesie Honkers", "Men At Arms Tobacco", "Lucky Stars Cigarettes", "Carcinoma Angels Cigarettes", "Robust Coffee", "Getmore Chocolate Corp products", "4no Raisins", "SweatMax products", "Space Cola", "Space Mountain Wind", "Dr.Gibb", "ClothingLord 9000 Clothes", "NanoTrasen Personal Computers", "Rougelady Chewing Tobacco", "Robust Softdrinks products") //this is just for the jokes
-	var/list/slogan = list("Now with 18% less carcinogens!", "Lawsuit free since 2579!", "Leading doctors only moderately advise against our products!", "Now occasionally without illegal narcotics!", "Now complying with 94% of trading standards laws!", "Condemned by the Space Pope!", "Larva-tested, pupa-approved", "For external use only", "Fun for the whole family except grandma and grandpa", "Beats a hard kick in the face", "The proud result of prison labor!", "No refunds", "For the sophisticated shut-in", "Tell your parents it's educational!")
+
+	var/list/brand = list(  //this is just for the jokes
+		"Cheesie Honkers",
+		"Men At Arms Tobacco",
+		"Lucky Stars Cigarettes",
+		"Carcinoma Angels Cigarettes",
+		"Robust Coffee",
+		"Getmore Chocolate Corp products",
+		"4no Raisins",
+		"SweatMax products",
+		"Space Cola",
+		"Space Mountain Wind",
+		"Dr.Gibb",
+		"ClothingLord 9000 Clothes",
+		"NanoTrasen Personal Computers",
+		"Rougelady Chewing Tobacco",
+		"Robust Softdrinks products"
+	)
+
+	var/list/slogan = list(
+		"Now with 18% less carcinogens!",
+		"Lawsuit free since 2579!",
+		"Leading doctors only moderately advise against our products!",
+		"Now occasionally without illegal narcotics!",
+		"Now complying with 94% of trading standards laws!",
+		"Condemned by the Space Pope!",
+		"Larva-tested, pupa-approved",
+		"For external use only",
+		"Fun for the whole family except grandma and grandpa",
+		"Beats a hard kick in the face",
+		"The proud result of prison labor!",
+		"No refunds",
+		"For the sophisticated shut-in",
+		"Tell your parents it's educational!"
+	)
+
+	//Don't forget our coporate overlords!
+	var/list/nanotrasen_nags = list(
+		"NanoTrasen staff are reminded that salaries cannot be re-negotiated once employment has commenced",
+		"NanoTrasen would like to remind staff that the Intellectual Property rights of any inventions and/or concepts created during your employment with NanoTrasen are waved in their entirety to NanoTrasen",
+		"Staff are reminded that unionizing is in direct violation of your employment contract. Dissatisfied staff are to book an appointment with a NanoTrasen Productivity and Morale Advisor, who will arrange an appointment with you within the next 895 working day(s)",
+		"NanoTrasen staff are reminded that minimising overhead and wastage to NanoTrasen is of paramount importance, as well as everyone's joint responsibility",
+		"NanoTrasen would like to remind contracted staff that failure to meet expectations during your annual performance review, can and will result in contract termination (termination fees applicable)",
+		"Staff are reminded that termination of the employment contract will incur a fee of 38.9% of your agreed annual salary for each year you have been employed by NanoTrasen, retrospectively adjusted for current inflation rates",
+		"NanoTrasen reserves the right to reimburse lost productivity caused by staff absence from the workplace for any reason (such as sickness), automatically from staff salary payment(s) until the lost sum is recovered in its entirety",
+		"Staff are once again reminded that comfort breaks are indeed on personal time, and as such will be docked from your pay entitlement"
+	)
+
 	var/payment_modifier = 5 //economic_power * this number = pay. tweak this number!
 	var/moneybuffer = 0 //how much money are we removing from the nerva's account?
 	var/total_paid = 0 //how much money have we paid out in total
 
 /datum/controller/subsystem/payment_controller/fire()
-	if (TimeUntilPayday() <= 0)
-		timerbuffer += 60 MINUTES
+	if (TimeUntilPayday() > 0)
+		return
 
-		if(station_account.money <= 0) //we can go into debt, a bit, but then we can't pay people anymore.
-			GLOB.global_announcer.autosay("<b>Hourly salary payments have been not been processed due to a lack of funds. Please direct all criticism towards the Captain.</b>", "[GLOB.using_map.station_name] Automated Payroll System", "Common")
-			return
+	timerbuffer += 60 MINUTES
 
-		else
-			PayPeople()
-			var/newbrand = pick(brand) //this is a dumb meme
-			GLOB.global_announcer.autosay("<b>Hourly salary payments have been processed and deposited into your accounts. Thank you for your service to the [GLOB.using_map.station_name]. This message is brought to you by [newbrand]: make sure to buy [newbrand] at your nearest vending machine.</b>", "[GLOB.using_map.station_name] Automated Payroll System", "Common")
-			total_paid += moneybuffer
-			var/datum/transaction/T = new("[GLOB.using_map.station_name] Payroll", "Automated Payroll Deposits", -moneybuffer, "[GLOB.using_map.station_name] Automated Payroll System")
-			station_account.add_transaction(T)
-			GLOB.global_announcer.autosay("<b>[moneybuffer]Th has been removed from the [GLOB.using_map.station_name]'s main account due to automated payroll services.</b>", "[GLOB.using_map.station_name] Automated Payroll System", "Command")
-			moneybuffer = 0
+	if(station_account.money <= 0) //we can go into debt, a bit, but then we can't pay people anymore.
+		GLOB.global_announcer.autosay("<b>Hourly salary payments have been not been processed due to a lack of funds. Please direct all criticism towards the Captain.</b>", "[GLOB.using_map.station_name] Automated Payroll System", "Common")
+		return
+
+	var/newbrand = pick(brand) //this is a dumb meme
+	PayPeople(newbrand)
+	GLOB.global_announcer.autosay("<b>Hourly salary payments have been processed and deposited into your accounts. Thank you for your service to the [GLOB.using_map.station_name]. This message is brought to you by [newbrand]: make sure to buy [newbrand] at your nearest vending machine.</b>", "[GLOB.using_map.station_name] Automated Payroll System", "Common")
+	total_paid += moneybuffer
+	var/datum/transaction/singular/T = new(station_account, "Automated Payroll Deposits", -moneybuffer, "[GLOB.using_map.station_name] Automated Payroll System")
+	T.perform()
+	GLOB.global_announcer.autosay("<b>[moneybuffer]Th has been removed from the [GLOB.using_map.station_name]'s main account due to automated payroll services.</b>", "[GLOB.using_map.station_name] Automated Payroll System", "Command")
+	moneybuffer = 0
 
 /datum/controller/subsystem/payment_controller/proc/TimeUntilPayday()
 	return timerbuffer - round_duration_in_ticks
 
-/datum/controller/subsystem/payment_controller/proc/PayPeople()
+/datum/controller/subsystem/payment_controller/proc/PayPeople(var/sponsor = pick(brand))
 	var/datum/computer_file/data/email_account/server = ntnet_global.find_email_by_name(EMAIL_PAYROLL)
-	var/thisbrand = pick(brand)
-	var/thisslogan = pick(slogan)
+	var/this_slogan = pick(slogan)
+	var/nanotrasen_nag = pick(nanotrasen_nags)
+
 	for(var/mob/living/carbon/H in GLOB.living_players) //we don't pay dead people
-		if(H.mind)
-			if(H.mind.initial_account && H.mind.assigned_role) //this excludes stowaways and other non-crew roles including derelict ships
-				if(H.mind.assigned_role == "Captain" && GLOB.using_map.name == "Nerva") //todo, make a map var for captain ownership if we have other ship maps in a similar situation (never)
-					continue
+		if(!H.mind?.assigned_role || !H.mind?.initial_account) //this excludes stowaways and other non-crew roles including derelict ships
+			continue
 
-				else
-					var/economic_modifier
-					if(H.mind.pay_suspended)
-						economic_modifier = 0
-					else
-						economic_modifier = H.mind.get_pay()
-						var/datum/transaction/T = new("[station_account.owner_name]", "Automated Payroll Deposit", economic_modifier, "[GLOB.using_map.station_name] Automated Payroll System")
-						H.mind.initial_account.add_transaction(T)
+		if(H.mind.assigned_role == "Captain" && GLOB.using_map.name == "Nerva") //todo, make a map var for captain ownership if we have other ship maps in a similar situation (never)
+			continue
 
-					if(H.mind.initial_email_login["login"])
-						var/datum/computer_file/data/email_message/message = new()
-						message.title = "[GLOB.using_map.station_name] Automated Payroll System"
-						if(!H.mind.pay_suspended)
-							message.stored_data = "[H.real_name],\n\n<b>[economic_modifier] Th</b> has been deposited into your account following hourly payroll payouts.\nThank you for your continued hard work.\n\n<i>This message is brought to you by [thisbrand] - [thisslogan]</i>"
-						else
-							message.stored_data = "[H.real_name],\n\nAs your wages have been suspended, your payout has not been processed. Please direct all complaints to your payroll administrator."
-						message.source = server.login
-						server.send_mail(H.mind.initial_email_login["login"], message)
+		var/economic_modifier = H.mind.pay_suspended ? 0 : H.mind.get_pay()
 
-					if((H.mind.assigned_role == "NanoTrasen Scientist" || H.mind.assigned_role == "Senior Scientist") && GLOB.using_map.name == "Nerva") //NanoTrasen pays the scientists on Nerva
-						continue
+		if(economic_modifier)
+			var/datum/transaction/singular/T = new(H.mind.initial_account, station_account.account_name, economic_modifier, "[GLOB.using_map.station_name] Automated Payroll System")
+			T.perform()
 
-					moneybuffer += economic_modifier
+		if(H.mind.initial_email_login["login"] && server)
+			var/datum/computer_file/data/email_message/message = new()
+			if((H.mind.assigned_role == "NanoTrasen Scientist" || H.mind.assigned_role == "Senior Scientist") && GLOB.using_map.name == "Nerva") ///NanoTrasen pays the scientists on Nerva
+				message.title = "NanoTrasen Payroll Services"
+				message.stored_data = "[H.real_name], \n\nYour agreed salary of <b>[economic_modifier] Th</b> has been deposited into your account on behalf of the NanoTrasen Research and Development department.\n\n<i>[nanotrasen_nag]</i>"
+
+				message.source = server.login
+				server.send_mail(H.mind.initial_email_login["login"], message)
+				continue
+
+			message.title = "[GLOB.using_map.station_name] Automated Payroll System"
+
+			if(!H.mind.pay_suspended)
+				message.stored_data = "[H.real_name],\n\n<b>[economic_modifier] Th</b> has been deposited into your account following hourly payroll payouts.\nThank you for your continued hard work.\n\n<i>This message is brought to you by [sponsor] - [this_slogan]</i>"
+			else
+				message.stored_data = "[H.real_name],\n\nAs your wages have been suspended, your payout has not been processed. Please direct all complaints to your payroll administrator."
+
+			message.source = server.login
+			server.send_mail(H.mind.initial_email_login["login"], message)
+
+		moneybuffer += economic_modifier

--- a/code/controllers/subsystems/payment.dm
+++ b/code/controllers/subsystems/payment.dm
@@ -47,7 +47,8 @@ SUBSYSTEM_DEF(payment_controller)
 		"NanoTrasen would like to remind contracted staff that failure to meet expectations during your annual performance review, can and will result in contract termination (termination fees applicable)",
 		"Staff are reminded that termination of the employment contract will incur a fee of 38.9% of your agreed annual salary for each year you have been employed by NanoTrasen, retrospectively adjusted for current inflation rates",
 		"NanoTrasen reserves the right to reimburse lost productivity caused by staff absence from the workplace for any reason (such as sickness), automatically from staff salary payment(s) until the lost sum is recovered in its entirety",
-		"Staff are once again reminded that comfort breaks are indeed on personal time, and as such will be docked from your pay entitlement"
+		"Staff are once again reminded that comfort breaks are indeed on personal time, and as such will be docked from your pay entitlement",
+		"NanoTrasen staff are reminded that payment processing fees are automatically deducted from your hourly pay entitlement, along with the mandatory convenience fees for the automatic deduction of the aforementioned processing fees"
 	)
 
 	var/payment_modifier = 5 //economic_power * this number = pay. tweak this number!

--- a/code/game/machinery/computer/account_manager.dm
+++ b/code/game/machinery/computer/account_manager.dm
@@ -529,7 +529,7 @@
 				M.manual_pay_rate = temp_account_items["pay"]
 				ntnet_global.create_email(M.current, temp_account_items["email"], "freemail.net")
 				var/datum/money_account/acc = create_account(M.current.real_name, 0)
-				var/datum/transaction/singular/T = new(TRUE, acc, machine_id, 0, "Account creation")
+				var/datum/transaction/singular/T = new(acc, machine_id, 0, "Account creation")
 				acc.transaction_log[1] = T
 				M.initial_account = acc
 

--- a/code/game/machinery/computer/account_manager.dm
+++ b/code/game/machinery/computer/account_manager.dm
@@ -184,9 +184,9 @@
 			for(var/datum/transaction/T in focused_account.transaction_log)
 				var/list/transaction = list()
 				transaction.Add(list(list(
-					"target_name" = T.get_target_name(),
+					"target_name" = focused_account.get_transaction_ledger(T),
 					"purpose" = T.purpose,
-					"amount" = T.amount,
+					"amount" = focused_account.get_transaction_amount(T),
 					"date" = T.date,
 					"time" = T.time
 				)))

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -39,6 +39,33 @@
 	var/datum/transaction/T = new(src, to_account, amount, purpose)
 	return T.perform()
 
+/datum/money_account/proc/is_credit(var/datum/transaction/T)
+	if(!istype(T))
+		return
+
+	if(istype(T, /datum/transaction/singular))
+		var/datum/transaction/singular/ST = T
+		return ST.is_deposit()
+	else
+		return (T.target == src && T.amount >= 0) || (T.source == src && T.amount <= 0)
+
+/datum/money_account/proc/get_transaction_amount(var/datum/transaction/T)
+	if(!istype(T))
+		return
+
+	return is_credit(T) ? abs(T.amount) : abs(T.amount)*-1
+
+/datum/money_account/proc/get_transaction_ledger(var/datum/transaction/T)
+	if(!istype(T))
+		return
+
+	if(istype(T, /datum/transaction/singular))
+		return T.target
+
+	if(is_credit(T))
+		return T.source == src ? T.target.account_name : T.source.account_name
+	else
+		return T.target == src ? T.source.account_name : T.target.account_name
 
 /proc/create_account(account_name = "Default account name", owner_name, starting_funds = 0, account_type = ACCOUNT_TYPE_PERSONAL, obj/machinery/computer/account_database/source_db)
 

--- a/code/modules/modular_computers/file_system/programs/security/finesmanager.dm
+++ b/code/modules/modular_computers/file_system/programs/security/finesmanager.dm
@@ -230,27 +230,9 @@ GLOBAL_LIST_INIT(all_fines, list("fineNum" = rand(1000,2500), "records" = list()
 				var/reason = fine_data["reason"]
 				var/fineNum = GLOB.all_fines["fineNum"]
 
-				if(target.money - amount < 0)
-					alert("Insufficient account funds (Amount short: [amount - target.money] Th)", "Unable to Fine")
+				if(!target.transfer(station_account, amount, "Fine Issued (Ref. #[fineNum])"))
+					alert("Cannot process money transfer. Ensure both accounts are not suspended and have the required funds", "Unable to Fine")
 					return TOPIC_NOACTION
-
-				var/datum/transaction/fine = new()
-				var/datum/transaction/deposit = new()
-
-				fine.target = "[station_account.owner_name] (via [auth_card.registered_name])"
-				fine.purpose = "Fine Issued (Ref. #[fineNum])"
-				fine.amount = -amount
-				fine.date = stationdate2text()
-				fine.time = stationtime2text()
-				fine.source = "Fines Manager"
-				deposit.target = "[target.owner_name] (via [auth_card.registered_name])"
-				deposit.purpose = "Fine Revenue (Ref. #[fineNum])"
-				deposit.amount = amount
-				deposit.date = stationdate2text()
-				deposit.time = stationtime2text()
-				deposit.source = "Fines Manager"
-				target.add_transaction(fine)
-				station_account.add_transaction(deposit)
 
 				var/main = "<center><font size = \"2\">[GLOB.using_map.station_name] Disciplinary Committee</font></center><br><hr><br>"
 				main += "<b>Issued to:</b> [target.owner_name]<br>"

--- a/code/modules/modular_computers/file_system/programs/security/finesmanager.dm
+++ b/code/modules/modular_computers/file_system/programs/security/finesmanager.dm
@@ -70,7 +70,7 @@ GLOBAL_LIST_INIT(all_fines, list("fineNum" = rand(1000,2500), "records" = list()
 	data["state"] = display_state
 	data["auth"] = get_auth(user)
 	data["has_target"] = !isnull(target)
-	data["have_id_slot"] = !!card_slot
+	data["has_cardslot"] = !!card_slot
 
 	if(card_slot)
 		data["id"] = !isnull(card_slot.stored_card)


### PR DESCRIPTION
This started as a simple bugfix, and once again, turned into much more...

- Fixes runtimes caused when looking at the transaction history for an account. Caused by the transaction datums requiring both entries to be real accounts, not pseudo accounts. These have been changed to use `/datum/transaction/singular` instead.
- Fixes another runtime when looking into the transaction history for a newly created account. Caused by.. some really wonky `new()` arguments passed in account creation. This must've changed at somepoint... I hope
- Fixes the finesmanager not being able to detect the card reader. Not sure if this somehow changed in the merge or at some point? Because this worked in testing and on the live server before? Caused by a data field using the wrong key
- Scientists now get an email from NanoTrasen. I thought it was a little odd that the Nerva would email scientists about their pay, so they now get one from NanoTrasen. On top of this, I can't imagine NanoTrasen subsiding their emails/payroll by taking sponsorships, so instead our corporate overlords will send us a lovely randomly picked message, reminding us of all of the glory of space capitalism.
- The radio sponsor product now matches the email product.
- Added `is_credit`, `get_transaction_amount` and `get_transaction_ledger` helper methods to `/datum/money_account`. This is a bit of a rabbit hole... But essentially `/datum/transaction` does not give a damn whether the amount is positive or negative. If it is negative, it simply removes from `target` and places it in `source`. This is fine by itself, however, `/datum/money_account/transfer()` uses a single transaction for both the source and target accounts, using a boolean in `/datum/money_account/add_transaction()` to denote if funds should be removed or added to the specified account. The problem is that the amount is **always** positive in the single transaction datum both accounts point to, and there's no record in the transaction itself of which way around this occurred. Coupling this with the previous negative amount business means for any singular transaction, you have _no_ clue if money was added to _your_ account or not. Just taking the transaction and seeing a positive value is not enough. These helper methods are all aware of the calling account and return results in relation to that account alone. 
- A lot of general clean up while I was in here. Murdering a lot of unnecessary indents.