### PR TITLE
Moves Assistant Spawns around Deck 3.

### DIFF
--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -2235,8 +2235,8 @@
 /area/logistics/auxtool)
 "eH" = (
 /obj/structure/noticeboard{
-	pixel_y = 32;
-	name = "menu board"
+	name = "menu board";
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/civilian/lounge)
@@ -2262,8 +2262,8 @@
 	},
 /obj/machinery/vending/coffee,
 /obj/machinery/light_switch{
-	pixel_y = 33;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 33
 	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/lounge)
@@ -3475,8 +3475,8 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 8
+	dir = 8;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -4934,6 +4934,9 @@
 /turf/simulated/floor/carpet/green,
 /area/civilian/lounge)
 "jv" = (
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
 /turf/simulated/floor/carpet/green,
 /area/civilian/lounge)
 "jx" = (
@@ -5139,8 +5142,8 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 4
+	dir = 4;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -5961,8 +5964,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -7145,8 +7148,8 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -7573,8 +7576,8 @@
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/corner/lightgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -7934,8 +7937,8 @@
 "pE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8008,8 +8011,8 @@
 "pN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8416,8 +8419,8 @@
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/machinery/rotating_alarm/supermatter{
-	icon_state = "alarm";
-	dir = 1
+	dir = 1;
+	icon_state = "alarm"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -8458,8 +8461,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8509,8 +8512,8 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -8728,8 +8731,8 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/orange{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8775,8 +8778,8 @@
 	icon_state = "intact-supply"
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -8834,8 +8837,8 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 8
+	dir = 8;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
@@ -9076,8 +9079,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -9155,8 +9158,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9166,8 +9169,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9753,8 +9756,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9765,8 +9768,8 @@
 /obj/item/stack/material/rods/ten,
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9779,8 +9782,8 @@
 /obj/item/clothing/gloves/insulated/cheap,
 /obj/item/crowbar,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 5
+	dir = 5;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -9793,8 +9796,8 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/floor_decal/corner/darkgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_three_quarters"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
@@ -10102,8 +10105,8 @@
 	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -10126,8 +10129,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -10227,51 +10230,21 @@
 /turf/simulated/floor/plating,
 /area/logistics/primtool)
 "tt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/bed/chair/wood/walnut{
 	dir = 4;
-	icon_state = "intact-scrubbers"
+	icon_state = "wooden_chair_preview"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
 /obj/effect/landmark/start{
 	name = "Assistant"
 	},
-/turf/simulated/floor/plating,
-/area/logistics/primtool)
+/turf/simulated/floor/wood/walnut,
+/area/civilian/lounge)
 "tu" = (
 /obj/effect/landmark/start{
 	name = "Assistant"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	icon_state = "intact-supply"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/logistics/primtool)
+/turf/simulated/floor/wood/walnut,
+/area/civilian/dorms)
 "tv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10284,9 +10257,6 @@
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
 /turf/simulated/floor/plating,
 /area/logistics/primtool)
 "tw" = (
@@ -10307,9 +10277,6 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
 /turf/simulated/floor/plating,
 /area/logistics/primtool)
 "tx" = (
@@ -10329,9 +10296,6 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
-/obj/effect/landmark/start{
-	name = "Assistant"
-	},
 /turf/simulated/floor/plating,
 /area/logistics/primtool)
 "ty" = (
@@ -10657,8 +10621,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11029,8 +10993,8 @@
 "uS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11039,8 +11003,8 @@
 /obj/machinery/light,
 /obj/random/toolbox,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11056,8 +11020,8 @@
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11070,8 +11034,8 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11085,8 +11049,8 @@
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -11095,8 +11059,8 @@
 /obj/item/device/paint_sprayer,
 /obj/item/tape_roll,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -13485,8 +13449,8 @@
 /area/maintenance/second_deck/afs)
 "zY" = (
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 8;
@@ -13838,8 +13802,8 @@
 /area/civilian/counselor)
 "Cc" = (
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -13942,8 +13906,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -14326,8 +14290,8 @@
 /area/maintenance/second_deck/fp)
 "Ey" = (
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -14340,8 +14304,8 @@
 /area/maintenance/second_deck/fs)
 "EH" = (
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -14376,8 +14340,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -14511,6 +14475,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"Fm" = (
+/obj/structure/bed/chair/wood/walnut,
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/civilian/lounge)
 "Fs" = (
 /obj/structure/closet/coffin,
 /obj/machinery/door/window/southleft{
@@ -14625,8 +14596,8 @@
 	icon_state = "intact-scrubbers"
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -14903,6 +14874,12 @@
 /obj/item/stool,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"Hb" = (
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/personal)
 "Hh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15118,8 +15095,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -15174,8 +15151,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -15208,8 +15185,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -15291,8 +15268,8 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/rotating_alarm/security_alarm{
-	icon_state = "code green";
-	dir = 1
+	dir = 1;
+	icon_state = "code green"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -15438,8 +15415,8 @@
 /obj/machinery/cell_charger,
 /obj/item/cell/super,
 /obj/effect/floor_decal/corner/darkgrey/three_quarters{
-	icon_state = "corner_white_three_quarters";
-	dir = 4
+	dir = 4;
+	icon_state = "corner_white_three_quarters"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -16235,8 +16212,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -16305,8 +16282,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -16394,8 +16371,8 @@
 	pixel_x = -24
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -16418,16 +16395,16 @@
 /area/security/prison)
 "OI" = (
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 1;
 	icon_state = "corner_white"
 	},
 /obj/effect/floor_decal/corner/gold/border{
-	icon_state = "bordercolor";
-	dir = 1
+	dir = 1;
+	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -16543,8 +16520,8 @@
 	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 6
+	dir = 6;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/aft/second_deck)
@@ -17336,6 +17313,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"TD" = (
+/obj/structure/bed/chair/couch/right/black,
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/civilian/observatory)
 "TE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17415,8 +17399,8 @@
 "Ub" = (
 /obj/machinery/vending/tool,
 /obj/effect/floor_decal/corner/darkgrey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
@@ -17719,8 +17703,8 @@
 	location = "Deck 2 Aft Starboard"
 	},
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 10
+	dir = 10;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -17873,6 +17857,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/fore/second_deck)
+"WB" = (
+/obj/effect/landmark/start{
+	name = "Assistant"
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/civilian/dorms)
 "WC" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
@@ -18138,8 +18128,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/grey{
-	icon_state = "corner_white";
-	dir = 9
+	dir = 9;
+	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/second_deck)
@@ -39154,7 +39144,7 @@ Az
 hH
 io
 jk
-jk
+tu
 Ep
 hH
 mV
@@ -39365,7 +39355,7 @@ oM
 XH
 qv
 uF
-sd
+Hb
 sd
 tS
 tS
@@ -41176,7 +41166,7 @@ hH
 hH
 kd
 ld
-ma
+WB
 ma
 nR
 hH
@@ -41800,7 +41790,7 @@ Uc
 Ic
 uJ
 vx
-wb
+TD
 uK
 mp
 Bm
@@ -45012,7 +45002,7 @@ gZ
 bA
 MI
 iz
-iy
+Fm
 mg
 iN
 jy
@@ -45224,7 +45214,7 @@ pP
 qL
 rA
 sv
-tt
+ts
 ub
 uS
 rz
@@ -45426,7 +45416,7 @@ pQ
 qR
 rA
 sw
-tu
+ts
 uc
 uT
 rz
@@ -45819,7 +45809,7 @@ ge
 gZ
 hJ
 eJ
-jq
+tt
 jq
 iA
 jq
@@ -45830,7 +45820,7 @@ pK
 qT
 rA
 sy
-tu
+ts
 sy
 Ub
 rz


### PR DESCRIPTION
Assistant no longer spawn in Tool Storage with no way out other than a bit of casual B&E.

Assistants will spawn around the top level bar, the lower observatory, the dormitory, arcade cabinet.

Fixes - 
https://github.com/UristMcStation/UristMcStation/issues/1415