### PR TITLE
Heavy Sniper now correctly has a open-bolt sound.

### DIFF
--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -50,8 +50,10 @@
 		if(chambered)
 			to_chat(user, SPAN_NOTICE("You work the bolt open, ejecting [chambered]!"))
 			unload_shell()
+
 		else
 			to_chat(user, SPAN_NOTICE("You work the bolt open."))
+			playsound(src.loc, 'sound/weapons/guns/interaction/rifle_boltback.ogg', 50, 1)
 	else
 		to_chat(user, SPAN_NOTICE("You work the bolt closed."))
 		playsound(src.loc, 'sound/weapons/guns/interaction/rifle_boltforward.ogg', 50, 1)


### PR DESCRIPTION
The Heavy Sniper did not have a bolt opening sound if there wasn't a round being ejected, it now correctly plays a bolt opening sound regardless of shell ejection.