### PR TITLE
Gamemodes - General Pop Cap + Coefficent Tinkering 

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -11,7 +11,7 @@
 		No one knows where it came from. No one knows who it is or what it wants. One thing is for \
 		certain though... there is never just one of them. Good luck."
 	config_tag = "changeling"
-	required_players = 5
+	required_players = 7
 	required_enemies = 1
 	end_on_antag_death = FALSE
 	antag_scaling_coeff = 10

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -11,8 +11,8 @@
 		No one knows where it came from. No one knows who it is or what it wants. One thing is for \
 		certain though... there is never just one of them. Good luck."
 	config_tag = "changeling"
-	required_players = 10
+	required_players = 5
 	required_enemies = 1
 	end_on_antag_death = FALSE
-	antag_scaling_coeff = 15
+	antag_scaling_coeff = 10
 	antag_tags = list(MODE_CHANGELING)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -3,7 +3,7 @@
 	round_description = "Some crewmembers are attempting to start a cult!"
 	extended_round_description = "There has been an infiltration by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "cult"
-	required_players = 10
+	required_players = 8
 	required_enemies = 3
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -3,7 +3,7 @@
 	round_description = "Some crewmembers are attempting to start a cult!"
 	extended_round_description = "There has been an infiltration by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "cult"
-	required_players = 8
+	required_players = 10
 	required_enemies = 3
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/heist
 	name = "Heist"
 	config_tag = "heist"
-	required_players = 12
+	required_players = 10
 	required_enemies = 3
 	round_description = "An unidentified bluespace signature has slipped into close sensor range and is approaching!"
 	extended_round_description = "The Company's majority control of phoron in Nyx has marked the \

--- a/code/game/gamemodes/mixed/crossfire.dm
+++ b/code/game/gamemodes/mixed/crossfire.dm
@@ -3,7 +3,7 @@
 	round_description = "Mercenaries and raiders are preparing for a nice visit..."
 	extended_round_description = "Nothing can possibly go wrong with lots of people and lots of guns, right?"
 	config_tag = "crossfire"
-	required_players = 22
+	required_players = 20
 	required_enemies = 6
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_RAIDER, MODE_MERCENARY)

--- a/code/game/gamemodes/mixed/pirates.dm
+++ b/code/game/gamemodes/mixed/pirates.dm
@@ -2,7 +2,7 @@
 	name = "Raiding Party"
 	round_description = "Prepare yourself! An unknown ship is approaching!"
 	config_tag = "voxraiders"
-	required_players = 15
+	required_players = 10
 	required_enemies = 3
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_VOXRAIDER, MODE_RAIDER)

--- a/code/game/gamemodes/mixed/spyvspy.dm
+++ b/code/game/gamemodes/mixed/spyvspy.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Traitors and renegades both spawn during this mode."
 	config_tag = "spyvspy"
 	required_players = 4
-	required_enemies = 4
+	required_enemies = 2
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_TRAITOR, MODE_RENEGADE)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/traitorling.dm
+++ b/code/game/gamemodes/mixed/traitorling.dm
@@ -3,8 +3,8 @@
 	round_description = "There are traitors and alien changelings. Do not let the changelings succeed!"
 	extended_round_description = "Traitors and changelings both spawn during this mode."
 	config_tag = "traitorling"
-	required_players = 15
-	required_enemies = 5
+	required_players = 10
+	required_enemies = 3
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CHANGELING, MODE_TRAITOR)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/traitorling.dm
+++ b/code/game/gamemodes/mixed/traitorling.dm
@@ -3,7 +3,7 @@
 	round_description = "There are traitors and alien changelings. Do not let the changelings succeed!"
 	extended_round_description = "Traitors and changelings both spawn during this mode."
 	config_tag = "traitorling"
-	required_players = 10
+	required_players = 12
 	required_enemies = 3
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CHANGELING, MODE_TRAITOR)

--- a/code/game/gamemodes/ninja/ninja.dm
+++ b/code/game/gamemodes/ninja/ninja.dm
@@ -9,7 +9,7 @@
 		carry is enough to turn heads far enough that they pop right off. Tread lightly and only hope this operative \
 		isn't here for you."
 	config_tag = "operative"
-	required_players = 10
+	required_players = 8
 	required_enemies = 1
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_NINJA)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -12,7 +12,7 @@ var/global/list/nuke_disks = list()
 		colony of sizable population and considerable wealth causes it to often be the target of various \
 		attempts of robbery, fraud and other malicious actions."
 	config_tag = "mercenary"
-	required_players = 15
+	required_players = 10
 	required_enemies = 3
 	end_on_antag_death = FALSE
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station


### PR DESCRIPTION
Reduces the pop cap for certain gamemodes, all team gamemodes still required atleast 10 population to play. Feedback is appreciated as always

**Changeling**: 7 - (Was 10) --- Keeps in line with BSR.
**Heist**: - 10 - (Was 12)
**Vox Raiders**: - 10 (Was 15)
**Merc**: - 12 - (Was 15)
**Ninja** - 8 - (Was 10)
**Spy vs Spy** - 4 (Enemy Count 2) - (Was 4)

Mixed Gamemodes:

**TraitorLing** - **12** - (Adjusted for 3 antags instead of 5.) - Was (15)
**Crossfire** - **20** - (Was 22)

**Antag Scaling -**

Changelings Coefficent changed to 10 instead of 15. -- Makes Lings more likely with Urist's lower pop compared to Bay.