### PR TITLE
Tweaks Bluespace Tomatoes.

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -236,6 +236,7 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#00e5ff")
 	set_trait(TRAIT_BIOLUM,1)
 	set_trait(TRAIT_BIOLUM_COLOUR,"#4da4a8")
+	set_trait(TRAIT_POTENCY, 15)
 
 //Eggplants/varieties.
 /datum/seed/eggplant


### PR DESCRIPTION
Adjusted default genetics of Bluespace Tomatoes so that they are slightly more dangerous. You can now be teleported up to 3 turfs away from your source turf, instead of 1, or 2. You are still at the mercy of RNG gods for a good number.

