### PR TITLE
spyvsspy minimum antagonists 2 instead of 4

### DIFF
--- a/code/game/gamemodes/mixed/spyvspy.dm
+++ b/code/game/gamemodes/mixed/spyvspy.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Traitors and renegades both spawn during this mode."
 	config_tag = "spyvspy"
 	required_players = 4
-	required_enemies = 4
+	required_enemies = 2
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_TRAITOR, MODE_RENEGADE)
 	require_all_templates = TRUE


### PR DESCRIPTION
read title

You need only one traitor and renegade to be selected at roundstart instead of two

🆑 

* tweak: Spy Vs. Spy gamemode only requires 2 antagonists (1 traitor and 1 renegade) instead of 4 (2 traitors and 2 renegades) to be allowed