### PR TITLE
Cargo Supply Additions 

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -84,3 +84,8 @@
 	name = "crab crate"
 	held_count = 3
 	held_type = /mob/living/simple_animal/passive/crab
+
+/obj/structure/largecrate/animal/opossum
+	name = "opossum crate"
+	held_count = 1
+	held_type = /mob/living/simple_animal/passive/opossum

--- a/code/modules/urist/datums/supplycrates.dm
+++ b/code/modules/urist/datums/supplycrates.dm
@@ -121,3 +121,106 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	containertype = /obj/structure/closet/crate/secure
 	containername = "cloning verification disk crate"
 	access = access_medical_equip
+
+/singleton/hierarchy/supply_pack/livecargo/opossom
+	name = "Opossum Crate"
+	contains = list(/mob/living/simple_animal/passive/opossum)
+	cost = 30
+	newcargocost = 55 // 2500th on Nerva
+	containertype = /obj/structure/largecrate/animal/opossum
+	containername = "Opossum Crate"
+
+/singleton/hierarchy/supply_pack/custodial/replacement_janicart
+	name = "Replacement Janitorial Cart"
+	contains = list(/obj/structure/janitorialcart)
+	cost = 10
+	newcargocost = 20 //900th on Nerva
+	containertype = /obj/structure/largecrate
+	containername = "replacement janitorial cart"
+
+/singleton/hierarchy/supply_pack/flooring/magenta
+	name = "Magenta carpet"
+	contains = list(/obj/item/stack/tile/carpetmagenta)
+	cost = 10
+	newcargocost = 15 //675th on Nerva
+	containertype = /obj/structure/closet/crate
+	containername = "magenta carpet crate"
+
+/singleton/hierarchy/supply_pack/flooring/poolturf
+	name = "Pool flooring"
+	contains = list(/obj/item/stack/tile/pool)
+	cost = 10
+	newcargocost = 30 // 1350th on Nerva
+	containertype = /obj/structure/closet/crate/secure
+	containername = "pool flooring crate"
+
+/singleton/hierarchy/supply_pack/flooring/walnut
+	name = "Walnut wooden flooring"
+	contains = list(/obj/item/stack/tile/walnut)
+	cost = 10
+	newcargocost = 15 //675th on Nerva
+	containertype = /obj/structure/closet/crate/secure
+	containername = "walnut wooden flooring crate"
+
+/singleton/hierarchy/supply_pack/flooring/mahogany
+	name = "Mahogany wooden flooring"
+	contains = list(/obj/item/stack/tile/mahogany)
+	cost = 10
+	newcargocost = 15 //675th on Nerva
+	containertype = /obj/structure/closet/crate/secure
+	containername = "mahogany wooden flooring crate"
+
+/singleton/hierarchy/supply_pack/flooring/maple
+	name = "Maple wooden flooring"
+	contains = list(/obj/item/stack/tile/maple)
+	cost = 10
+	newcargocost = 15 //675th on Nerva
+	containertype = /obj/structure/closet/crate/secure
+	containername = "maple wooden flooring crate"
+
+/singleton/hierarchy/supply_pack/flooring/ebony
+	name = "Ebony wooden flooring"
+	contains = list(/obj/item/stack/tile/ebony)
+	cost = 10
+	newcargocost = 15 //675th on Nerva
+	containertype = /obj/structure/closet/crate/secure
+	containername = "ebony wooden flooring crate"
+
+/singleton/hierarchy/supply_pack/flooring/bamboo
+	name = "Bamboo wooden flooring"
+	contains = list(/obj/item/stack/tile/bamboo)
+	cost = 10
+	newcargocost = 15 //675th on Nerva
+	containertype = /obj/structure/closet/crate/secure
+	containername = "bamboo wooden flooring crate"
+
+/singleton/hierarchy/supply_pack/flooring/yew
+	name = "Yew wooden flooring"
+	contains = list(/obj/item/stack/tile/yew)
+	cost = 10
+	newcargocost = 15 //675th on Nerva
+	containertype = /obj/structure/closet/crate/secure
+	containername = "yew wooden flooring crate"
+
+/singleton/hierarchy/supply_pack/security/uniform_crate
+	name = "Security uniform crate"
+	contains = list(/obj/item/clothing/accessory/armband,
+					/obj/item/storage/backpack/messenger/sec,
+					/obj/item/storage/backpack/security,
+					/obj/item/clothing/glasses/hud/security/prot/sunglasses,
+					/obj/item/clothing/gloves/thick,
+					/obj/item/clothing/glasses/hud/security/prot,
+					/obj/item/clothing/accessory/storage/black_vest,
+					/obj/item/storage/belt/security,
+					/obj/item/storage/belt/holster/security,
+					/obj/item/clothing/under/urist/nerva/secfield,
+					/obj/item/clothing/under/urist/nerva/secregular,
+					/obj/item/device/radio/headset/nerva_sec/alt,
+					/obj/item/device/radio/headset/nerva_sec,
+					/obj/item/clothing/suit/urist/armor/nerva/sec // Only the older vest, no plate carriers.
+					)
+	cost = 20
+	newcargocost = 32 //1440th on Nerva
+	containertype = /obj/structure/closet/crate/secure
+	access = access_security
+	containername = "securuty uniform crate"

--- a/code/modules/urist/datums/supplycrates.dm
+++ b/code/modules/urist/datums/supplycrates.dm
@@ -127,7 +127,7 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	contains = list(/mob/living/simple_animal/passive/opossum)
 	cost = 30
 	newcargocost = 55 // 2500th on Nerva
-	containertype = /obj/structure/largecrate/animal/opossum
+	containertype = /obj/structure/largecrate
 	containername = "Opossum Crate"
 
 /singleton/hierarchy/supply_pack/custodial/replacement_janicart
@@ -143,7 +143,7 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	contains = list(/obj/item/stack/tile/carpetmagenta)
 	cost = 10
 	newcargocost = 15 //675th on Nerva
-	containertype = /obj/structure/closet/crate
+	containertype = /obj/structure/closet/crate/secure
 	containername = "magenta carpet crate"
 
 /singleton/hierarchy/supply_pack/flooring/poolturf
@@ -223,4 +223,4 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	newcargocost = 32 //1440th on Nerva
 	containertype = /obj/structure/closet/crate/secure
 	access = access_security
-	containername = "securuty uniform crate"
+	containername = "security uniform crate"

--- a/code/modules/urist/datums/supplycrates.dm
+++ b/code/modules/urist/datums/supplycrates.dm
@@ -201,26 +201,3 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	newcargocost = 15 //675th on Nerva
 	containertype = /obj/structure/closet/crate/secure
 	containername = "yew wooden flooring crate"
-
-/singleton/hierarchy/supply_pack/security/uniform_crate
-	name = "Security uniform crate"
-	contains = list(/obj/item/clothing/accessory/armband,
-					/obj/item/storage/backpack/messenger/sec,
-					/obj/item/storage/backpack/security,
-					/obj/item/clothing/glasses/hud/security/prot/sunglasses,
-					/obj/item/clothing/gloves/thick,
-					/obj/item/clothing/glasses/hud/security/prot,
-					/obj/item/clothing/accessory/storage/black_vest,
-					/obj/item/storage/belt/security,
-					/obj/item/storage/belt/holster/security,
-					/obj/item/clothing/under/urist/nerva/secfield,
-					/obj/item/clothing/under/urist/nerva/secregular,
-					/obj/item/device/radio/headset/nerva_sec/alt,
-					/obj/item/device/radio/headset/nerva_sec,
-					/obj/item/clothing/suit/urist/armor/nerva/sec // Only the older vest, no plate carriers.
-					)
-	cost = 20
-	newcargocost = 32 //1440th on Nerva
-	containertype = /obj/structure/closet/crate/secure
-	access = access_security
-	containername = "security uniform crate"

--- a/maps/nerva/datums/nerva_supplypacks.dm
+++ b/maps/nerva/datums/nerva_supplypacks.dm
@@ -33,3 +33,26 @@
 	containertype = /obj/structure/largecrate
 	containername = "Heavy Autocannon - Ship-to-Ship"
 	access = access_bridge
+
+/singleton/hierarchy/supply_pack/security/uniform_crate   // Nerva Specific Uniform Crate
+	name = "Security uniform crate"
+	contains = list(/obj/item/clothing/accessory/armband,
+					/obj/item/storage/backpack/messenger/sec,
+					/obj/item/storage/backpack/security,
+					/obj/item/clothing/glasses/hud/security/prot/sunglasses,
+					/obj/item/clothing/gloves/thick,
+					/obj/item/clothing/glasses/hud/security/prot,
+					/obj/item/clothing/accessory/storage/black_vest,
+					/obj/item/storage/belt/security,
+					/obj/item/storage/belt/holster/security,
+					/obj/item/clothing/under/urist/nerva/secfield,
+					/obj/item/clothing/under/urist/nerva/secregular,
+					/obj/item/device/radio/headset/nerva_sec/alt,
+					/obj/item/device/radio/headset/nerva_sec,
+					/obj/item/clothing/suit/urist/armor/nerva/sec // Only the older vest, no plate carriers.
+					)
+	cost = 20
+	newcargocost = 32 //1440th on Nerva
+	containertype = /obj/structure/closet/crate/secure
+	access = access_security
+	containername = "security uniform crate"


### PR DESCRIPTION
**Adds a few additional supplies cargo can buy:**

**Live Animals:**
- Opossums: 2475th

**Custodial:**
- Replacement Janitorial Cart: 900th

**Flooring:**
- Magenta carpet (missing before): 675th
- All variations of wooden flooring (Mahogany, yew, ebony, maple, etc.)  675th

**Security:**
- Uniform Crate (All security uniform + headset, bar the plate carrier) 800th