### PR TITLE
Traitor sleepy ring

### DIFF
--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -33,6 +33,12 @@
 	item_cost = 20
 	path = /obj/item/pen/reagent/sleepy
 
+/datum/uplink_item/item/stealthy_weapons/sleepyring
+	name = "Sleepy Ring"
+	desc = "A silver ring that will quickly put its wearer to sleep with discreetly injected chemicals. WARNING: Not effective on robots. Do not wear this yourself."
+	item_cost = 13
+	path = /obj/item/clothing/ring/reagent/sleepy
+
 /datum/uplink_item/item/stealthy_weapons/syringegun
 	name = "Disguised Syringe Gun"
 	desc = "A syringe gun disguised as an electronic cigarette with 4 darts included in the box. Chemicals not included!"


### PR DESCRIPTION
This thing's just been [sitting in the code since 2017](https://github.com/UristMcStation/UristMcStation/blob/baymerge-testing/code/modules/clothing/rings/rings.dm#L52). I think Baystation forgot about it. Apparently it's also in Aurora station? I don't know what they use it for either

13 cool kid points
When it's worn, it immediately injects its 15u of chloral hydrate into the wearer
Like the paralysis pen, it counts as an open container so it can be refilled
Do not propose ring to robots