### PR TITLE
Fix landmarks not spawning correclty

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -137,9 +137,12 @@
 	if (delete_me)
 		return INITIALIZE_HINT_QDEL
 
-	var/list/options = typesof(/obj/effect/landmark/costume)
-	var/PICK= options[rand(1,length(options))]
-	new PICK(src.loc)
+/obj/effect/landmark/costume/random/Initialize()
+	var/list/landmarks = subtypesof(/obj/effect/landmark/costume)
+	landmarks -= /obj/effect/landmark/costume/random
+	var/landmark_path = pick(landmarks)
+	new landmark_path(src.loc)
+	. = ..()
 
 //SUBCLASSES.  Spawn a bunch of items and disappear likewise
 /obj/effect/landmark/costume/chameleon/Initialize()

--- a/maps/RandomZLevels/backup/negastation.dmm
+++ b/maps/RandomZLevels/backup/negastation.dmm
@@ -188,7 +188,7 @@
 "dF" = (/obj/effect/shadow_wight,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
 "dG" = (/mob/living/simple_animal/hostile/scarybat/cult,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
 "dH" = (/obj/item/storage/mirror{pixel_y = 28},/obj/structure/hygiene/sink{pixel_y = 17},/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
-"dI" = (/obj/structure/closet,/obj/effect/landmark/costume,/obj/effect/landmark/costume,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
+"dI" = (/obj/structure/closet,/obj/effect/landmark/costume/random,/obj/effect/landmark/costume/random,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
 "dJ" = (/obj/machinery/door/firedoor,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
 "dK" = (/obj/machinery/status_display{use_power = 0; mode = 2; message1 = "HELL"; density = 0; pixel_y = -30},/turf/unsimulated/floor{icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult-narsie"; light_color = "ff0000"; light_power = 2; light_range = 3; name = "engraved floor"},/area/space)
 "dL" = (/mob/living/simple_animal/hostile/faithless/cult,/turf/unsimulated/floor{icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult-narsie"; light_color = "ff0000"; light_power = 2; light_range = 3; name = "engraved floor"},/area/space)

--- a/maps/RandomZLevels/negastation.dmm
+++ b/maps/RandomZLevels/negastation.dmm
@@ -188,7 +188,7 @@
 "dF" = (/obj/effect/shadow_wight,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
 "dG" = (/mob/living/simple_animal/hostile/scarybat/cult,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
 "dH" = (/obj/item/storage/mirror{pixel_y = 28},/obj/structure/hygiene/sink{pixel_y = 17},/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
-"dI" = (/obj/structure/closet,/obj/effect/landmark/costume,/obj/effect/landmark/costume,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
+"dI" = (/obj/structure/closet,/obj/effect/landmark/costume/random,/obj/effect/landmark/costume/random,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
 "dJ" = (/obj/machinery/door/firedoor,/turf/unsimulated/floor{name = "engraved floor"; icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult"},/area/space)
 "dK" = (/obj/machinery/status_display{use_power = 0; mode = 2; message1 = "HELL"; density = 0; pixel_y = -30},/turf/unsimulated/floor{icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult-narsie"; light_color = "ff0000"; light_power = 2; light_range = 3; name = "engraved floor"},/area/space)
 "dL" = (/mob/living/simple_animal/hostile/faithless/cult,/turf/unsimulated/floor{icon = 'icons/turf/flooring/cult.dmi'; icon_state = "cult-narsie"; light_color = "ff0000"; light_power = 2; light_range = 3; name = "engraved floor"},/area/space)

--- a/maps/glloydstation/Glloydstation2-1.dmm
+++ b/maps/glloydstation/Glloydstation2-1.dmm
@@ -3542,13 +3542,13 @@
 /area/maintenance/fpmaint)
 "ahH" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "ahI" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "ahJ" = (
@@ -6811,8 +6811,8 @@
 /area/bridge/blueshield)
 "aoT" = (
 /obj/structure/closet,
-/obj/effect/landmark/costume,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "aoU" = (
@@ -19629,7 +19629,7 @@
 "aPG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleeping)
 "aPH" = (
@@ -28910,7 +28910,7 @@
 /area/crew_quarters/sleeping)
 "bhY" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleeping)
 "bhZ" = (
@@ -46869,7 +46869,7 @@
 /area/crew_quarters/theatre)
 "bRi" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -57992,7 +57992,7 @@
 /area/rnd/xenobiology)
 "cnv" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/kitchen)
 "cnw" = (
@@ -65283,7 +65283,7 @@
 /area/maintenance/atmos_control)
 "cCE" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/atmos_control)
 "cCF" = (
@@ -67617,7 +67617,7 @@
 /area/maintenance/asmaint2)
 "cHN" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cHO" = (
@@ -68330,7 +68330,7 @@
 /area/maintenance/cargo)
 "cJt" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "cJu" = (
@@ -72019,10 +72019,10 @@
 /area/maintenance/aft)
 "cQw" = (
 /obj/structure/closet,
-/obj/effect/landmark/costume,
-/obj/effect/landmark/costume,
-/obj/effect/landmark/costume,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
+/obj/effect/landmark/costume/random,
+/obj/effect/landmark/costume/random,
+/obj/effect/landmark/costume/random,
 /obj/item/toy/katana,
 /obj/item/gun/projectile/revolver/capgun,
 /obj/item/toy/sword,
@@ -76337,7 +76337,7 @@
 /area/maintenance/aft)
 "cZg" = (
 /obj/item/table_parts/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "cZh" = (
@@ -78971,7 +78971,7 @@
 /area/maintenance/disposal)
 "dei" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "dej" = (

--- a/maps/glloydstation/Glloydstation2-2.dmm
+++ b/maps/glloydstation/Glloydstation2-2.dmm
@@ -103,14 +103,14 @@
 /area/holodeck/source_picnicarea)
 "aar" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/holofloor{
 	icon_state = "cult";
 	dir = 2
 	},
 /area/holodeck/source_theatre)
 "aas" = (
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /obj/structure/table/rack,
 /turf/simulated/floor/holofloor{
 	icon_state = "cult";

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -360,13 +360,13 @@
 /area/maintenance/fourth_deck/afp)
 "aU" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "aV" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "aW" = (
@@ -19153,7 +19153,7 @@
 /area/medical/extstorage)
 "HB" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /obj/machinery/light/small/red/maintenance{
 	dir = 1;
 	icon_state = "firelight1"
@@ -22466,7 +22466,7 @@
 /area/command/bottom_hallway)
 "Sy" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /obj/random/hat,
 /obj/random/masks,
 /turf/simulated/floor/plating,

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -14879,7 +14879,7 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /obj/machinery/alarm{
 	pixel_y = 25
 	},

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -7118,7 +7118,7 @@
 /area/maintenance/first_deck/central)
 "np" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "nq" = (
@@ -7496,7 +7496,7 @@
 /area/maintenance/first_deck/central)
 "oa" = (
 /obj/structure/table/rack,
-/obj/effect/landmark/costume,
+/obj/effect/landmark/costume/random,
 /obj/item/device/flashlight,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)


### PR DESCRIPTION
Fixes #1392 

I spent too long on this, end me. The issue was clear as day.

Caused by `delete_me` being `TRUE` on the base type, meaning it _always_ returned on ln 138, making the random part of the code unreachable...

Split the randomness of it into its own subtype `/costume/random`, because previously all types would've also had spawned random landmarks during their init call, which is not the intended behaviour. Yay inheritance!