### PR TITLE
readds toilet paper

### DIFF
--- a/code/game/machinery/vending/lavatory.dm
+++ b/code/game/machinery/vending/lavatory.dm
@@ -16,7 +16,9 @@
 		/obj/item/haircomb/random = 40,
 		/obj/item/haircomb/brush = 80,
 		/obj/item/towel/random = 50,
-		/obj/item/reagent_containers/spray/cleaner/deodorant = 30
+		/obj/item/reagent_containers/spray/cleaner/deodorant = 30,
+		/obj/item/taperoll/bog = 10,
+		/obj/item/weapon/storage/box/bogrolls = 80
 	)
 	products = list(
 		/obj/item/soap = 12,
@@ -24,7 +26,9 @@
 		/obj/item/haircomb/random = 8,
 		/obj/item/haircomb/brush = 4,
 		/obj/item/towel/random = 6,
-		/obj/item/reagent_containers/spray/cleaner/deodorant = 5
+		/obj/item/reagent_containers/spray/cleaner/deodorant = 5,
+		/obj/item/taperoll/bog = 6,
+		/obj/item/weapon/storage/box/bogrolls = 2
 	)
 	contraband = list(
 		/obj/item/inflatable_duck = 1

--- a/code/game/machinery/vending/lavatory.dm
+++ b/code/game/machinery/vending/lavatory.dm
@@ -18,7 +18,6 @@
 		/obj/item/towel/random = 50,
 		/obj/item/reagent_containers/spray/cleaner/deodorant = 30,
 		/obj/item/taperoll/bog = 10,
-		/obj/item/weapon/storage/box/bogrolls = 80
 	)
 	products = list(
 		/obj/item/soap = 12,
@@ -28,7 +27,6 @@
 		/obj/item/towel/random = 6,
 		/obj/item/reagent_containers/spray/cleaner/deodorant = 5,
 		/obj/item/taperoll/bog = 6,
-		/obj/item/weapon/storage/box/bogrolls = 2
 	)
 	contraband = list(
 		/obj/item/inflatable_duck = 1

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -506,7 +506,7 @@
 /obj/item/taperoll/bog
 	name = "toilet paper roll"
 	icon = 'icons/obj/watercloset.dmi'
-	desc = "A unbranded roll of standard issue two ply toilet paper. Refined from carefully rendered down sea shells due to SolGov's 'Abuse Of The Trees Act'."
+	desc = "A unbranded roll of standard issue two-ply toilet paper. Refined from carefully rendered-down seashells due to the Terran Confederacy's 'Abuse Of The Trees Act'."
 	tape_type = /obj/item/tape/bog
 	icon_state = "bogroll"
 	item_state = "mummy_poor"
@@ -553,7 +553,7 @@
 
 /obj/item/paper/crumpled/bog
 	name = "sheet of toilet paper"
-	desc = "A single sheet of toilet paper. Two ply."
+	desc = "A single sheet of toilet paper. Two-ply."
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "bogroll_sheet"
 

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -22677,6 +22677,7 @@
 	dir = 4;
 	icon_state = "map_scrubber_on"
 	},
+/obj/item/taperoll/bog,
 /turf/simulated/floor/tiled/white,
 /area/medical/extstorage)
 "TF" = (

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -3496,6 +3496,7 @@
 /obj/structure/hygiene/toilet{
 	pixel_y = 12
 	},
+/obj/item/storage/box/bogrolls,
 /turf/simulated/floor/tiled/white,
 /area/command/captain)
 "gs" = (
@@ -9345,6 +9346,7 @@
 /obj/structure/hygiene/toilet{
 	dir = 4
 	},
+/obj/item/taperoll/bog,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/bath)
 "rW" = (
@@ -11816,7 +11818,6 @@
 	pixel_x = 22;
 	pixel_y = 0
 	},
-/obj/item/clothing/mask/plunger,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -11827,6 +11828,8 @@
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
+/obj/item/storage/box/bogrolls,
+/obj/item/clothing/mask/plunger,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/bath)
 "wC" = (


### PR DESCRIPTION
toilet paper: use it for its intended purpose, disguise yourself with it, or use the entire roll to clog the drains and flood the place 😈 

added 6 rolls to the lavatory vendor, a roll to the 4th deck medical hygiene room, 9 rolls (one in each toilet and one box of 6) to the second deck restroom, and a roll in the captain's quarters

It was [originally added in 2020](https://github.com/Baystation12/Baystation12/pull/27813) and [still exists in Urist code](https://github.com/UristMcStation/UristMcStation/commit/a24adcc813e645b93b920e2ab62f23b59ac7660e), the thing is that it was simply mapped onto the Torch instead of carried inside of any vending machines or anything, so it was likely forgotten - I'm guessing everyone on the Nerva have just used towels the entire time? 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->