### PR TITLE
Adds additional Holomaps & a wheelchair to Nerva

### DIFF
--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -9919,6 +9919,9 @@
 	icon_state = "intact-supply"
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/ship_map{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/logistics/hangar)
 "rr" = (
@@ -17164,6 +17167,9 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
+/obj/machinery/ship_map{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/lowercargo)
 "DY" = (
@@ -23953,6 +23959,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hadrian/main)
+"YW" = (
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/tiled/white/monotile,
+/area/medical/extstorage)
 "YY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -43552,7 +43562,7 @@ aM
 bd
 af
 bW
-LR
+YW
 cC
 af
 cw

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -2195,6 +2195,10 @@
 /obj/machinery/light/spot/warmtint{
 	dir = 1
 	},
+/obj/structure/noticeboard{
+	pixel_y = 32;
+	name = "menu board"
+	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
 "aeM" = (
@@ -12698,7 +12702,12 @@
 	},
 /obj/machinery/requests_console{
 	department = "Crew Quarters";
-	pixel_y = 30
+	pixel_y = 30;
+	pixel_x = 32
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -15901,14 +15910,12 @@
 /obj/effect/landmark{
 	name = "JoinLateCryo"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
+	},
+/obj/machinery/ship_map{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -28249,10 +28256,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
 "euF" = (
-/obj/structure/noticeboard{
-	pixel_y = 32;
-	name = "menu board"
-	},
+/obj/machinery/ship_map,
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
 "eyp" = (
@@ -30320,6 +30324,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/fs)
+"ptV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/ship_map,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
 "puU" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1;
@@ -31323,6 +31351,14 @@
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
+"vim" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/machinery/ship_map,
+/turf/simulated/floor/tiled,
+/area/hallway/fore/third_deck)
 "vkW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -56404,7 +56440,7 @@ ayp
 cXI
 ayp
 brf
-wpN
+vim
 ujt
 aGE
 hNR
@@ -58009,7 +58045,7 @@ bFA
 bFA
 bFA
 bFA
-asl
+ptV
 atK
 auM
 fRl

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -5283,6 +5283,7 @@
 	dir = 2;
 	icon_state = "camera"
 	},
+/obj/machinery/ship_map,
 /turf/simulated/floor/wood/walnut,
 /area/civilian/dorms)
 "ke" = (
@@ -10962,6 +10963,7 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
+/obj/machinery/ship_map,
 /turf/simulated/floor/tiled/dark,
 /area/civilian/observatory)
 "uK" = (
@@ -13710,6 +13712,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/ship_map{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
@@ -17097,6 +17102,20 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/security/boardarmoury)
+"RE" = (
+/obj/effect/floor_decal/urist/nervalogo{
+	dir = 1;
+	icon_state = "nerva2"
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/ship_map{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/aft/second_deck)
 "RF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
@@ -38143,7 +38162,7 @@ GK
 Ps
 hF
 ik
-jh
+RE
 Ah
 Ah
 Ah

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -8809,6 +8809,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfirst)
+"zw" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5;
+	icon_state = "corner_white"
+	},
+/obj/machinery/ship_map,
+/turf/simulated/floor/tiled,
+/area/hallway/centralfirst)
 "AB" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28869,7 +28877,7 @@ qk
 qk
 qk
 qk
-Ym
+zw
 aQ
 bi
 bt


### PR DESCRIPTION
This adds additional Holomaps all around the Nerva, usually near key and memorable areas, or specific hallways.
The intent is to make it easier for new players to look around the map aside from viewing that one pinned PNG

**Locations:**

**Deck 1:**
Bottom of Trajan Hangar

**Deck 2:**
Cryo Storage
Bar
Near Security Lobby
Holodeck

**Deck 3:**

Near Deck 3 Stairway Elevator.
Dormitory
Observatory
Near Teleporter Outside.


**Deck 4:**
Top Docking Port.

This also adds a singular wheelchair in the Medical Storage Bay.

**TODO:**

- [ ] Check all dir are working correctly.