### PR TITLE
Chameleon Kit adjustment, Smuggler Satchel TC Cost, Smuggler Satchel duplicate crowbar bugfix.

### DIFF
--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -48,18 +48,19 @@
 
 /datum/uplink_item/item/stealth_items/chameleon_kit
 	name = "Chameleon Kit"
-	desc = "Comes with a full set of appearance changing clothing you need to impersonate most people.  \
-	Accessories, backpack, and gun included!"
-	item_cost = 20
+	desc = "A discreet disguise kit, with a full set of apperance changing clothes, and a voice modulator mask, allowing you \
+	to impersonate most people"
+	item_cost = 24 // Increase for Mask included.
 	path = /obj/item/storage/backpack/chameleon/sydie_kit
 
-/datum/uplink_item/item/stealth_items/voice
+/*/datum/uplink_item/item/stealth_items/voice   Urist Specific - Changed to be available with the Chameleon Kit.
 	name = "Modified Gas Mask"
 	desc = "A fully functioning gas mask that is able to conceal your face and has a built in voice modulator, \
 	so you can become a true shadow operative!"
 	item_cost = 20
 	path = /obj/item/clothing/mask/chameleon/voice
 
+*/
 /datum/uplink_item/item/stealth_items/chameleon_projector
 	name = "Chameleon Projector"
 	desc = "Use this to scan a small, portable object in order to disguise yourself as said object."
@@ -82,5 +83,5 @@
 	name = "Smuggler's Satchel"
 	desc = "This satchel is thin enough to be hidden in the gap between plating and tiling, \
 	great for stashing your stolen goods. Comes with a crowbar and a floor tile."
-	item_cost = 20
+	item_cost = 16
 	path = /obj/item/storage/backpack/satchel/flat

--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -48,7 +48,7 @@
 
 /datum/uplink_item/item/stealth_items/chameleon_kit
 	name = "Chameleon Kit"
-	desc = "A discreet disguise kit, with a full set of apperance changing clothes, and a voice modulator mask, allowing you \
+	desc = "A discreet disguise kit, with a full set of appearance changing clothes, and a voice modulator mask, allowing you \
 	to impersonate most people"
 	item_cost = 24 // Increase for Mask included.
 	path = /obj/item/storage/backpack/chameleon/sydie_kit

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -61,7 +61,7 @@ var/global/list/uplink_random_selections_
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealth_items/spy)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealth_items/chameleon_kit)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealth_items/chameleon_projector)
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealth_items/voice)
+//	items += new/datum/uplink_random_item(/datum/uplink_item/item/stealth_items/voice)
 
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/toolbox, reselect_propbability = 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/tools/plastique)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -65,7 +65,7 @@
 		/obj/item/clothing/suit/chameleon,
 		/obj/item/clothing/shoes/chameleon,
 		/obj/item/clothing/head/chameleon,
-		/obj/item/clothing/mask/chameleon,
+		/obj/item/clothing/mask/chameleon/voice,
 		/obj/item/storage/box/syndie_kit/chameleon,
 		/obj/item/gun/energy/chameleon,
 		)

--- a/code/modules/urist/items/tgitems.dm
+++ b/code/modules/urist/items/tgitems.dm
@@ -320,7 +320,7 @@ Please only put items here that don't have a huge definition - Glloyd											
 
 /obj/item/storage/backpack/satchel/flat/New()
 	..()
-	new /obj/item/crowbar(src)
+
 
 // Rolling papers from /tg/
 


### PR DESCRIPTION
**Changes:**

Chameleon Kit is now bundled with the chameleon voice changer. This allows antagonists to use the chameleon kit for more of it's inteded purpose, and for making interesting gimmicks or stealthy stuff at a cheaper price point than buying both items individually, giving them more wiggle-room to buy other items and experiment.

Chameleon Kit price is raised to 24tc for the addition of the Voice Changer.

Smugglers Satchel no longer spawns with double crowbars, and now only spawns with 1 crowbar and a floor tile.
Smugglers Satchel now costs 16tc instead of 20.