### PR TITLE
Restores Space Lube chemical + functions - HONK!!!

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -115,6 +115,8 @@
 			descriptors |= "glowing"
 		if(seed.get_trait(TRAIT_EXPLOSIVE))
 			descriptors |= "bulbous"
+		if(reagents.has_reagent(/datum/reagent/lube))
+			descriptors |= "slippery"
 
 		var/descriptor_num = rand(2,4)
 		var/descriptor_count = descriptor_num

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -216,7 +216,7 @@
 	seed_name = "blue tomato"
 	display_name = "blue tomato plant"
 	mutants = list("bluespacetomato")
-	chems = list(/datum/reagent/nutriment = list(1,20), /datum/reagent/cryoxadone = list(1,5))
+	chems = list(/datum/reagent/nutriment = list(1,20), /datum/reagent/lube = list(1,5))
 
 /datum/seed/tomato/blue/New()
 	..()

--- a/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
@@ -32,8 +32,8 @@
 
 /obj/item/robot_module/janitor/finalize_emag()
 	. = ..()
-	emag.reagents.add_reagent(/datum/reagent/oil, 250)
-	emag.SetName("Oil spray")
+	emag.reagents.add_reagent(/datum/reagent/lube, 200)
+	emag.SetName("Space Lube spray")
 
 /obj/item/robot_module/janitor/respawn_consumable(mob/living/silicon/robot/R, amount)
 	..()

--- a/code/modules/organs/internal/species/vox.dm
+++ b/code/modules/organs/internal/species/vox.dm
@@ -37,7 +37,8 @@
 		/datum/reagent/thermite =      1,
 		/datum/reagent/foaming_agent = 1,
 		/datum/reagent/surfactant =    1,
-		/datum/reagent/paint =         1
+		/datum/reagent/paint =         1,
+		/datum/reagent/lube =		   1
 	)
 	var/static/list/can_digest_matter = list(
 		MATERIAL_WOOD =        TRUE,

--- a/code/modules/urist/datums/uristchem.dm
+++ b/code/modules/urist/datums/uristchem.dm
@@ -44,3 +44,25 @@
 	..()
 	M.adjustToxLoss(0.5)
 	M.adjustBrainLoss(0.2)
+
+/datum/chemical_reaction/spacelube // Restores Space Lube from Bay Merge.
+	name = "Space Lube"
+	result = /datum/reagent/lube
+	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/silicon = 1, /datum/reagent/acetone = 1)
+	result_amount = 4
+	mix_message = "The solution becomes thick and slimy."
+
+/datum/reagent/lube
+	name = "Space Lube"
+	description = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them."
+	taste_description = "slime"
+	reagent_state = LIQUID
+	color = "#009ca8"
+	value = 0.6
+	should_admin_log = TRUE // So we can see who's spraying the hallways.
+
+/datum/reagent/lube/touch_turf(var/turf/simulated/T)
+	if(!istype(T))
+		return
+	if(volume >= 1)
+		T.wet_floor(80) // Restored original wet floor value.


### PR DESCRIPTION
Reimplements space lube, as god intended.

**All previous features have been restored using it -**

- Space Lube is made using water, silicon and acetone equal parts 1, to create 4 units, per.
- Jani Borg has it's space lube sprayer module restored when emagged.
- Blue Tomatoes made from Botany now make space lube again.
- Vox restored ability to eat it for nutriment like other inedible chemicals.
- Original slip value duration retained.

It is a admin logged chemical, so spraying it will cause a notice to admins, to bring it in line with other griefy/dangerous chemicals.