### PR TITLE
Adds a bunch of fax machines

### DIFF
--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -226,8 +226,8 @@
 	dir = 6
 	},
 /obj/machinery/computer/cloning{
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Cloning Bay";
@@ -1188,8 +1188,8 @@
 	},
 /obj/machinery/power/smes/buildable/preset/nerva/shuttle,
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
+	dir = 5;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
@@ -2718,12 +2718,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/spline/plain/blue{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/spline/plain/blue{
-	icon_state = "spline_plain";
-	dir = 10
+	dir = 10;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3191,8 +3191,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/plain/blue{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
@@ -3229,12 +3229,12 @@
 /obj/structure/table/steel_reinforced,
 /obj/item/bodybag/cryobag,
 /obj/effect/floor_decal/spline/plain/paleblue{
-	icon_state = "spline_plain";
-	dir = 9
+	dir = 9;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/spline/plain/paleblue{
-	icon_state = "spline_plain";
-	dir = 4
+	dir = 4;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/white,
 /area/exploration_shuttle/main)
@@ -3373,8 +3373,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/plain/blue{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
@@ -3391,12 +3391,12 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/plain/paleblue{
-	icon_state = "spline_plain";
-	dir = 6
+	dir = 6;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/spline/plain/paleblue{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/white,
 /area/exploration_shuttle/main)
@@ -3458,8 +3458,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
+	dir = 5;
+	icon_state = "techfloor_edges"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -3670,8 +3670,8 @@
 	icon_state = "camera"
 	},
 /obj/effect/floor_decal/spline/plain/blue{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
@@ -4011,8 +4011,8 @@
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/spline/plain/blue{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/exploration_shuttle/main)
@@ -4455,8 +4455,8 @@
 "iq" = (
 /obj/structure/handrail,
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 9
+	dir = 9;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
@@ -4465,8 +4465,8 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -4476,8 +4476,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -4496,8 +4496,8 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 1
+	dir = 1;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -4507,8 +4507,8 @@
 /obj/item/material/knife/kitchen/cleaver,
 /obj/item/beartrap,
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 5
+	dir = 5;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -4798,8 +4798,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
@@ -4835,8 +4835,8 @@
 /obj/item/roller_bed,
 /obj/item/roller_bed,
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 4
+	dir = 4;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -5314,8 +5314,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
@@ -5449,8 +5449,8 @@
 	},
 /obj/machinery/computer/modular/preset/nervasec{
 	autorun_program = /datum/computer_file/program/records;
-	icon_state = "computer";
-	dir = 4
+	dir = 4;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/security/forensics)
@@ -5940,8 +5940,8 @@
 	id = "Trajanmain"
 	},
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
@@ -5963,8 +5963,8 @@
 	icon_state = "handrail"
 	},
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 4
+	dir = 4;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
@@ -6196,8 +6196,8 @@
 	dir = 1
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -6306,8 +6306,8 @@
 	id = "Trajanmain"
 	},
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 8
+	dir = 8;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
@@ -6318,8 +6318,8 @@
 	},
 /obj/machinery/conveyor,
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 4
+	dir = 4;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
@@ -6369,8 +6369,8 @@
 	c_tag = "General Expedition Prep Port"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
+	dir = 5;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/logistics/genprep)
@@ -6893,8 +6893,8 @@
 	id = "Trajanmain"
 	},
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 10
+	dir = 10;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
@@ -6928,8 +6928,8 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 6
+	dir = 6;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -7345,8 +7345,8 @@
 	icon_state = "camera"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/centralfourth)
@@ -8432,8 +8432,8 @@
 	id_tag = null
 	},
 /obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_corners"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/drone_fabrication)
@@ -8631,8 +8631,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/techfloor/corner{
-	icon_state = "techfloor_corners";
-	dir = 8
+	dir = 8;
+	icon_state = "techfloor_corners"
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4;
@@ -8885,8 +8885,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/techfloor{
-	icon_state = "techfloor_edges";
-	dir = 5
+	dir = 5;
+	icon_state = "techfloor_edges"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/drone_fabrication)
@@ -9041,8 +9041,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/gold/border{
-	icon_state = "bordercolor";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
@@ -9740,27 +9740,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/security/hangercheckpoint)
-"rd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/guestpass{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 4
-	},
-/obj/item/folder/red,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8;
-	id_tag = null
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/hangercheckpoint)
@@ -11072,8 +11051,8 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/spline/plain/blue{
-	icon_state = "spline_plain";
-	dir = 9
+	dir = 9;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -11736,8 +11715,8 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -12530,8 +12509,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -14435,22 +14414,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/white,
-/area/command/seniorntoffice)
-"za" = (
-/obj/effect/floor_decal/corner/purple/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	operating = 1;
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine,
 /turf/simulated/floor/tiled/white,
 /area/command/seniorntoffice)
 "zb" = (
@@ -18845,8 +18808,8 @@
 "GV" = (
 /obj/machinery/mining/drill,
 /obj/effect/floor_decal/spline/plain/yellow{
-	icon_state = "spline_plain";
-	dir = 4
+	dir = 4;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -19931,19 +19894,6 @@
 /obj/random/bomb_supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
-"IY" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 9;
-	icon_state = "techfloor_edges"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/command/safe_room)
 "IZ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -20051,8 +20001,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 8
+	dir = 8;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
@@ -20859,8 +20809,8 @@
 /area/medical/extstorage)
 "LS" = (
 /obj/effect/floor_decal/spline/plain/black{
-	icon_state = "spline_plain";
-	dir = 4
+	dir = 4;
+	icon_state = "spline_plain"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/exploration_shuttle/cargo)
@@ -20952,8 +20902,8 @@
 "Mk" = (
 /obj/machinery/mining/brace,
 /obj/effect/floor_decal/spline/plain/yellow{
-	icon_state = "spline_plain";
-	dir = 4
+	dir = 4;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -21097,6 +21047,24 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/safe_room)
+"Nl" = (
+/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	operating = 1;
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine{
+	department = "NanoTrasen Nerva Senior Scientist"
+	},
+/turf/simulated/floor/tiled/white,
+/area/command/seniorntoffice)
 "No" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22566,6 +22534,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
+"Ta" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 9;
+	icon_state = "techfloor_edges"
+	},
+/obj/structure/table/steel,
+/obj/machinery/photocopier/faxmachine{
+	department = "Saferoom"
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/techmaint,
+/area/command/safe_room)
 "Tb" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/freezer,
@@ -23398,6 +23385,30 @@
 /obj/effect/paint_stripe/mauve,
 /turf/simulated/wall/r_wall/prepainted,
 /area/rnd/chemlab)
+"WH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/guestpass{
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 4
+	},
+/obj/item/folder/red,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8;
+	id_tag = null
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Hangar Checkpoint"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/security/hangercheckpoint)
 "WI" = (
 /obj/structure/cable{
 	d1 = 0;
@@ -23676,8 +23687,8 @@
 "Yb" = (
 /obj/machinery/mining/brace,
 /obj/effect/floor_decal/spline/plain/yellow{
-	icon_state = "spline_plain";
-	dir = 6
+	dir = 6;
+	icon_state = "spline_plain"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -24037,8 +24048,8 @@
 /area/command/bottom_hallway)
 "Zg" = (
 /obj/machinery/atmospherics/valve/open{
-	icon_state = "map_valve1";
-	dir = 8
+	dir = 8;
+	icon_state = "map_valve1"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fp)
@@ -41145,7 +41156,7 @@ nk
 nX
 oZ
 pX
-rd
+WH
 nX
 sG
 nT
@@ -47214,7 +47225,7 @@ vG
 wt
 Rb
 ym
-za
+Nl
 Sb
 AJ
 Bp
@@ -54279,7 +54290,7 @@ rO
 rO
 rO
 NJ
-IY
+Ta
 Wv
 Kh
 Zy

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -7418,8 +7418,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/commandport)
@@ -7814,7 +7814,7 @@
 	},
 /obj/machinery/tele_beacon,
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Deck 3 Port Central");
+	codes = list("patrol" = 1, "next_patrol" = "Deck 3 Port Central");
 	location = "Medbay"
 	},
 /turf/simulated/floor/tiled/white,
@@ -8078,8 +8078,8 @@
 	},
 /obj/machinery/computer/modular/preset/nervasec{
 	autorun_program = /datum/computer_file/program/camera_monitor;
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/office)
@@ -11248,7 +11248,7 @@
 	output_attempt = 1;
 	output_level = 100000;
 	outputting = 2;
-	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/weak=4)
+	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/weak = 4)
 	},
 /obj/effect/engine_setup/smes,
 /obj/machinery/light{
@@ -11303,8 +11303,8 @@
 	pixel_y = -28
 	},
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 4
+	dir = 4;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/tool)
@@ -11458,7 +11458,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Medbay");
+	codes = list("patrol" = 1, "next_patrol" = "Medbay");
 	location = "Deck 3 Aft Port"
 	},
 /obj/structure/disposalpipe/segment{
@@ -11705,8 +11705,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -12080,7 +12080,7 @@
 	output_attempt = 1;
 	output_level = 100000;
 	outputting = 2;
-	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/weak=4)
+	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/weak = 4)
 	},
 /obj/structure/sign/warning/secure_area{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -12271,8 +12271,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -12563,7 +12563,7 @@
 	output_attempt = 1;
 	output_level = 100000;
 	outputting = 2;
-	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/weak=4)
+	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/weak = 4)
 	},
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -12610,8 +12610,8 @@
 	dir = 4
 	},
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 4
+	dir = 4;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/lobby)
@@ -12772,12 +12772,12 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/three_quarters,
 /obj/machinery/vending/coffee{
-	icon_state = "coffee";
-	dir = 1
+	dir = 1;
+	icon_state = "coffee"
 	},
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -13191,7 +13191,7 @@
 	output_attempt = 1;
 	output_level = 100000;
 	outputting = 2;
-	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/weak=4)
+	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/weak = 4)
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/tiled/dark,
@@ -14123,12 +14123,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/effect/floor_decal/corner/gold/border{
-	icon_state = "bordercolor";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -14445,7 +14445,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Security");
+	codes = list("patrol" = 1, "next_patrol" = "Security");
 	location = "Hydroponics"
 	},
 /turf/simulated/floor/tiled,
@@ -14541,7 +14541,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Bridge Starboard");
+	codes = list("patrol" = 1, "next_patrol" = "Bridge Starboard");
 	location = "Bar"
 	},
 /turf/simulated/floor/wood/walnut,
@@ -16000,8 +16000,8 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/corner/lightgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/vending/whitedragon,
 /obj/effect/floor_decal/corner/b_green,
@@ -16058,8 +16058,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/gold/border{
-	icon_state = "bordercolor";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -16469,8 +16469,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 8
+	dir = 8;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -16580,8 +16580,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -16680,8 +16680,8 @@
 	},
 /obj/machinery/computer/modular/preset/cardslot/nerva_cos{
 	autorun_program = /datum/computer_file/program/camera_monitor;
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -16939,7 +16939,7 @@
 	sort_type = "Disposals"
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Deck 2 Aft Port");
+	codes = list("patrol" = 1, "next_patrol" = "Deck 2 Aft Port");
 	location = "Deck 3 Aft Starboard"
 	},
 /obj/structure/cable{
@@ -17198,8 +17198,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -17516,8 +17516,8 @@
 	dir = 9
 	},
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 4
+	dir = 4;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
@@ -17628,8 +17628,8 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -17845,8 +17845,8 @@
 	dir = 4
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/central/third_deck)
@@ -18094,8 +18094,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -18212,8 +18212,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -18346,7 +18346,7 @@
 	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Personnel");
+	codes = list("patrol" = 1, "next_patrol" = "Personnel");
 	location = "Bridge Starboard"
 	},
 /turf/simulated/floor/tiled,
@@ -18490,8 +18490,8 @@
 	},
 /obj/machinery/computer/modular/preset/nerva_qm{
 	autorun_program = /datum/computer_file/program/reports;
-	icon_state = "computer";
-	dir = 1
+	dir = 1;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
@@ -18518,8 +18518,8 @@
 	level = 2
 	},
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 4
+	dir = 4;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -19353,13 +19353,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/wood/walnut,
 /area/rnd/office)
-"aHL" = (
-/obj/structure/table/woodentable/walnut,
-/obj/machinery/photocopier/faxmachine{
-	department = "Nanotrasen Scientists"
-	},
-/turf/simulated/floor/wood/walnut,
-/area/rnd/office)
 "aHM" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -20099,8 +20092,8 @@
 /area/command/eva)
 "aJf" = (
 /obj/machinery/computer/modular/preset/cardslot/nerva_cos{
-	icon_state = "computer";
-	dir = 1
+	dir = 1;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/carpet,
 /area/security/cosoffice)
@@ -20110,16 +20103,6 @@
 /obj/item/pen,
 /obj/item/book/manual/security_space_law/nervaspacelaw,
 /obj/item/stamp/hos,
-/turf/simulated/floor/carpet,
-/area/security/cosoffice)
-"aJh" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/paper_bin,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet,
 /area/security/cosoffice)
 "aJi" = (
@@ -20186,7 +20169,7 @@
 	icon_state = "bordercolor"
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="EVA");
+	codes = list("patrol" = 1, "next_patrol" = "EVA");
 	location = "Personnel"
 	},
 /turf/simulated/floor/tiled,
@@ -20796,8 +20779,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandstarboard)
@@ -20903,8 +20886,8 @@
 	},
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 4
+	dir = 4;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/genstorage)
@@ -24732,8 +24715,8 @@
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/yellow/three_quarters,
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 4
+	dir = 4;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
@@ -25053,7 +25036,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Mailing Office");
+	codes = list("patrol" = 1, "next_patrol" = "Mailing Office");
 	location = "Deck 3 Cargo"
 	},
 /turf/simulated/floor/tiled,
@@ -25178,19 +25161,6 @@
 /obj/item/storage/belt/medical,
 /obj/item/storage/fancy/vials,
 /obj/item/storage/fancy/vials,
-/turf/simulated/floor/tiled/white,
-/area/medical/cmo)
-"aRD" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4;
-	icon_state = "corner_white_diagonal"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/cmo)
 "aRE" = (
@@ -26087,19 +26057,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/afs)
-"aTc" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Nanotrasen Scientists"
-	},
-/obj/structure/table/standard,
-/obj/item/storage/secure/alert_safe{
-	pixel_y = 38
-	},
-/turf/simulated/floor/tiled/dark,
-/area/logistics/qm)
 "aTd" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -26779,8 +26736,8 @@
 /area/logistics/qm)
 "aUB" = (
 /obj/machinery/computer/modular/preset/nerva_qm{
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/qm)
@@ -27628,8 +27585,8 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/computer/modular/preset/nervasec{
-	icon_state = "computer";
-	dir = 8
+	dir = 8;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/checkpoint)
@@ -27828,8 +27785,8 @@
 /area/maintenance/third_deck/fp)
 "cSX" = (
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -27840,8 +27797,8 @@
 "cUF" = (
 /obj/effect/floor_decal/corner/lightgrey,
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -27996,12 +27953,12 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/vending/cola{
-	icon_state = "Cola_Machine";
-	dir = 1
+	dir = 1;
+	icon_state = "Cola_Machine"
 	},
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -28198,7 +28155,7 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Bridge Port");
+	codes = list("patrol" = 1, "next_patrol" = "Bridge Port");
 	location = "Security"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -28244,15 +28201,15 @@
 /area/security/portgun)
 "etW" = (
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "euF" = (
 /obj/structure/noticeboard{
-	pixel_y = 32;
-	name = "menu board"
+	name = "menu board";
+	pixel_y = 32
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
@@ -28292,7 +28249,7 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Deck 3 Aft Starboard");
+	codes = list("patrol" = 1, "next_patrol" = "Deck 3 Aft Starboard");
 	location = "Mailing Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28301,19 +28258,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
-"eGp" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 22
-	},
-/obj/effect/decal/cleanable/cobweb{
-	dir = 1;
-	icon_state = "cobweb1"
-	},
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/plating,
-/area/civilian/abandonedoffice)
 "eIr" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Dorms"
@@ -28493,8 +28437,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -28675,19 +28619,19 @@
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/corner/lightgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 8
+	dir = 8;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -28796,7 +28740,7 @@
 	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Bar");
+	codes = list("patrol" = 1, "next_patrol" = "Bar");
 	location = "Bridge Port"
 	},
 /obj/structure/disposalpipe/segment{
@@ -28831,7 +28775,7 @@
 	dir = 5
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Hydroponics");
+	codes = list("patrol" = 1, "next_patrol" = "Hydroponics");
 	location = "Deck 3 Port Central"
 	},
 /turf/simulated/floor/tiled,
@@ -28895,6 +28839,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/mailing)
+"hMT" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/paper_bin,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief of Security"
+	},
+/turf/simulated/floor/carpet,
+/area/security/cosoffice)
 "hNR" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
@@ -29556,6 +29513,13 @@
 /obj/item/folder/white,
 /turf/simulated/floor/tiled/white,
 /area/medical/cmo)
+"lri" = (
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/photocopier/faxmachine{
+	department = "NanoTrasen Nerva Scientists"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/rnd/office)
 "ltj" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -29645,8 +29609,8 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -29697,20 +29661,20 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/corner/lightgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/machinery/vending/snack{
-	icon_state = "snack";
-	dir = 1
+	dir = 1;
+	icon_state = "snack"
 	},
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 8
+	dir = 8;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -30133,8 +30097,8 @@
 /area/space)
 "oxV" = (
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 4
+	dir = 4;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine)
@@ -30191,8 +30155,8 @@
 /area/hallway/aft/third_deck)
 "oHH" = (
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/third_deck)
@@ -31024,6 +30988,19 @@
 /obj/effect/paint_stripe/beige,
 /turf/simulated/wall/prepainted,
 /area/maintenance/third_deck/afs)
+"tZj" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Quartermaster"
+	},
+/obj/structure/table/standard,
+/obj/item/storage/secure/alert_safe{
+	pixel_y = 38
+	},
+/turf/simulated/floor/tiled/dark,
+/area/logistics/qm)
 "uaA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -31163,7 +31140,7 @@
 	dir = 10
 	},
 /obj/machinery/navbeacon{
-	codes = list("patrol"=1,"next_patrol"="Deck 3 Cargo");
+	codes = list("patrol" = 1, "next_patrol" = "Deck 3 Cargo");
 	location = "EVA"
 	},
 /turf/simulated/floor/tiled,
@@ -31296,6 +31273,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/bridge)
+"vdj" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4;
+	icon_state = "corner_white_diagonal"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Medical Officer"
+	},
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/white,
+/area/medical/cmo)
 "vey" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics"
@@ -31429,8 +31423,8 @@
 	},
 /obj/machinery/vending/sol,
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -31448,8 +31442,8 @@
 	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/b_green{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -31705,6 +31699,22 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/security/boardarmoury)
+"xdK" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 22
+	},
+/obj/effect/decal/cleanable/cobweb{
+	dir = 1;
+	icon_state = "cobweb1"
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/photocopier/faxmachine{
+	department = "Abandoned Office"
+	},
+/turf/simulated/floor/plating,
+/area/civilian/abandonedoffice)
 "xfr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -51570,7 +51580,7 @@ oDe
 aPQ
 jIp
 aSd
-aTc
+tZj
 aTW
 aUB
 aUY
@@ -55397,7 +55407,7 @@ kjM
 wpN
 aFp
 aGB
-aHL
+lri
 aIY
 nNc
 aLk
@@ -55610,7 +55620,7 @@ aQi
 bqm
 aSr
 aTp
-eGp
+xdK
 aNz
 aUN
 jEQ
@@ -58226,7 +58236,7 @@ aEg
 aFy
 aGK
 aHW
-aJh
+hMT
 aKj
 aLt
 aMz
@@ -59243,7 +59253,7 @@ aGL
 aNN
 aPb
 aQu
-aRD
+vdj
 aSG
 aTz
 aUo

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -2235,8 +2235,8 @@
 /area/logistics/auxtool)
 "eH" = (
 /obj/structure/noticeboard{
-	pixel_y = 32;
-	name = "menu board"
+	name = "menu board";
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
@@ -2262,8 +2262,8 @@
 	},
 /obj/machinery/vending/coffee,
 /obj/machinery/light_switch{
-	pixel_y = 33;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 33
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
@@ -3475,8 +3475,8 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 8
+	dir = 8;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -3961,59 +3961,8 @@
 /obj/random/medical/lite,
 /turf/simulated/floor/plating,
 /area/engineering/fdengine)
-"hw" = (
-/obj/structure/table/rack{
-	dir = 8
-	},
-/obj/item/cell/super,
-/obj/item/stack/medical/bruise_pack{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/device/megaphone,
-/obj/item/reagent_containers/pill/kelotane{
-	pixel_x = -3;
-	pixel_y = -8
-	},
-/obj/effect/floor_decal/corner/fadeblue{
-	dir = 9;
-	icon_state = "corner_white"
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Chief Engineer's Office";
-	dir = 4;
-	icon_state = "camera"
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/ce)
 "hx" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
-/area/command/ce)
-"hy" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/paper/monitorkey,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/ce)
-"hz" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/fadeblue{
-	dir = 6;
-	icon_state = "corner_white"
-	},
-/obj/item/pen,
-/obj/item/stamp/ce,
 /turf/simulated/floor/tiled/dark,
 /area/command/ce)
 "hA" = (
@@ -5139,8 +5088,8 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 4
+	dir = 4;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -5961,8 +5910,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -7142,8 +7091,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -7570,8 +7519,8 @@
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/corner/lightgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -7931,8 +7880,8 @@
 "pE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8005,8 +7954,8 @@
 "pN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8413,8 +8362,8 @@
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 1
+	dir = 1;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -8455,8 +8404,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8506,8 +8455,8 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8725,8 +8674,8 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/orange{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8772,8 +8721,8 @@
 	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8831,8 +8780,8 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 8
+	dir = 8;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -9073,8 +9022,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -9152,8 +9101,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9163,8 +9112,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9750,8 +9699,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9762,8 +9711,8 @@
 /obj/item/stack/material/rods/ten,
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9776,8 +9725,8 @@
 /obj/item/clothing/gloves/insulated/cheap,
 /obj/item/crowbar,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9790,8 +9739,8 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/floor_decal/corner/darkgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
@@ -10099,8 +10048,8 @@
 	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -10123,8 +10072,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -10654,8 +10603,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11026,8 +10975,8 @@
 "uS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11036,8 +10985,8 @@
 /obj/machinery/light,
 /obj/random/toolbox,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11053,8 +11002,8 @@
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11067,8 +11016,8 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11082,8 +11031,8 @@
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11092,8 +11041,8 @@
 /obj/item/device/paint_sprayer,
 /obj/item/tape_roll,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -13482,8 +13431,8 @@
 /area/maintenance/second_deck/afs)
 "zY" = (
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 8;
@@ -13647,6 +13596,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/substation/second_deck)
+"AQ" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/closet,
+/obj/item/device/camera/tvcamera,
+/obj/item/device/camera_film,
+/obj/item/device/camera_film,
+/obj/item/storage/briefcase,
+/obj/item/folder,
+/obj/item/device/taperecorder,
+/obj/item/device/tape,
+/obj/item/clothing/suit/storage/urist/coat/journocoat,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/item/clothing/accessory/badge/press,
+/obj/item/device/camera,
+/turf/simulated/floor/wood/walnut,
+/area/civilian/journalist)
 "AS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -13742,6 +13717,18 @@
 /obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/fs)
+"BD" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/command/ce)
 "BE" = (
 /obj/item/caution/cone,
 /turf/simulated/floor/plating,
@@ -13835,8 +13822,8 @@
 /area/civilian/counselor)
 "Cc" = (
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -13939,8 +13926,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -14122,6 +14109,49 @@
 /obj/random/toolbox,
 /turf/simulated/floor/wood/walnut,
 /area/logistics/auxtool)
+"DH" = (
+/obj/structure/table/rack{
+	dir = 8
+	},
+/obj/item/cell/super,
+/obj/item/stack/medical/bruise_pack{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/device/megaphone,
+/obj/item/reagent_containers/pill/kelotane{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Chief Engineer's Office";
+	dir = 4;
+	icon_state = "camera"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -24
+	},
+/obj/item/folder/yellow,
+/obj/item/paper/monitorkey,
+/turf/simulated/floor/tiled/dark,
+/area/command/ce)
+"DM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/obj/structure/table/woodentable/walnut,
+/obj/machinery/photocopier/faxmachine{
+	department = "Journalist"
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/civilian/journalist)
 "DN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -14323,8 +14353,8 @@
 /area/maintenance/second_deck/fp)
 "Ey" = (
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -14337,8 +14367,8 @@
 /area/maintenance/second_deck/fs)
 "EH" = (
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -14373,8 +14403,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -14622,8 +14652,8 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -15109,8 +15139,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -15165,8 +15195,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -15199,8 +15229,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -15282,8 +15312,8 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -15429,8 +15459,8 @@
 /obj/machinery/cell_charger,
 /obj/item/cell/super,
 /obj/effect/floor_decal/corner/darkgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -15557,6 +15587,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"KS" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/material/ashtray/wood,
+/obj/item/clothing/mask/smokable/cigarette/cigar,
+/obj/machinery/newscaster{
+	pixel_x = 28
+	},
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/item/material/clipboard,
+/turf/simulated/floor/carpet/blue2,
+/area/civilian/journalist)
 "KT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15591,15 +15633,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/logistics/auxtool)
-"La" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/material/ashtray/wood,
-/obj/item/clothing/mask/smokable/cigarette/cigar,
-/obj/machinery/newscaster{
-	pixel_x = 28
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/civilian/journalist)
 "Lc" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/polarized/full{
@@ -15870,18 +15903,6 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/substation/atmos)
-"Mp" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	icon_state = "map_vent_out"
-	},
-/obj/structure/table/woodentable/walnut,
-/obj/item/device/camera,
-/obj/item/pen,
-/obj/item/paper_bin,
-/obj/item/material/clipboard,
-/turf/simulated/floor/carpet/blue2,
-/area/civilian/journalist)
 "Mq" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1;
@@ -16226,8 +16247,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -16296,8 +16317,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -16385,8 +16406,8 @@
 	pixel_x = -24
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -16409,16 +16430,16 @@
 /area/security/prison)
 "OI" = (
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 1;
 	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/gold/border{
-	icon_state = "bordercolor";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -16534,8 +16555,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -16828,31 +16849,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"Qw" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/closet,
-/obj/item/device/camera/tvcamera,
-/obj/item/device/camera_film,
-/obj/item/device/camera_film,
-/obj/item/storage/briefcase,
-/obj/item/folder,
-/obj/item/device/taperecorder,
-/obj/item/device/tape,
-/obj/item/clothing/suit/storage/urist/coat/journocoat,
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/item/clothing/accessory/badge/press,
-/turf/simulated/floor/wood/walnut,
-/area/civilian/journalist)
 "Qx" = (
 /obj/machinery/ship_map{
 	dir = 1
@@ -17406,8 +17402,8 @@
 "Ub" = (
 /obj/machinery/vending/tool,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -17710,8 +17706,8 @@
 	location = "Deck 2 Aft Starboard"
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -18129,8 +18125,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -18372,6 +18368,17 @@
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/second_deck/afp)
+"Yv" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/fadeblue{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/item/pen,
+/obj/item/stamp/ce,
+/obj/item/paper_bin,
+/turf/simulated/floor/tiled/dark,
+/area/command/ce)
 "Yy" = (
 /obj/effect/paint_stripe/brown,
 /turf/simulated/wall/r_wall/prepainted,
@@ -34900,7 +34907,7 @@ em
 eX
 fv
 gz
-hw
+DH
 ic
 fz
 jP
@@ -35304,7 +35311,7 @@ em
 eX
 fx
 gB
-hy
+BD
 ie
 jd
 jR
@@ -35506,7 +35513,7 @@ em
 eX
 fy
 gC
-hz
+Yv
 if
 fz
 jS
@@ -42796,7 +42803,7 @@ Qd
 Jv
 EK
 Fz
-Mp
+DM
 Hu
 tV
 tV
@@ -42995,10 +43002,10 @@ ru
 sp
 tn
 Qd
-Qw
+AQ
 GG
 DQ
-La
+KS
 Mi
 Ch
 ah

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -339,8 +339,8 @@
 	dir = 6
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/centralfirst)
@@ -1245,8 +1245,8 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 8
+	dir = 8;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -2092,12 +2092,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	icon_state = "map_vent_out"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/security/dockingcheckpoint)
-"et" = (
-/obj/effect/floor_decal/corner/red/three_quarters{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/dockingcheckpoint)
@@ -4130,8 +4124,8 @@
 	pixel_x = 30
 	},
 /obj/effect/floor_decal/corner/lightgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
@@ -5334,8 +5328,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
@@ -6616,8 +6610,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -8472,8 +8466,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated,
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 4
+	dir = 4;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/centralfirst)
@@ -8905,6 +8899,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
+"PQ" = (
+/obj/effect/floor_decal/corner/red/three_quarters{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Docking Customs"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/security/dockingcheckpoint)
 "Rh" = (
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Bluespace Drive";
@@ -28072,7 +28076,7 @@ cH
 db
 dB
 dZ
-et
+PQ
 cI
 ff
 fQ


### PR DESCRIPTION
Via fastdmm2

Now traitors shouldn't have to hack into the bodyguard's room to fake a fax message

Fixes the fax machine tag in the quartermaster's office tagged as "Nanotrasen Scientists" and the tagless fax machine in the senior scientist office, adds a paper bin and pen to the Chief Engineer office (so the stamp has something to be used on) and new fax machines to the 1st deck Docking checkpoint, 2nd deck Chief Engineer office, Journalist office, 3rd deck CMO office, CoS office, and Abandoned office, and the 4th deck Hangar checkpoint

🆑 

* adds: fax machines to 1st deck Docking checkpoint, 2nd deck Chief Engineer office, Journalist office, 3rd deck CMO office, CoS office, and Abandoned office, and 4th deck Hangar checkpoint
* bugfix: the fax machines in the QM and senior scientist offices have tags now