### PR TITLE
Adjusts Game Vendor Stock

### DIFF
--- a/code/game/machinery/vending/games.dm
+++ b/code/game/machinery/vending/games.dm
@@ -47,16 +47,16 @@
 		/obj/item/storage/box/checkers/chess/red = 2,
 		/obj/item/storage/box/checkers/chess = 2,
 		/obj/item/board = 2,
-		/obj/item/storage/fancy/crayons = 3
+		/obj/item/storage/fancy/crayons = 3,
+		/obj/item/ammo_magazine/caps = 5
 	)
 	contraband = list(
 		/obj/item/reagent_containers/spray/waterflower = 2,
-		/obj/item/storage/box/snappops = 3,
 		/obj/item/toy/sword = 3,
-		/obj/item/toy/katana = 3,
-		/obj/item/gun/projectile/revolver/capgun = 1,
-		/obj/item/ammo_magazine/caps = 4
+		/obj/item/toy/katana = 3
 	)
 	premium = list(
-		/obj/item/spirit_board = 1
+		/obj/item/spirit_board = 1,
+		/obj/item/gun/projectile/revolver/capgun = 1,
+		/obj/item/storage/box/snappops = 3
 	)


### PR DESCRIPTION
You can now buy cap gun rounds normally without hacking the vendor.

You can use a coin to buy a capgun now, instead of having to hack the vendor

You can use a coin to buy snap pops now, instead of hacking, or just buy them at the cargo vend.