### PR TITLE
fixes the easiest xenophage bugs

### DIFF
--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -235,6 +235,8 @@
 		if(!silent)
 			to_chat(user, SPAN_WARNING("\The [src] is occupied to capacity."))
 		return FALSE
+	if(!user.IsAdvancedToolUser()) //no mechs allowed for xenophages
+		return FALSE
 	return TRUE
 
 /mob/living/exosuit/proc/enter(mob/user, silent = FALSE, check_incap = TRUE, instant = FALSE)

--- a/code/modules/mob/living/carbon/alien/larva/progression.dm
+++ b/code/modules/mob/living/carbon/alien/larva/progression.dm
@@ -63,9 +63,8 @@
 
 	to_chat(src, "<span class='notice'><b>You are growing into a beautiful alien! It is time to choose a caste.</b></span>")
 	to_chat(src, "<span class='notice'>There are three to choose from:</span>")
-	to_chat(src, "<B>Hunters</B> <span class='notice'>are strong and agile, able to hunt away from the hive and rapidly move through ventilation shafts. Hunters generate plasma slowly and have low reserves.</span>")
-	to_chat(src, "<B>Sentinels</B> <span class='notice'>are tasked with protecting the hive and are deadly up close and at a range. They are not as physically imposing nor fast as the hunters.</span>")
-	to_chat(src, "<B>Drones</B> <span class='notice'>are the working class, offering the largest plasma storage and generation. They are the only caste which may evolve again, turning into the dreaded alien queen.</span>")
+	to_chat(src, "<B>Hunters</B> <span class='notice'>are strong and agile, able to hunt away from the hive, pry airlocks (via the right mouse menu), and rapidly move through ventilation shafts. Hunters generate plasma slowly and have low reserves.</span>")
+	to_chat(src, "<B>Sentinels</B> <span class='notice'>are tasked with protecting the hive and are deadly up close and at a range. They are not as physically imposing nor fast as the hunters, and cannot pry airlocks.</span>")
+	to_chat(src, "<B>Drones</B> <span class='notice'>are the working class, offering the largest plasma storage and generation. They are the only caste which may evolve again, turning into the dreaded alien queen. However, their hunting ability is poor and they cannot pry airlocks.</span>")
 	var/alien_caste = alert(src, "Please choose which alien caste you shall belong to.",,"Hunter","Sentinel","Drone")
 	return alien_caste ? "Xenophage [alien_caste]" : null
-

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -511,13 +511,7 @@
 	to_chat(user, SPAN_NOTICE("You cause \the [src] to flick on and off."))
 	flicker(1)
 
-// attack with hand - remove tube/bulb
-// if hands aren't protected and the light is on, burn the player
-/obj/machinery/light/physical_attack_hand(mob/living/user)
-	if(!lightbulb)
-		to_chat(user, SPAN_WARNING("There is no [get_fitting_name()] in this light."))
-		return TRUE
-
+/obj/machinery/light/attack_hand(mob/user)
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
 		if(H.species.can_shred(H))
@@ -527,6 +521,14 @@
 				SPAN_WARNING("You hear glass shattering!"))
 			broken()
 			return TRUE
+	..()
+
+// attack with hand - remove tube/bulb
+// if hands aren't protected and the light is on, burn the player
+/obj/machinery/light/physical_attack_hand(mob/living/user)
+	if(!lightbulb)
+		to_chat(user, SPAN_WARNING("There is no [get_fitting_name()] in this light."))
+		return TRUE
 
 	// make it burn hands if not wearing fire-insulated gloves
 	if(on)

--- a/code/modules/species/xenomorphs/alien_species.dm
+++ b/code/modules/species/xenomorphs/alien_species.dm
@@ -396,3 +396,6 @@
 		"storage1" =     list("loc" = ui_storage1,  "name" = "Left Pocket",  "slot" = slot_l_store,   "state" = "pocket"),
 		"storage2" =     list("loc" = ui_storage2,  "name" = "Right Pocket", "slot" = slot_r_store,   "state" = "pocket"),
 		)
+
+/datum/species/xenos/can_shred(mob/living/carbon/human/H, ignore_intent, ignore_antag)
+	return TRUE

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -192,6 +192,26 @@
 
 	return ..()
 
+/obj/structure/table/attack_hand(mob/user as mob)
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	if(MUTATION_HULK in user.mutations)
+		user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!"))
+		user.visible_message(SPAN_DANGER("[user] smashes through [src]!"))
+		user.do_attack_animation(src)
+		break_to_parts()
+	else if(MUTATION_FERAL in user.mutations)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN*2) //Additional cooldown
+		attack_generic(user, 10, "smashes")
+
+	else if (user.a_intent && user.a_intent == I_HURT)
+
+		if (istype(user,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = user
+			if(H.species.can_shred(H))
+				attack_generic(H,25)
+				return
+	return
+
 /obj/structure/table/MouseDrop_T(obj/item/stack/material/what)
 	if(can_reinforce && isliving(usr) && (!usr.stat) && istype(what) && usr.get_active_hand() == what && Adjacent(usr))
 		reinforce_table(what, usr)


### PR DESCRIPTION
- Xenophage/non-advanced tool users cannot climb into mechs and run off with them anymore
- Xenophage (and hulk and zombies) can smash lights and tables with their hands again
- Larva-growth caste briefing tells you whether or not you can pry airlocks