### PR TITLE
Fix missing null checks for examine + healthscanner

### DIFF
--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -114,9 +114,9 @@
 	var/breathing = "none"
 	if(H.should_have_organ(BP_LUNGS))
 		var/obj/item/organ/internal/lungs/lungs = H.internal_organs_by_name[BP_LUNGS]
-		if(H.status_flags & FAKEDEATH)
+		if(!lungs || H.status_flags & FAKEDEATH)
 			breathing = SPAN_CLASS("scan_danger", "none")
-		if(lungs.breath_fail_ratio < 0.3)
+		else if(lungs.breath_fail_ratio < 0.3)
 			breathing = "normal"
 		else if(lungs.breath_fail_ratio < 1)
 			breathing = SPAN_CLASS("scan_warning", "shallow")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -158,7 +158,7 @@
 				msg += E.species.disfigure_msg(src)
 			else //Just in case they lack a species for whatever reason.
 				msg += "[SPAN_WARNING("[P.His] face is horribly mangled!")]\n"
-		var/datum/robolimb/robohead = all_robolimbs[E.model]
+		var/datum/robolimb/robohead = all_robolimbs[E?.model]
 		if(length(robohead?.display_text) && facial_hair_style == "Text")
 			msg += "The message \"[robohead.display_text]\" is displayed on its screen.\n"
 


### PR DESCRIPTION
Fixes #1479 

Caused by missing null checks where the organs are expected to be present.