### PR TITLE
Minor Xenophage Fix - Xenophage Queen can pry over doors.

### DIFF
--- a/code/modules/species/xenomorphs/alien_species.dm
+++ b/code/modules/species/xenomorphs/alien_species.dm
@@ -363,7 +363,8 @@
 		/mob/living/carbon/human/proc/corrosive_acid,
 		/mob/living/carbon/human/proc/neurotoxin,
 		/mob/living/carbon/human/proc/resin,
-		/mob/living/carbon/human/proc/xeno_infest
+		/mob/living/carbon/human/proc/xeno_infest,
+		/mob/living/carbon/human/proc/pry_open
 		)
 
 	genders = list(FEMALE)


### PR DESCRIPTION
Moments after commiting the zombie proc PR, I remembered that the Xenophage Queen can't pry open doors either.
It is now fixed