### PR TITLE
Using a scope is now a dedicated hotkey - [CTRL + T]

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -694,7 +694,7 @@ macro "hotkeymode"
 		name = "."
 		command = "move-down"
 	elem
-		name = "CTRL+V"
+		name = "CTRL+T"
 		command = "scope"
 
 macro "borgmacro"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -693,6 +693,9 @@ macro "hotkeymode"
 	elem
 		name = "."
 		command = "move-down"
+	elem
+		name = "CTRL+V"
+		command = "scope"
 
 macro "borgmacro"
 	elem


### PR DESCRIPTION
You can now unscope/scope without having to right click your weapon and go through the right click menu. This makes using scoped weapons not a test of how fast you can click Byond's awful menus.

I chose CTRL + V since it's close to the homerow and is easy to press quickly.