### PR TITLE
Assistants now have access again to Tool Storage.

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -7,9 +7,12 @@
 	spawn_positions = -1
 	supervisors = "absolutely everyone"
 	economic_power = 1
-	access = list()
+	access = list(access_prim_tool) // Fixing Urist Access issues, and removing the below access shit.
 	alt_titles = list("Technical Assistant","Medical Intern","Research Assistant","Visitor")
 	outfit_type = /singleton/hierarchy/outfit/job/assistant
 
+/*
 /datum/job/assistant/get_access()
 	return list()
+
+This totally fucks with Nerva Access, so it's uncommented for now. - Y*/

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -7,7 +7,7 @@
 	spawn_positions = -1
 	supervisors = "absolutely everyone"
 	economic_power = 1
-	access = list(access_prim_tool) // Fixing Urist Access issues, and removing the below access shit.
+	access = list() // Fixing Urist Access issues, and removing the below access shit.
 	alt_titles = list("Technical Assistant","Medical Intern","Research Assistant","Visitor")
 	outfit_type = /singleton/hierarchy/outfit/job/assistant
 

--- a/maps/nerva/datums/nerva_jobs.dm
+++ b/maps/nerva/datums/nerva_jobs.dm
@@ -312,13 +312,16 @@
 //misc
 
 /datum/job/assistant
-	supervisors = "the second officer"
+	title = "Assistant"
+	supervisors = "everyone"
 	access = list(access_prim_tool)
+	outfit_type = /singleton/hierarchy/outfit/job/nerva/assistant
 	alt_titles = list(
 	"Technical Assistant","Medical Intern","Cargo Assistant",
 	"Botanist" = /singleton/hierarchy/outfit/job/service/gardener,
 	"Librarian" = /singleton/hierarchy/outfit/job/librarian,
-	"Journalist" = /singleton/hierarchy/outfit/job/librarian
+	"Journalist" = /singleton/hierarchy/outfit/job/librarian,
+	minimal_player_age = 0
 	)
 
 /datum/job/assistant/get_description_blurb()

--- a/maps/nerva/datums/nerva_outfits.dm
+++ b/maps/nerva/datums/nerva_outfits.dm
@@ -218,3 +218,8 @@
 	shoes = /obj/item/clothing/shoes/black
 	id_types = list(/obj/item/card/id)
 	pda_type = /obj/item/modular_computer/pda
+
+// assistant - mainly for tool storage.
+/singleton/hierarchy/outfit/job/nerva/assistant
+	name = OUTFIT_JOB_NAME("Nerva Assistant")
+	id_types = list(/obj/item/card/id/civillian/nerva_assistant)

--- a/maps/nerva/datums/nerva_outfits.dm
+++ b/maps/nerva/datums/nerva_outfits.dm
@@ -222,4 +222,4 @@
 // assistant - mainly for tool storage.
 /singleton/hierarchy/outfit/job/nerva/assistant
 	name = OUTFIT_JOB_NAME("Nerva Assistant")
-	id_types = list(/obj/item/card/id/civillian/nerva_assistant)
+	id_types = list(/obj/item/card/id/civilian/nerva_assistant)

--- a/maps/nerva/obj/nerva_ids.dm
+++ b/maps/nerva/obj/nerva_ids.dm
@@ -50,3 +50,9 @@
 
 /obj/item/card/id/medical/psychiatrist/nerva
 	job_access_type = /datum/job/psychiatrist
+
+/obj/item/card/id/civillian/nerva_assistant
+	name = "identification card"
+	desc = "A card issued to the ship's assistant"
+	detail_color = COLOR_CIVIE_GREEN
+	job_access_type = /datum/job/assistant

--- a/maps/nerva/obj/nerva_ids.dm
+++ b/maps/nerva/obj/nerva_ids.dm
@@ -51,7 +51,7 @@
 /obj/item/card/id/medical/psychiatrist/nerva
 	job_access_type = /datum/job/psychiatrist
 
-/obj/item/card/id/civillian/nerva_assistant
+/obj/item/card/id/civilian/nerva_assistant
 	name = "identification card"
 	desc = "A card issued to the ship's assistant"
 	detail_color = COLOR_CIVIE_GREEN


### PR DESCRIPTION
Assistants no longer have to B&E speedrun instantly.
They now have access to just tool storage, and anything with no access requirements.

It seems that there is an override for the assistant job which will remove any access you give it, so I've just commented it out, after an hour of debugging and waiting.

Fixes: https://github.com/UristMcStation/UristMcStation/issues/1415 - Initial Bug Report
Fixes: https://github.com/UristMcStation/UristMcStation/pull/1474  - Assistant Access Goal