### PR TITLE
Syndicate Hardsuits now come bundled with a Suit Cooling Unit.

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -55,6 +55,7 @@
 		/obj/item/clothing/head/helmet/space/void/merc,
 		/obj/item/clothing/mask/gas/syndicate,
 		/obj/item/tank/oxygen_emergency_double,
+		/obj/item/device/suit_cooling_unit
 		)
 
 // Chameleon uplink kit


### PR DESCRIPTION
As said in the title
Doesn't lock out IPC + FBPs by making them search for one before-hand.
They'd still need to find additional cells and such.

Probably also assists Merc FBPs/IPCs as well if they are allowed (I haven't play merc in forever and don't remember)