### PR TITLE
Fixes cyborg dropped stacks

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -196,7 +196,8 @@
 	if(!wrapped)
 		// Ensure fumbled items are accessible.
 		for(var/obj/item/thing in src.contents)
-			thing.dropInto(loc)
+			if(thing.canremove)
+				thing.dropInto(loc)
 		return
 
 	if(wrapped.loc != src)
@@ -205,7 +206,8 @@
 		return
 
 	to_chat(src.loc, SPAN_WARNING("You drop \the [wrapped]."))
-	wrapped.dropInto(loc)
+	if(wrapped.canremove)
+		wrapped.dropInto(loc)
 	wrapped = null
 	update_icon()
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -205,9 +205,12 @@
 		update_icon()
 		return
 
-	to_chat(src.loc, SPAN_WARNING("You drop \the [wrapped]."))
 	if(wrapped.canremove)
 		wrapped.dropInto(loc)
+		to_chat(src.loc, SPAN_WARNING("You drop \the [wrapped]."))
+	else
+		to_chat(src.loc, SPAN_NOTICE("You return \the [wrapped] to your internal storage."))
+
 	wrapped = null
 	update_icon()
 

--- a/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
@@ -44,7 +44,6 @@
 		/obj/item/taperoll/engineering,
 		/obj/item/taperoll/atmos,
 		/obj/item/gripper,
-		/obj/item/gripper,
 		/obj/item/gripper/no_use/loader,
 		/obj/item/device/lightreplacer,
 		/obj/item/device/paint_sprayer,


### PR DESCRIPTION
Closes #1457 

Caused by cyborg stacks being set to `canremove = FALSE`, meaning mobs cannot normally drop these. I explored allowing borgs to drop these, however, doing so allows for very broken behaviour.

For starters, the sheet loader doesn't _split_ on picking up the item, it simply references the same item. Meaning if you drop it, it's in _both_ the borg's inventory, as well as in the game world. 

Secondly, splitting these cyborg stacks spawns a _regular_ version of the material, meaning it now contains matter and bypasses the whole restriction on cyborg materials. So a regular mob who picks up one of these stacks, can split them almost infinitely (as it's bound to the borg still and uses charges, not amounts), and turns into regular metal. Oops.

Now if you drop one of these materials, it is simply unset from the gripper, freeing it back up


PR also removes a duplicate gripper from the engi borg