### PR TITLE
Secure Safes can now contain briefcases.

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -170,7 +170,6 @@
 	max_storage_space = 56
 	anchored = TRUE
 	density = FALSE
-	cant_hold = list(/obj/item/storage/secure/briefcase)
 	startswith = list(
 		/obj/item/paper = 1,
 		/obj/item/pen = 1


### PR DESCRIPTION
Currently the nuke disk spawns in a secure brief inside of the secure safe, there's no way to put the secure brief back in, if taken out.

Considering you can put the station account lockbox back into the secure safe, it makes sense that the briefcases can also go back into the safe, considering it spawns in there.