### PR TITLE
Bug fixes

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -179,3 +179,20 @@
 	if (HAS_FLAGS(damage_flags, DAMAGE_FLAG_TURF_BREAKER))
 		damage *= 4
 	. = ..()
+
+/turf/simulated/verb/engrave()
+	set name = "Engrave floor"
+	set desc = "Writes a message on the floor."
+	set category = "Object"
+	set src in oview(1)
+
+	var/obj/item/I = usr.get_active_hand()
+	if(!I)
+		to_chat(usr, "<span class='notice'>You aren't holding anything to write with.</span>")
+		return
+
+	if (!can_touch(usr))
+		return
+
+	try_graffiti(usr, I)
+	return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -812,7 +812,7 @@
 
 		//Unbanning job list
 		//all jobs in job list are banned already OR we didn't give a reason (implying they shouldn't be banned)
-		if(length(bannedlist))
+		if(LAZYLEN(bannedlist))
 			if(!config.ban_legacy_system)
 				to_chat(usr, "Unfortunately, database based unbanning cannot be done through this panel")
 				DB_ban_panel(M.ckey)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -347,7 +347,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(COM))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -367,7 +368,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(SPT))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -388,7 +390,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(SEC))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -409,7 +412,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(ENG))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -430,7 +434,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(MED))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -451,7 +456,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(SCI))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -471,7 +477,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(EXP))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -491,7 +498,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(SRV))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -512,7 +520,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(SUP))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -533,7 +542,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(CIV))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -560,7 +570,8 @@
 		for(var/jobPos in SSjobs.titles_by_department(MSC))
 			if(!jobPos)	continue
 			var/datum/job/job = SSjobs.get_by_title(jobPos)
-			if(!job) continue
+			if(!job || (jobPos in job.alt_titles))
+				continue
 
 			if(jobban_isbanned(M, job.title))
 				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[SPAN_COLOR("red", replacetext(job.title, " ", "&nbsp"))]</a></td>"
@@ -734,9 +745,12 @@
 
 		//Create a list of unbanned jobs within job_list
 		var/list/notbannedlist = list()
+		var/list/bannedlist = list()
 		for(var/job in job_list)
 			if(!jobban_isbanned(M, job))
 				notbannedlist += job
+			else
+				bannedlist |= job
 
 		//Banning comes first
 		if(length(notbannedlist)) //at least 1 unbanned job exists in job_list so we have stuff to ban.
@@ -794,16 +808,17 @@
 						return 1
 				if("Cancel")
 					return
+			return
 
 		//Unbanning job list
 		//all jobs in job list are banned already OR we didn't give a reason (implying they shouldn't be banned)
-		if(LAZYLEN(SSjobs.titles_to_datums)) //at least 1 banned job exists in job list so we have stuff to unban.
+		if(length(bannedlist))
 			if(!config.ban_legacy_system)
 				to_chat(usr, "Unfortunately, database based unbanning cannot be done through this panel")
 				DB_ban_panel(M.ckey)
 				return
 			var/msg
-			for(var/job in SSjobs.titles_to_datums)
+			for(var/job in bannedlist)
 				var/reason = jobban_isbanned(M, job)
 				if(!reason) continue //skip if it isn't jobbanned anyway
 				switch(alert("Job: '[job]' Reason: '[reason]' Un-jobban?","Please Confirm","Yes","No"))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -361,6 +361,7 @@
 	name = "\improper CondiMaster 3000"
 	desc = "A machine pre-supplied with plastic condiment containers to bottle up reagents for use with foods."
 	production_options = CHEMMASTER_OPTIONS_CONDIMENTS
+	condi = TRUE
 
 /obj/machinery/chem_master/condimaster/get_chem_info(datum/reagent/reagent)
 	return ..(reagent, "Condiment Info", 0)

--- a/nano/templates/crew_records.tmpl
+++ b/nano/templates/crew_records.tmpl
@@ -50,11 +50,10 @@
 <br><br>
 <h2>Available records:</h2>
 <table style="width:100%">
-<tr><td style="width:40%">Name<th>Position<th>Rank
+<tr><td style="width:40%">Name<th>Position
 {{for data.all_records}}
 	<tr class="candystripe"><td>{{:helper.link(value.name, '', {'set_active' : value.id})}}
 	<td>{{:value.rank}}
-	<td>{{:value.milrank}}
 {{/for}}
 </table>
 {{/if}}


### PR DESCRIPTION
Tackles a few low-hanging bugs while I have a bit of spare time.

- Fixes #1352 - Caused by the subtype not setting the `condi` boolean
- Fixes #1381 - Deleted the "rank" header from the crew records nano program
- Fixes #1368 - This actually hurts my brain. Previously, clicking on a job to unban it would cause the code to **loop through every job in existence, check if they're banned, and unban them**. Rather than.. using the job passed to it in the href? This would not work for roles that aren't explicitly jobs, such as antag and special roles.
- Fixes unbanning categories in the unban panel - Related to above, it now populates a "unban" list, which it loops through and unbans. Early return added to clicking category headers, prioritising banning all if only some jobs in that category are previously banned.
- Removed duplicate job entries in the unban panel. It used to load all job titles, then output the job datum associated with it for each job title. A check has been added to make sure only the base job is listed, and alt-titles are ignored.
- Fixes #1411 - Caused by a regression during baymerge