### PR TITLE
Fixes MMI language transfer

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -111,6 +111,7 @@
 	brainmob.SetName(H.real_name)
 	brainmob.real_name = H.real_name
 	brainmob.dna = H.dna
+	brainmob.languages |= H.languages
 	brainmob.container = src
 
 	SetName("[initial(name)]: [brainmob.real_name]")

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -71,6 +71,7 @@
 		brainmob.real_name = H.real_name
 		brainmob.dna = H.dna.Clone()
 		brainmob.timeofhostdeath = H.timeofdeath
+		brainmob.languages |= H.languages
 
 	if(H.mind)
 		H.mind.transfer_to(brainmob)

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -156,9 +156,10 @@
 	stored_mmi.update_icon()
 	icon_state = stored_mmi.icon_state
 
-	owner.verbs += /mob/living/carbon/human/proc/eject_mmi
+	owner?.verbs += /mob/living/carbon/human/proc/eject_mmi
+	owner?.languages |= stored_mmi.brainmob.languages
 
-	if(owner && owner.stat == DEAD)
+	if(owner?.stat == DEAD)
 		owner.set_stat(CONSCIOUS)
 		owner.switch_from_dead_to_living_mob_list()
 		owner.visible_message(SPAN_DANGER("\The [owner] twitches visibly!"))


### PR DESCRIPTION
Fixes #1369 
On brain removal, a brainmob is created and the client is transferred to it. As languages are now stored in mobs rather than the mind datum (thanks bay), the body's languages are now transferred into the brainmob on creation.
On MMI insertion into a FBP, languages present in the brainmob are now transferred into the new body.