### PR TITLE
Pens can now be hidden in shoes

### DIFF
--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -12,6 +12,7 @@
 	matter = list(MATERIAL_PLASTIC = 10)
 	var/colour = "black"	//what colour the ink is!
 	var/color_description = "black ink"
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 	var/active = TRUE
 	var/iscrayon = FALSE


### PR DESCRIPTION
**Changes:**
Pens now have the item flag to allow them to be hidden in shoes.
Now you can put crayons, pens, or sleepy pens in your shoes, similar to knives and glass shards. 
It'll still make a visible message if you go to take it out, so it won't be sneaky using it, but good to hide from unsuspecting crew.