### PR TITLE
Gives Stowaway Role the Originally Intended Crowbar

### DIFF
--- a/maps/nerva/datums/nerva_outfits.dm
+++ b/maps/nerva/datums/nerva_outfits.dm
@@ -162,9 +162,9 @@
 	id_types = null
 	pda_type = null
 	l_ear = null
+	r_hand = /obj/item/crowbar
 	l_pocket = /obj/item/wrench
-	r_pocket = /obj/item/crowbar
-	backpack_contents = list(/obj/item/device/flashlight = 1)
+	r_pocket = /obj/item/device/flashlight
 
 //psychiatrist
 


### PR DESCRIPTION
- Moves the crowbar spawn in the stowaway outfit to the characters hand. This is instead of their pocket, where it would be impossible to appear.
- Also moves the flashlight given to the same pocket slot. This is so it is not a necessity to spawn with a backpack to receive it.