### PR TITLE
Minor Loadout Tweaks.

### DIFF
--- a/maps/nerva/loadout/loadout_accessories.dm
+++ b/maps/nerva/loadout/loadout_accessories.dm
@@ -41,16 +41,16 @@
 /datum/gear/survivalkit
 	display_name = "survival kit"
 	path = /obj/item/storage/box/survivalkit
-	allowed_roles = list(/datum/job/qm, /datum/job/cargo_tech)
+	allowed_roles = SUPPLY_ROLES
 
 /datum/gear/storage/pouches
-	allowed_roles = COMMAND_ROLES
+	allowed_roles = null
 	cost = 3
 
 /datum/gear/accessory/badge
 	display_name = "badge selection"
 	path = /obj/item/clothing/accessory/badge
-	allowed_roles = list(/datum/job/officer, /datum/job/hos)
+	allowed_roles = SECURITY_ROLES
 
 /datum/gear/accessory/badge/New()
 	..()


### PR DESCRIPTION
Drop Pouches are no longer only available to Command Roles, and can be purchased for 3 loadout points.
Updates Badges to use SECURITY_ROLES instead of manual define of job
Updates Survival Kit to use SUPPLY_ROLES.