### PR TITLE
[DRAFT] Item Action Button Overhaul

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -4,6 +4,7 @@
 	suffix = "\[3\]"
 	icon_state = "walkietalkie"
 	item_state = "walkietalkie"
+	action_button_name = "Configure Radio"
 
 	var/on = 1 // 0 for off
 	var/last_transmission

--- a/code/game/objects/items/devices/scanners/_scanner.dm
+++ b/code/game/objects/items/devices/scanners/_scanner.dm
@@ -17,6 +17,7 @@
 	var/use_delay
 	var/scan_sound
 	var/printout_color
+	action_button_name = "Access Scanner"
 
 /obj/item/device/scanner/attack_self(mob/user)
 	show_menu(user)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -21,6 +21,7 @@
 	throwforce = 2
 	throw_speed = 4
 	throw_range = 20
+	action_button_name = "Toggle Universal Recorder"
 
 /obj/item/device/taperecorder/New()
 	..()

--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -8,6 +8,7 @@
 	var/channel = "General News Feed"
 	var/obj/machinery/camera/network/thunder/camera
 	var/obj/item/device/radio/radio
+	action_button_name = "Access EyeBuddy Interface"
 
 /obj/item/device/camera/tvcamera/New()
 	..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -963,11 +963,13 @@
 	name = "\improper Newton's cradle"
 	desc = "An ancient 21th century super-weapon model demonstrating that Sir Isaac Newton is the deadliest sonuvabitch in space."
 	icon_state = "newtoncradle"
+	action_button_name = "Toggle Cradle"
 
 /obj/item/toy/desk/fan
 	name = "office fan"
 	desc = "Your greatest fan."
 	icon_state= "fan"
+	action_button_name = "Toggle Fan"
 
 /obj/item/toy/desk/officetoy
 	name = "office toy"
@@ -978,6 +980,7 @@
 	name = "dipping bird toy"
 	desc = "An ancient human bird idol, worshipped by clerks and desk jockeys."
 	icon_state= "dippybird"
+	action_button_name = "Toggle Bird"
 
 // tg station ports
 

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -14,6 +14,7 @@
 	base_parry_chance = 15
 	matter = list(MATERIAL_STEEL = 90)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
+	action_button_name = "Toggle Safety"
 
 	var/spray_particles = 3
 	var/spray_amount = 120	//units of liquid per spray - 120 -> same as splashing them with a bucket per spray

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -13,6 +13,7 @@
 	var/random_colour = FALSE
 	var/available_colors = list(COLOR_WHITE, COLOR_BLUE_GRAY, COLOR_GREEN_GRAY, COLOR_BOTTLE_GREEN, COLOR_DARK_GRAY, COLOR_RED_GRAY, COLOR_GUNMETAL, COLOR_RED, COLOR_YELLOW, COLOR_CYAN, COLOR_GREEN, COLOR_VIOLET, COLOR_NAVY_BLUE, COLOR_PINK)
 	light_color = "#e09d37"
+	action_button_name = "Toggle Lighter"
 
 /obj/item/flame/lighter/Initialize()
 	. = ..()
@@ -144,6 +145,7 @@
 	item_state = "zippo"
 	max_fuel = 10
 	available_colors = list(COLOR_WHITE, COLOR_WHITE, COLOR_WHITE, COLOR_DARK_GRAY, COLOR_GUNMETAL, COLOR_BRONZE, COLOR_BRASS)
+	action_button_name = "Toggle Zippo (so cool)"
 
 /obj/item/flame/lighter/zippo/on_update_icon()
 	var/datum/extension/base_icon_state/bis = get_extension(src, /datum/extension/base_icon_state)

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -14,7 +14,7 @@ Single Use Emergency Pouches
 	open_sound = 'sound/effects/rip1.ogg'
 	var/injury_type = "generic"
 	var/static/image/cross_overlay
-
+	action_button_name = "Access Pouch"
 	var/instructions = {"
 	1) Tear open the emergency medical pack using the easy open tab at the top.\n\
 	\t2) Carefully remove all items from the pouch and discard the pouch.\n\

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -40,6 +40,7 @@ var/global/list/tank_gauge_cache = list()
 	var/tank_flags = EMPTY_BITFIELD
 
 	var/list/starting_pressure //list in format 'xgm gas id' = 'desired pressure at start'
+	action_button_name = "Access Tank"
 
 /obj/item/tank/Initialize()
 	. = ..()

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -10,6 +10,7 @@
 	siemens_coefficient = 0.9
 	body_parts_covered = 0
 	species_restricted = list("exclude")
+	action_button_name = "Flip Cap"
 
 
 /obj/item/clothing/head/soft/New()

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -21,6 +21,7 @@
 	w_class = ITEM_SIZE_SMALL
 	icon = 'icons/obj/playing_cards.dmi'
 	var/list/cards = list()
+	action_button_name = "Shuffle Deck"
 
 /obj/item/deck/inherit_custom_item_data(datum/custom_item/citem)
 	. = ..()

--- a/code/modules/integrated_electronics/core/prefab/prefabs.dm
+++ b/code/modules/integrated_electronics/core/prefab/prefabs.dm
@@ -2,7 +2,6 @@
 	assembly_name = "hand-teleporter"
 	data = {"{'assembly':{'type':'type-a electronic mechanism','name':'Hand Teleporter', 'detail_color':'#5d99be'},'components':\[{'type':'teleporter locator'},{'type':'bluespace rift generator'},{'type':'button','name':'Open Rift'}\],'wires':\[\[\[1,'O',1\],\[2,'I',1\]\],\[\[2,'A',1\],\[3,'A',1\]\]\]}"}
 	power_cell_type = /obj/item/cell/hyper
-	action_button_name = "Access Hand-Teleporter"
 
 /obj/prefab/hand_teleporter
 	name = "hand teleporter"

--- a/code/modules/integrated_electronics/core/prefab/prefabs.dm
+++ b/code/modules/integrated_electronics/core/prefab/prefabs.dm
@@ -2,6 +2,7 @@
 	assembly_name = "hand-teleporter"
 	data = {"{'assembly':{'type':'type-a electronic mechanism','name':'Hand Teleporter', 'detail_color':'#5d99be'},'components':\[{'type':'teleporter locator'},{'type':'bluespace rift generator'},{'type':'button','name':'Open Rift'}\],'wires':\[\[\[1,'O',1\],\[2,'I',1\]\],\[\[2,'A',1\],\[3,'A',1\]\]\]}"}
 	power_cell_type = /obj/item/cell/hyper
+	action_button_name = "Access Hand-Teleporter"
 
 /obj/prefab/hand_teleporter
 	name = "hand teleporter"

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -13,6 +13,7 @@
 	stored_pen = /obj/item/pen/retractable
 	interact_sounds = list('sound/machines/pda_click.ogg')
 	interact_sound_volume = 20
+	action_button_name = "Access PDA"
 
 /obj/item/modular_computer/pda/Initialize()
 	. = ..()

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -7,6 +7,7 @@
 	matter = list(MATERIAL_STEEL = 1260)
 	max_ammo = 6
 	multiple_sprites = 1
+	action_button_name = "Empty Speedloader"
 
 /obj/item/ammo_magazine/speedloader/rubber
 	labels = list("rubber")

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -10,7 +10,7 @@
 	projectile_type = /obj/item/projectile/beam/stun
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	modifystate = "energystun"
-
+	action_button_name = "Toggle Firemode"
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, modifystate="energystun"),
 		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock, modifystate="energyshock"),

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -19,6 +19,7 @@
 	accuracy_power = 8
 	one_hand_penalty = 2
 	bulk = 3
+	action_button_name = "Empty Cylinder"
 
 /obj/item/gun/projectile/revolver/on_update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -56,6 +56,7 @@
 	bulk = 6
 	var/recentpump = 0 // to prevent spammage
 	load_sound = 'sound/weapons/guns/interaction/shotgun_instert.ogg'
+	action_button_name = "Rack Shotgun"
 
 /obj/item/gun/projectile/shotgun/on_update_icon()
 	..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -136,6 +136,7 @@
 	item_state = "beaker"
 	center_of_mass = "x=15;y=10"
 	matter = list(MATERIAL_GLASS = 500)
+	action_button_name = "Toggle Lid"
 
 
 /obj/item/reagent_containers/glass/beaker/New()

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -12,6 +12,7 @@
 	item_flags = 0
 	obj_flags = 0
 	volume = 60
+	action_button_name = "Toggle Lid"
 
 
 /obj/item/reagent_containers/glass/bottle/on_reagent_change()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -18,6 +18,7 @@
 	var/list/spray_sizes = list(1,3)
 	var/step_delay = 10 // lower is faster
 	volume = 250
+	action_button_name = "Adjust Pressure Nozzle"
 
 /obj/item/reagent_containers/spray/New()
 	..()


### PR DESCRIPTION
WIP af for now, will definitely need a round or two of playtesting once it's ready to make sure we don't have any issues.

Lots of Items now have action buttons relating to specific context.

**I.E:**
Accessing Scanners
Toggling Devices, Lighters, Toys, Tools, Etc.
Weapons - Racking and Emptying
Scopes & Binoculars: Aiming Down Sights w/out needing to use a verb.
Speedloaders - Emptying
Hats - Flipping Caps around.
Energy Weapons - Toggling Firemodes.


I'll be adding more and doing verb specific buttons for important elements. 
Weapons will only be getting specific verbs as buttons to avoid being able to activate certain things meant to only be done in your hands, such as grenades.