### PR TITLE
Makes all loadout items without a defined cost 0 points to buy

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/xenowear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear.dm
@@ -101,7 +101,7 @@
 
 // Misc clothing
 /datum/gear/uniform/harness
-	display_name = "gear harness (Full Body Prosthetic, Diona)"
+	display_name = "gear harness (IPC, Diona)"
 	path = /obj/item/clothing/under/harness
 	slot = slot_w_uniform
 	sort_category = "Xenowear"

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -288,7 +288,7 @@ var/global/list/gear_datums = list()
 	var/display_name       //Name/index. Must be unique.
 	var/description        //Description of this gear. If left blank will default to the description of the pathed item.
 	var/path               //Path to item.
-	var/cost = 0           //Number of points used. Items in general cost 1 point, storage/armor/gloves/special use costs 2 points.
+	var/cost = 0           //Number of points used. Items in general cost 1 point, storage/armor/gloves/special use costs 2 points. Apr. 2024 change to 0 points for general items
 	var/slot               //Slot to equip to.
 	var/list/allowed_roles //Roles that can spawn with this item.
 	var/list/allowed_branches //Service branches that can spawn with it.

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -288,7 +288,7 @@ var/global/list/gear_datums = list()
 	var/display_name       //Name/index. Must be unique.
 	var/description        //Description of this gear. If left blank will default to the description of the pathed item.
 	var/path               //Path to item.
-	var/cost = 1           //Number of points used. Items in general cost 1 point, storage/armor/gloves/special use costs 2 points.
+	var/cost = 0           //Number of points used. Items in general cost 1 point, storage/armor/gloves/special use costs 2 points.
 	var/slot               //Slot to equip to.
 	var/list/allowed_roles //Roles that can spawn with this item.
 	var/list/allowed_branches //Service branches that can spawn with it.


### PR DESCRIPTION
The implementation of [this deliberation](https://discord.com/channels/145674110075273216/168412517851201536/1228026477245628518)

Overall consensus - Items without a significant mechanical impact cost 1 point or are otherwise job restricted to jobs that get given equivalents for free that look different (read: those 1 points stacks up quickly)

Also cleaned up a misleading description for the gear harness - it says it fits body prosthetics when in reality it is just race-restricted to IPCs and dooners, misleading when I tried to make a human FBP character only to be blocked from the item

🆑 
* tweak: makes all loadout items without a defined cost into the public domain - 0 points to buy
* grammar: cleans up a misleading description for the gear harness
/ 🆑 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->