### PR TITLE
Ports Random Tip of the Round System to Round Start.

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -113,9 +113,9 @@ SUBSYSTEM_DEF(ticker)
 		return
 	if(round_progressing && last_fire)
 		pregame_timeleft -= world.time - last_fire
-	if(pregame_timeleft <= 300 && !tipped)
+	if(pregame_timeleft <= 30 SECONDS && !tipped)
 		send_random_tip()
-		tipped = 1
+		tipped = TRUE
 	if(pregame_timeleft <= 0)
 		Master.SetRunLevel(RUNLEVEL_SETUP)
 		return

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -404,16 +404,6 @@ Helpers
 	if(randomtips.len)
 		to_world(SPAN_GOOD("<b>Tip of the Round:</b>" + strip_html_properly(pick(randomtips))))
 
-	//				to_world(SPAN_NOTICE("<b>Rebooting due to destruction of [station_name()] in [restart_timeout/10] seconds</b>"))
-/*
-/datum/subsystem/ticker/proc/send_random_tip()
-	var/list/randomtips = file2list("config/tips.txt")
-	if(randomtips.len)
-		world << "<font color='purple'><b>Tip of the round: </b>[strip_html_properly(pick(randomtips))]</font>"
-
-*/
-
-
 /datum/controller/subsystem/ticker/proc/collect_minds()
 	for(var/mob/living/player in GLOB.player_list)
 		if(player.mind)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -26,6 +26,7 @@ SUBSYSTEM_DEF(ticker)
 	var/list/minds = list()         //Minds of everyone in the game.
 	var/list/antag_pool = list()
 	var/looking_for_antags = 0
+	var/tipped = FALSE
 
 	var/secret_force_mode = "secret"
 
@@ -112,6 +113,9 @@ SUBSYSTEM_DEF(ticker)
 		return
 	if(round_progressing && last_fire)
 		pregame_timeleft -= world.time - last_fire
+	if(pregame_timeleft <= 300 && !tipped)
+		send_random_tip()
+		tipped = 1
 	if(pregame_timeleft <= 0)
 		Master.SetRunLevel(RUNLEVEL_SETUP)
 		return
@@ -394,6 +398,20 @@ Helpers
 			continue
 		ready_players += player
 	return ready_players
+
+/datum/controller/subsystem/ticker/proc/send_random_tip()
+	var/list/randomtips = file2list("config/tips.txt")
+	if(randomtips.len)
+		to_world(SPAN_GOOD("<b>Tip of the Round:</b>" + strip_html_properly(pick(randomtips))))
+
+	//				to_world(SPAN_NOTICE("<b>Rebooting due to destruction of [station_name()] in [restart_timeout/10] seconds</b>"))
+/*
+/datum/subsystem/ticker/proc/send_random_tip()
+	var/list/randomtips = file2list("config/tips.txt")
+	if(randomtips.len)
+		world << "<font color='purple'><b>Tip of the round: </b>[strip_html_properly(pick(randomtips))]</font>"
+
+*/
 
 
 /datum/controller/subsystem/ticker/proc/collect_minds()

--- a/config/tips.txt
+++ b/config/tips.txt
@@ -1,0 +1,5 @@
+This is a test tip.
+This is a second test tip.
+This is a third test tip.
+Test Tip 4!
+This is a fifth test tip.

--- a/config/tips.txt
+++ b/config/tips.txt
@@ -1,101 +1,99 @@
-You can use fire extingushers as a makeshift jetpack in space.
+You can use fire extinguishers as a makeshift jetpack in space.
 Coins can be reused on vending machines if you add cable coil to make it a coin on a string.
 When loading a shotgun, racking the shotgun lets you load one additional shell.
 Standing still before firing improves your hit chance with firearms.
-Going into Aim Mode before firing a weapon strongly increases your chance to hit your target.
-Being chased going up a ladder? You can block ladders with objects, or yourself to prevent people climbing up.
+Going into Aim Mode before firing a weapon strongly increases your chance of hitting your target.
+Being chased up a ladder? You can block ladders with objects, or yourself to prevent people from climbing up.
 Paper can be held up to a camera to directly show the AI the contents, great for discreet messaging.
-Stuck in the center of a room with no gravity? Try throwing a object diagionally to move you in the opposite direction thrown.
+Stuck in the center of a room with no gravity? Try throwing an object diagonally to move you in the opposite direction thrown.
 Autolathes can be hacked to print a variety of different lethal ammo.
 Thermite is the poor man's all-access, if you don't mind leaving a few holes in walls.
 Fuel and Water tanks can be manually wrenched open, leaking the contents onto the floor.
 The Supermatter's integrity can be repaired with duct tape!
 Duct Tape is great for patching suit punctures from combat.
-Splints are easier to to attach to broken limbs if you have someone else do it.
+Splints are easier to attach to broken limbs if you have someone else do it.
 Coins let you buy a variety of premium vending goods.
 There is a variety of vendor goods that can only be obtained through hacking, or emagging.
 Experiment with Emagging! There is a huge variety of fun features unlocked by emagging items and equipment!
-Laptops and PDAs can install illict software if emagged, giving you access to cameras, DDosing NT Net and manually bruteforcing ID access.
+Laptops and PDAs can install illicit software if emagged, giving you access to cameras, DDoSing NT Net, and manually brute-forcing ID access.
 Certain plants effects when thrown can be scaled with the Potency gene they have.
 Most shuttles on vessels have a teleporter beacon installed on them, which is easily removable...
 Explosive implants can be set to detonate specific limbs, instead of full-body explosions.
-If you are in a really bad spot, self-surgery is better than no-surgery. Just make sure you have painkillers and the right tools, or close enough to the right tools.
+If you are in a really bad spot, self-surgery is better than no-surgery. Just make sure you have painkillers and the right tools, or are close enough to the right tools.
 You can buy coagulent and combat stimulants from the uplink to help keep you going during a gunfight.
-Weapons may be operated differently depending on their loading method, some may be magazine fed, pumped manually, bolt-action, et cetera.
+Weapons may be operated differently depending on their loading method; some may be magazine-fed, pumped manually, bolt-action, et cetera.
 You can quickly aim down the scope of a weapon using CTRL + T.
 Signallers can be manually attached to doors, letting you trigger the input of one specific wire.
 Sunglasses aren't just for looking cool, they will protect you from a lot of different flash-based stuns.
 You can craft improvised armor vests using a hazard vest, metal sheets and cable coil.
-When dealing with a threat, consider what weaponry they have been seen with, ballistic, albative and riot armor have different values that can increase your survivability.
-Painkillers can increase your survivability against injuries that may of otherwise put you into a Pain Critical state, but be careful of overdose.
+When dealing with a threat, consider what weaponry they have been seen with; ballistic, ablative and riot armor have different values that can increase your survivability.
+Painkillers can increase your survivability against injuries that may have otherwise put you into a pain-critical state, but be careful of overdose.
 Chemical reagents can be ground down into a powder using an ID card, and snorted using thaler notes.
 Spiders cocoon any deceased bodies they come across, remember to smash them open.
-Zipguns will take a random ammo cartidge when created, it may be wise to make another if you don't get the ammo type you want.
+Zipguns will take a random ammo cartridge when created, it may be wise to make another if you don't get the ammo type you want.
 Crossbows can impale people into walls!
 Synthetics do not feel pain, and cannot be put into a pain critical state.
 Synthetics, Mechs and Cyborgs can be easily dealt with using ionic weaponry.
-Synthetics can still function without a head, as their brain is installed in the chest.
+Some synthetics can still function without a head, as their brain may be located in their chest.
 Vox can consume a majority of commonly inedible chemicals and turn them into nutriment.
 Vox need nitrogen to breathe and will suffocate without it. Make sure to keep their air tank on them.
-Maintenance drones are deactivatable using your ID Card.
+Maintenance drones can be deactivated using your ID Card.
 Sometimes when the odds are stacked against you it's better to surrender than die.
 Toilet cisterns can store a plethora of different items if crowbarred open, just make sure to close them afterwards.
-Toilet mirrors can be opened using Alt + Click, you can store items discreetly inside.
+Toilet mirrors can be opened using Alt + Click - you can store items discreetly inside.
 Disposal outlets make for great hidden storage provided you turn the pumps off.
 Riding down disposal chutes is a great way to end up in the Mourge.
 Enabling the neural lace option will allow you to be cloned, instead of being transferred to a synthetic body or borged.
-Pirate vessels come in sizes and armament. It's good to consider how well-armed you are for a fight.
+Pirate vessels come in various sizes and armament. It's good to consider how well-armed you are for a fight.
 Pirate vessels usually contain a vault full of materials and loot, it's always worthwhile boarding them.
-Critically low blood-levels will cause brain damage. Iron + Sugar pills, IV drips with blood and eating food will help you restore blood levels.
-Lasers will cause burn damage and remove blood in your body.
+Critically low blood levels will cause brain damage. Iron + sugar pills, IV drips with blood, and eating food will help you restore blood levels faster.
+Lasers will cause burn damage and remove blood from your body.
 Exposure to low air environments will cause your lungs to collapse, always wear internals in low air environments to combat this.
-Not all exo-planets will have a breathable atmosphere, or safe temperatures. Shuttles will often have a sensor console that will have data to reflect the atmosphere.
-Some exo-planets may have flammable atmospheres, laser weaponry, smoking and gun-fire may set areas, or the entire planet on fire.
-Long-Range Holocommunicators allow you to talk to other vessels in the sector, provided someone is around on the other end to reply.
-Short-wave radios allow you to communicate with each-other in areas without telecommunications.
-Abandoned and derelict ruins may hold ancient treasures, or horrors.
+Not all exoplanets will have a breathable atmosphere or safe temperatures. Shuttles will often have a sensor console that will have data to reflect the atmosphere.
+Some exoplanets may have flammable atmospheres; laser weaponry, smoking, and gunfire may set areas, or the entire planet, on fire.
+Long-range Holocommunicators allow you to talk to other vessels in the sector, provided someone is around at the other end to reply. However, each hologram consumes twice as much power as their shorter-range counterparts.
+Short-wave radios allow you to communicate with each other in areas without telecommunications.
+Abandoned and derelict ruins may hold ancient treasures or horrors.
 No two alien anomalies will have the same activation state, use the anomaly computer to analyze and outline what you may need to do to activate them.
-It is considered poor taste to decapitate someone and keep their neural lace, always give people a chance to come back into the round in some way.
-Straightjackets and Electropacks should never be used without admin approval, as they are impossible to get out of.
 Stowaways have a chance to be spawnable after the round starts, however as a Stowaway you won't be defined on the crew manifest or have any ID.
-Most ship AI will start with the manifest lawset, making it follow orders of crew on the ship manifest, as defined by the Captain.
-Ionispheric anomalies may cause AI's to gain new laws, making them act in unusual or fun manners.
-You can use Intellicards to card AI's into a portable state, allowing them to be repaired and have their lawsets visible.
-Rule Lawyering as an AI or Borg with lawsets or custom lawsets defined by antagonists is not fun for anyone.
-Rule Lawering as a imprint implanted person is not fun for anyone, especially the antagonist who used it on you.
-When you are cloned, you forget the last 5 minutes of the events leading up to your death.
+Most ship AI will start with the manifest lawset, making it follow the orders of the crew on the ship manifest, as defined by the Captain.
+Ionospheric anomalies may cause AIs to gain new laws, making them act in unusual or fun manners.
+You can use Intellicards to card AIs into a portable state, allowing them to be repaired and have their lawsets visible.
+Nitpicking laws as an AI or Borg with lawsets or custom lawsets defined by antagonists is not fun for anyone.
+Nitpicking laws as an imprint-implanted person is not fun for anyone, especially the antagonist who used it on you.
+When you are revived, you forget the last 5 minutes of the events leading up to your death.
 Find a bug, want to give feedback or a feature suggestion? Go to our Github Page - https://github.com/UristMcStation/UristMcStation/issues and write it up!
 The best antagonist rounds usually tend to include most players in someway.
 Losing is !FUN!, each round lost is a lesson to learn and apply for the next round.
-Changelings can take peoples voices, appearance and memories.
-Bluespace Revenants will slowly distort overtime without creating runes and feeding on blood.
-Fire Extingushers can be used to wet floors to slip people with.
+Changelings can assume people's voices, appearance and memories.
+Bluespace Revenants will slowly distort over time without quelling their hunger.
+Fire extinguishers can be used to wet floors to slip people with.
 You can remove fingerprints on objects by using a rag on them.
 You may leave partial fingerprints with specific types of gloves.
-You may leave fibers of identifiable clothing on any object you interact with, swapping to less identifable clothing is always wise before doing something bad.
-Flashers can repeatidly stun cyborgs and disable their movement and tools.
+You may leave fibers of identifiable clothing on any object you interact with; swapping to less identifiable clothing is always wise before doing something nefarious.
+Flashers can repeatedly stun cyborgs and disable their movement and tools.
 Emagging a cyborg only unlocks their access panel, and does not upload custom laws.
 You can redirect package-wrapped items using the delivery tagger and deliver them to a specific area.
 Items can be thrown down Z-levels to unsuspecting people below.
 Screwdrivers allow you to change the timers on a grenade to detonate at different times.
-Insulated Gloves can be redyed to another colour using a crayon in the washing machine.
-Budget Insulated Gloves will either reduce or multiply the amount of electrical shock damage you get.
-Leaving the Emitter on in the Engine Room is a unwise decision.
-Emagging the Fax Machine lets you send messages to syndicate contacts.
+Insulated gloves can be redyed to another colour using a crayon in the washing machine.
+Budget insulated gloves will either reduce or multiply the amount of electrical shock damage you get.
+Leaving the Emitter on in the Engine Room is usually an unwise decision.
+Emagging a fax machine lets you send messages to syndicate contacts.
 Praying to the gods may grant you all sorts of boons, or just a cookie.
 The best judgements are always made on the decision of a magic 8-ball.
-It is good practice to remove a victim's headset and turn-off their suit sensors while they are still alive, to avoid medbay or security noticing.
-You can disguise yourself to look like a cyborg by wearing a cardboard helmet and cardboard suit and can control what sprite dependant on your backpack.
-Gunshots and cleaned blood will leave residue which can be found using the Detective's luminol sprayer.
-You can put your PDA in your ID slot and insert you ID into it in order to save space.
-You can delete emails sent to you on your PDA, but they will still be visible on the PDA Messanger Server in Engineering.
-The camera is the AI's eyes, if the AI is rogue, it is wise to disable the camera nearby to prevent them for seeing you.
+It is good practice to remove a victim's headset and turn off their suit sensors while they are still alive, to avoid medbay or security noticing.
+You can disguise yourself to look like a cyborg by wearing a cardboard helmet and cardboard suit; you can control what sprite is used depending on your backpack.
+Gunshots and cleaned blood will leave a residue which can be found using the Detective's luminol sprayer.
+You can put your PDA in your ID slot and insert your ID into it to save space.
+You can delete emails sent to you on your PDA, but they will still be visible on the PDA Messenger Server in Telecommunications.
+The camera is the AI's eyes, if the AI is rogue, it is wise to disable any cameras nearby to prevent them from seeing you.
 You can replace the pen in your PDA with other pens, such as para-pens.
-You can replace walls with false-walls, these walls however will not carry over any paint applied above it.
+You can replace walls with false walls, these walls however will not carry over any paint applied above it.
 You can fill bottles with welding fuel and stuff them with a rag to create a molotov.
 The Bluespace Drive is destructible and can create horrible anomalies if destroyed when the ship is jumping.
-You can respawn back into the round after 10 minutes, but remember to spawn as a different character with the memories of what has occured already in the round.
-Torpedo Warheads can be re-wired into a portable IED with a time-delay, make sure you find the detonator wire before disabling the safeties.
+You can respawn back into the round after 10 minutes, but remember to spawn as a different character which has not already died in the round. You must not use the memories of your dead characters to your advantage, doing so will result in staff action.
+Torpedo Warheads can be re-wired into a portable IED with a time delay; make sure you find the detonator wire before disabling the safeties.
 Always tuck the nuclear authentication into bed, sleep tight disky.
 You can use an E-Sword to saw through secured suitcases.
 You can use a multi-tool to reset secure devices if you need to access them without the code.
@@ -104,33 +102,33 @@ The cryo-chambers will always contain a crowbar in the lockers to allow you to e
 You will always spawn with an inaprovaline auto-injector and gauze. Use this to keep yourself awake and staunch bleeding if attacked until you go to medbay.
 You can escape welded lockers by resisting inside of them.
 You can add metal into soda-can IEDs to increase the amount of shrapnel created when detonated.
-The best hiding spaces for stolen or illict items can often be in plain sight: O2 lockers, disposals, toolboxes and closets can all serve as great places to store items.
+The best hiding spaces for stolen or illicit items can often be in plain sight: O2 lockers, disposals, toolboxes and closets can all serve as great places to store items.
 Smugglers Satchels can be hidden underneath a floor tile, making a great small stash for supplies.
 The Nuclear Authentication disk can be tracked with the pinpointer device, making stealing it incredibly risky.
-Smart weaponry can be location tracked using the use-of-force computer software, always be careful when stealing smart weapons.
-Taking a GPS with you when going on Away Missions will increase the likelyhood of being found if deceased.
-Going into space while an EVA Ban is in effect is a good way to go missing for the rest of the round.
-The Trajan, Antonine and Hadrian can all independantly explore sectors without the ICS Nerva, just ensure to bring a canister for thrust fuel.
-There is a emergency entrance somewhat far from the Permanent Brig - if prepared well enough, you could just reach it.
-It is good to plan to get caught, especially if committing a grand-crime, as this gives you time to stash escape items.
+Smart weaponry can be location-tracked using the use-of-force computer software, always be careful when stealing smart weapons.
+Taking a GPS with you when going on away missions will increase the likelihood of being found if deceased.
+Going into space while an EVA ban is in effect is a good way to go missing for the rest of the round.
+The Trajan, Antonine and Hadrian can all independently explore sectors without the ICS Nerva, just ensure to bring a canister for thrust fuel.
+There is an emergency entrance somewhat far from the Permanent Brig - if prepared well enough, you could just reach it.
+It is good to plan to get caught, especially if committing a grand crime, as this gives you time to stash escape items.
 The Singularity and Supermatter should never touch.
 Dionae are unable to commit violent acts.
-Unathi are negatively affected by consuming food or drink with sugar.
+Unathi are negatively affected by consuming food or drinks that contain sugar.
 Lifts are great at going up and down Z-levels, but it's a good idea not to put anything below them.
 Different gas mixes will affect how the Supermatter generates heat and cools, it's always good to ask the Chief Engineer how it works.
 Hacking the access wire on a vending machine will allow you to purchase items without the needed access level.
-Chameleon projectors are most effective when projecting a small or tiny item, such as a ciggarette butt, try to match the environment you are in.
+Chameleon projectors are most effective when projecting a small or tiny item, such as a cigarette butt, try to match the environment you are in.
 Glass shards will cause pain and knock you down if you aren't wearing shoes.
 Certain gloves won't fit species without being manually adjusted with wirecutters.
 Use the ship's holomaps if you want to get your bearings.
-The AI cannot AI if you take it's power...
+The AI cannot AI if you take its power...
 The Clown's Noisemaker can make a variety of discreet or annoying sounds, use this to distract someone, make a panic or just have fun!
-You can disable lobby music, ship hum ambience and admin MIDIs using the preference tab.
-Using your PDA infront of someone will make a audible sound and emote, so it's unwise to use it in a dangerous situation.
+You can disable lobby music, ship hum ambience, and admin MIDIs from within the preference tab.
+Using your PDA in front of someone will make an audible sound and emote, so it's unwise to use it in a dangerous situation.
 Traitors will spawn with codewords, you can use these words with potential collaborators to identify if they are syndicate agents.
-As a Team Antagonist, always work together with your fellow antagonists, selling your team out or stating who they are over comms immediatley is against the rules.
-Traitors do not have to mutally work together and could easily backstab on another.
-Changelings can spawn as jobs that might otherwise not be spawnable as traitor antagonist, such as Detectives, Second Officers, etc.
+As a team antagonist, always work together with your fellow antagonists; selling your team out or stating who they are over comms immediately is against the rules.
+Traitors do not have to mutually work together and could easily backstab one another.
+Changelings can spawn as jobs that might otherwise not be spawn-able as a Traitor antagonist; such as Detectives, Second Officers, etc.
 Floor Tiles can be sharpened using a wirecutter to create a more deadly thrown projectile.
-Spacesuits have injection ports to administer medicine safely while in low-pressure.
+Spacesuits have injection ports to administer medicine safely while in low pressure environments. These however take extra time to use.
 Setting your suit sensors to maximum isn't a good idea if you are an antagonist, as medbay can track wherever you go.

--- a/config/tips.txt
+++ b/config/tips.txt
@@ -1,5 +1,136 @@
-This is a test tip.
-This is a second test tip.
-This is a third test tip.
-Test Tip 4!
-This is a fifth test tip.
+You can use fire extingushers as a makeshift jetpack in space.
+Coins can be reused on vending machines if you add cable coil to make it a coin on a string.
+When loading a shotgun, racking the shotgun lets you load one additional shell.
+Standing still before firing improves your hit chance with firearms.
+Going into Aim Mode before firing a weapon strongly increases your chance to hit your target.
+Being chased going up a ladder? You can block ladders with objects, or yourself to prevent people climbing up.
+Paper can be held up to a camera to directly show the AI the contents, great for discreet messaging.
+Stuck in the center of a room with no gravity? Try throwing a object diagionally to move you in the opposite direction thrown.
+Autolathes can be hacked to print a variety of different lethal ammo.
+Thermite is the poor man's all-access, if you don't mind leaving a few holes in walls.
+Fuel and Water tanks can be manually wrenched open, leaking the contents onto the floor.
+The Supermatter's integrity can be repaired with duct tape!
+Duct Tape is great for patching suit punctures from combat.
+Splints are easier to to attach to broken limbs if you have someone else do it.
+Coins let you buy a variety of premium vending goods.
+There is a variety of vendor goods that can only be obtained through hacking, or emagging.
+Experiment with Emagging! There is a huge variety of fun features unlocked by emagging items and equipment!
+Laptops and PDAs can install illict software if emagged, giving you access to cameras, DDosing NT Net and manually bruteforcing ID access.
+Certain plants effects when thrown can be scaled with the Potency gene they have.
+Most shuttles on vessels have a teleporter beacon installed on them, which is easily removable...
+Explosive implants can be set to detonate specific limbs, instead of full-body explosions.
+If you are in a really bad spot, self-surgery is better than no-surgery. Just make sure you have painkillers and the right tools, or close enough to the right tools.
+You can buy coagulent and combat stimulants from the uplink to help keep you going during a gunfight.
+Weapons may be operated differently depending on their loading method, some may be magazine fed, pumped manually, bolt-action, et cetera.
+You can quickly aim down the scope of a weapon using CTRL + T.
+Signallers can be manually attached to doors, letting you trigger the input of one specific wire.
+Sunglasses aren't just for looking cool, they will protect you from a lot of different flash-based stuns.
+You can craft improvised armor vests using a hazard vest, metal sheets and cable coil.
+When dealing with a threat, consider what weaponry they have been seen with, ballistic, albative and riot armor have different values that can increase your survivability.
+Painkillers can increase your survivability against injuries that may of otherwise put you into a Pain Critical state, but be careful of overdose.
+Chemical reagents can be ground down into a powder using an ID card, and snorted using thaler notes.
+Spiders cocoon any deceased bodies they come across, remember to smash them open.
+Zipguns will take a random ammo cartidge when created, it may be wise to make another if you don't get the ammo type you want.
+Crossbows can impale people into walls!
+Synthetics do not feel pain, and cannot be put into a pain critical state.
+Synthetics, Mechs and Cyborgs can be easily dealt with using ionic weaponry.
+Synthetics can still function without a head, as their brain is installed in the chest.
+Vox can consume a majority of commonly inedible chemicals and turn them into nutriment.
+Vox need nitrogen to breathe and will suffocate without it. Make sure to keep their air tank on them.
+Maintenance drones are deactivatable using your ID Card.
+Sometimes when the odds are stacked against you it's better to surrender than die.
+Toilet cisterns can store a plethora of different items if crowbarred open, just make sure to close them afterwards.
+Toilet mirrors can be opened using Alt + Click, you can store items discreetly inside.
+Disposal outlets make for great hidden storage provided you turn the pumps off.
+Riding down disposal chutes is a great way to end up in the Mourge.
+Enabling the neural lace option will allow you to be cloned, instead of being transferred to a synthetic body or borged.
+Pirate vessels come in sizes and armament. It's good to consider how well-armed you are for a fight.
+Pirate vessels usually contain a vault full of materials and loot, it's always worthwhile boarding them.
+Critically low blood-levels will cause brain damage. Iron + Sugar pills, IV drips with blood and eating food will help you restore blood levels.
+Lasers will cause burn damage and remove blood in your body.
+Exposure to low air environments will cause your lungs to collapse, always wear internals in low air environments to combat this.
+Not all exo-planets will have a breathable atmosphere, or safe temperatures. Shuttles will often have a sensor console that will have data to reflect the atmosphere.
+Some exo-planets may have flammable atmospheres, laser weaponry, smoking and gun-fire may set areas, or the entire planet on fire.
+Long-Range Holocommunicators allow you to talk to other vessels in the sector, provided someone is around on the other end to reply.
+Short-wave radios allow you to communicate with each-other in areas without telecommunications.
+Abandoned and derelict ruins may hold ancient treasures, or horrors.
+No two alien anomalies will have the same activation state, use the anomaly computer to analyze and outline what you may need to do to activate them.
+It is considered poor taste to decapitate someone and keep their neural lace, always give people a chance to come back into the round in some way.
+Straightjackets and Electropacks should never be used without admin approval, as they are impossible to get out of.
+Stowaways have a chance to be spawnable after the round starts, however as a Stowaway you won't be defined on the crew manifest or have any ID.
+Most ship AI will start with the manifest lawset, making it follow orders of crew on the ship manifest, as defined by the Captain.
+Ionispheric anomalies may cause AI's to gain new laws, making them act in unusual or fun manners.
+You can use Intellicards to card AI's into a portable state, allowing them to be repaired and have their lawsets visible.
+Rule Lawyering as an AI or Borg with lawsets or custom lawsets defined by antagonists is not fun for anyone.
+Rule Lawering as a imprint implanted person is not fun for anyone, especially the antagonist who used it on you.
+When you are cloned, you forget the last 5 minutes of the events leading up to your death.
+Find a bug, want to give feedback or a feature suggestion? Go to our Github Page - https://github.com/UristMcStation/UristMcStation/issues and write it up!
+The best antagonist rounds usually tend to include most players in someway.
+Losing is !FUN!, each round lost is a lesson to learn and apply for the next round.
+Changelings can take peoples voices, appearance and memories.
+Bluespace Revenants will slowly distort overtime without creating runes and feeding on blood.
+Fire Extingushers can be used to wet floors to slip people with.
+You can remove fingerprints on objects by using a rag on them.
+You may leave partial fingerprints with specific types of gloves.
+You may leave fibers of identifiable clothing on any object you interact with, swapping to less identifable clothing is always wise before doing something bad.
+Flashers can repeatidly stun cyborgs and disable their movement and tools.
+Emagging a cyborg only unlocks their access panel, and does not upload custom laws.
+You can redirect package-wrapped items using the delivery tagger and deliver them to a specific area.
+Items can be thrown down Z-levels to unsuspecting people below.
+Screwdrivers allow you to change the timers on a grenade to detonate at different times.
+Insulated Gloves can be redyed to another colour using a crayon in the washing machine.
+Budget Insulated Gloves will either reduce or multiply the amount of electrical shock damage you get.
+Leaving the Emitter on in the Engine Room is a unwise decision.
+Emagging the Fax Machine lets you send messages to syndicate contacts.
+Praying to the gods may grant you all sorts of boons, or just a cookie.
+The best judgements are always made on the decision of a magic 8-ball.
+It is good practice to remove a victim's headset and turn-off their suit sensors while they are still alive, to avoid medbay or security noticing.
+You can disguise yourself to look like a cyborg by wearing a cardboard helmet and cardboard suit and can control what sprite dependant on your backpack.
+Gunshots and cleaned blood will leave residue which can be found using the Detective's luminol sprayer.
+You can put your PDA in your ID slot and insert you ID into it in order to save space.
+You can delete emails sent to you on your PDA, but they will still be visible on the PDA Messanger Server in Engineering.
+The camera is the AI's eyes, if the AI is rogue, it is wise to disable the camera nearby to prevent them for seeing you.
+You can replace the pen in your PDA with other pens, such as para-pens.
+You can replace walls with false-walls, these walls however will not carry over any paint applied above it.
+You can fill bottles with welding fuel and stuff them with a rag to create a molotov.
+The Bluespace Drive is destructible and can create horrible anomalies if destroyed when the ship is jumping.
+You can respawn back into the round after 10 minutes, but remember to spawn as a different character with the memories of what has occured already in the round.
+Torpedo Warheads can be re-wired into a portable IED with a time-delay, make sure you find the detonator wire before disabling the safeties.
+Always tuck the nuclear authentication into bed, sleep tight disky.
+You can use an E-Sword to saw through secured suitcases.
+You can use a multi-tool to reset secure devices if you need to access them without the code.
+You will always spawn with an oxygen mask and tank, use this in emergencies with low air.
+The cryo-chambers will always contain a crowbar in the lockers to allow you to escape if the doors are unpowered.
+You will always spawn with an inaprovaline auto-injector and gauze. Use this to keep yourself awake and staunch bleeding if attacked until you go to medbay.
+You can escape welded lockers by resisting inside of them.
+You can add metal into soda-can IEDs to increase the amount of shrapnel created when detonated.
+The best hiding spaces for stolen or illict items can often be in plain sight: O2 lockers, disposals, toolboxes and closets can all serve as great places to store items.
+Smugglers Satchels can be hidden underneath a floor tile, making a great small stash for supplies.
+The Nuclear Authentication disk can be tracked with the pinpointer device, making stealing it incredibly risky.
+Smart weaponry can be location tracked using the use-of-force computer software, always be careful when stealing smart weapons.
+Taking a GPS with you when going on Away Missions will increase the likelyhood of being found if deceased.
+Going into space while an EVA Ban is in effect is a good way to go missing for the rest of the round.
+The Trajan, Antonine and Hadrian can all independantly explore sectors without the ICS Nerva, just ensure to bring a canister for thrust fuel.
+There is a emergency entrance somewhat far from the Permanent Brig - if prepared well enough, you could just reach it.
+It is good to plan to get caught, especially if committing a grand-crime, as this gives you time to stash escape items.
+The Singularity and Supermatter should never touch.
+Dionae are unable to commit violent acts.
+Unathi are negatively affected by consuming food or drink with sugar.
+Lifts are great at going up and down Z-levels, but it's a good idea not to put anything below them.
+Different gas mixes will affect how the Supermatter generates heat and cools, it's always good to ask the Chief Engineer how it works.
+Hacking the access wire on a vending machine will allow you to purchase items without the needed access level.
+Chameleon projectors are most effective when projecting a small or tiny item, such as a ciggarette butt, try to match the environment you are in.
+Glass shards will cause pain and knock you down if you aren't wearing shoes.
+Certain gloves won't fit species without being manually adjusted with wirecutters.
+Use the ship's holomaps if you want to get your bearings.
+The AI cannot AI if you take it's power...
+The Clown's Noisemaker can make a variety of discreet or annoying sounds, use this to distract someone, make a panic or just have fun!
+You can disable lobby music, ship hum ambience and admin MIDIs using the preference tab.
+Using your PDA infront of someone will make a audible sound and emote, so it's unwise to use it in a dangerous situation.
+Traitors will spawn with codewords, you can use these words with potential collaborators to identify if they are syndicate agents.
+As a Team Antagonist, always work together with your fellow antagonists, selling your team out or stating who they are over comms immediatley is against the rules.
+Traitors do not have to mutally work together and could easily backstab on another.
+Changelings can spawn as jobs that might otherwise not be spawnable as traitor antagonist, such as Detectives, Second Officers, etc.
+Floor Tiles can be sharpened using a wirecutter to create a more deadly thrown projectile.
+Spacesuits have injection ports to administer medicine safely while in low-pressure.
+Setting your suit sensors to maximum isn't a good idea if you are an antagonist, as medbay can track wherever you go.

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -30,7 +30,7 @@ exactly 2 "/datum text paths" '"/datum'
 exactly 2 "/mob text paths" '"/mob'
 exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
-exactly 139 "to_world uses" '\sto_world\('
+exactly 140 "to_world uses" '\sto_world\('
 exactly 0 "globals with leading /" '^/var' -P
 exactly 0 "globals without global sugar" '^var/(?!global/)' -P
 exactly 0 "apparent paths with trailing /" '\w/[,\)\n]' -P


### PR DESCRIPTION
Ports setup of tip sub-system that allows for random Round Start tips - Enabled in the config/tips.txt file.

A mix of /TG/ code and a bit of my own minor code changes to get it inline with Bay's formatting standards

It fires once, 30 seconds before round start, with a nice green text, and won't repeat if the round didn't start (due to not being ready, etc.)