### PR TITLE
Flashlight  Subtypes (Flares, Glowsticks,  Lanterns, Penlights, Flashdarks, Lamps) now have action buttons.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -251,7 +251,7 @@
 	light_color = "#e58775"
 	icon_state = "flare"
 	item_state = "flare"
-	action_button_name = null //just pull it manually, neckbeard.
+	action_button_name = "Ignite Flare"
 	var/fuel = 0
 	var/on_damage = 7
 	var/produce_heat = 1500
@@ -332,6 +332,7 @@
 	randpixel = 12
 	produce_heat = 0
 	activation_sound = 'sound/effects/glowstick.ogg'
+	action_button_name = "Snap Glowstick"
 
 	flashlight_max_bright = 0.6
 	flashlight_inner_range = 0.1

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -150,6 +150,7 @@
 	flashlight_outer_range = 4
 	flashlight_inner_range = 1
 	flashlight_flags = FLASHLIGHT_CANNOT_BLIND
+	action_button_name = "Toggle Flashdark"
 
 /obj/item/device/flashlight/pen
 	name = "penlight"
@@ -162,6 +163,7 @@
 	flashlight_max_bright = 0.25
 	flashlight_inner_range = 0.1
 	flashlight_outer_range = 2
+	action_button_name = "Toggle Penlight"
 
 /obj/item/device/flashlight/maglight
 	name = "maglight"
@@ -190,6 +192,7 @@
 	slot_flags = SLOT_BELT
 	matter = list(MATERIAL_STEEL = 200,MATERIAL_GLASS = 100)
 	flashlight_outer_range = 5
+	action_button_name = "Toggle Lantern"
 
 /obj/item/device/flashlight/lantern/on_update_icon()
 	..()
@@ -224,6 +227,7 @@
 	flashlight_max_bright = 0.3
 	flashlight_inner_range = 2
 	flashlight_outer_range = 5
+	action_button_name = "Toggle Lamp"
 
 	on = 1
 


### PR DESCRIPTION
![image](https://github.com/UristMcStation/UristMcStation/assets/53942081/a83b93c7-0075-4402-8576-a7e1244b0036)

Emergency Flares and Glowsticks now have action buttons to ignite/snap them.
Pressing them again will just inform the user in chat that it's already ignited/in use.