### PR TITLE
Pass on Tiny Items capable of being hidden in shoes + Clown can now hide items in his oversized shoes.

### DIFF
--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -5,7 +5,7 @@
 	icon_state = "eshield0"
 	item_state = "nothing"
 	layer = BELOW_TABLE_LAYER
-
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	force = 5.0
 	w_class = ITEM_SIZE_TINY
@@ -18,6 +18,7 @@
 
 	var/obj/item/device/radio/spy/radio
 	var/obj/machinery/camera/spy/camera
+
 
 /obj/item/device/spy_bug/New()
 	..()

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -13,6 +13,7 @@
 	var/random_colour = FALSE
 	var/available_colors = list(COLOR_WHITE, COLOR_BLUE_GRAY, COLOR_GREEN_GRAY, COLOR_BOTTLE_GREEN, COLOR_DARK_GRAY, COLOR_RED_GRAY, COLOR_GUNMETAL, COLOR_RED, COLOR_YELLOW, COLOR_CYAN, COLOR_GREEN, COLOR_VIOLET, COLOR_NAVY_BLUE, COLOR_PINK)
 	light_color = "#e09d37"
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/flame/lighter/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -11,7 +11,7 @@
 	thrown_force_multiplier = 0.1
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
-	item_flags = ITEM_FLAG_TRY_ATTACK
+	item_flags = ITEM_FLAG_TRY_ATTACK | ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 	/// The smallest interval allowed between coin flips.
 	var/const/FLIP_COOLDOWN = 5 SECONDS

--- a/code/game/objects/items/weapons/material/thrown.dm
+++ b/code/game/objects/items/weapons/material/thrown.dm
@@ -12,6 +12,7 @@
 	sharp = TRUE
 	edge =  TRUE
 	w_class = ITEM_SIZE_TINY
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/material/star/New()
 	..()

--- a/code/game/objects/items/weapons/storage/fancy/vials.dm
+++ b/code/game/objects/items/weapons/storage/fancy/vials.dm
@@ -5,6 +5,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_TINY
 	storage_slots = 12
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 	key_type = /obj/item/reagent_containers/glass/beaker/vial
 	startswith = list(/obj/item/reagent_containers/glass/beaker/vial = 12)

--- a/code/game/objects/items/weapons/storage/fancy/vials.dm
+++ b/code/game/objects/items/weapons/storage/fancy/vials.dm
@@ -5,7 +5,6 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_TINY
 	storage_slots = 12
-	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 	key_type = /obj/item/reagent_containers/glass/beaker/vial
 	startswith = list(/obj/item/reagent_containers/glass/beaker/vial = 12)

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -85,6 +85,7 @@
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
 	matter = list(MATERIAL_STEEL = 10000, MATERIAL_GLASS = 5000)
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /*
  * Researchable Scalpels

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -195,6 +195,7 @@
 	ignitermes = "<span class='notice'>USER fiddles with FLAME, and manages to light their NAME.</span>"
 	brand = "\improper Trans-Stellar Duty-free"
 	var/list/filling = list(/datum/reagent/tobacco = 1)
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES // Nothing like a good shoe-ciggie to get through the day.
 
 /obj/item/clothing/mask/smokable/cigarette/New()
 	..()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -151,7 +151,7 @@
 	force = 0
 	var/footstep = 1	//used for squeeks whilst walking
 	species_restricted = null
-	can_add_hidden_item = FALSE
+	can_add_hidden_item = TRUE // The Clown's got big shoes, damnit.
 
 /obj/item/clothing/shoes/clown_shoes/Initialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -244,6 +244,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = "5;10;15;30"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/reagent_containers/glass/beaker/insulated
 	name = "insulated beaker"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -12,6 +12,7 @@
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 	volume = 30
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/reagent_containers/pill/New()
 	..()


### PR DESCRIPTION
**Following Items can now be hidden in shoes -**

- Spy Bugs (Syndi-Bug Kit) - Steal someones shoes and give em back
- Lighters
- Coins
- Vials
- Scalpels (Bringing in line w/ Knives.)
- Ciggarettes
- Pills
- Syndicate Shruikens.

Clown can now have items in his shoes.