### PR TITLE
Fixes: #1444 - (Bar Spotlights)

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -68,7 +68,8 @@
 		/obj/item/clothing/shoes/galoshes,
 		/obj/item/soap,
 		/obj/item/reagent_containers/glass/rag,
-		/obj/item/storage/belt/janitor
+		/obj/item/storage/belt/janitor,
+		/obj/item/storage/box/lights/incandescent // Urist Specific
 	)
 
 /*

--- a/code/modules/fabrication/designs/general/designs_general.dm
+++ b/code/modules/fabrication/designs/general/designs_general.dm
@@ -113,3 +113,18 @@
 
 /datum/fabricator_recipe/toolbox
 	path = /obj/item/storage/toolbox
+
+/datum/fabricator_recipe/warmincandescent // urist
+	path = /obj/item/light/tube/tinted/warmtint
+
+/datum/fabricator_recipe/coldtinted // urist
+	path = /obj/item/light/tube/tinted/coldtint
+
+/datum/fabricator_recipe/largewarmincandescent // urist
+	path = /obj/item/light/tube/large/tinted/warmtint
+
+/datum/fabricator_recipe/redtintedlight // urist
+	path = /obj/item/light/tube/tinted/redtint
+
+/datum/fabricator_recipe/greentintedlight // urist
+	path = /obj/item/light/tube/tinted/greentint

--- a/code/modules/urist/structures/uristlighting.dm
+++ b/code/modules/urist/structures/uristlighting.dm
@@ -141,3 +141,11 @@
 /obj/machinery/light/broken/Initialize()
 	. = ..()
 	broken()
+
+/obj/item/storage/box/lights/incandescent
+	name = "box of replacement incandescent lights"
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "lighttube"
+	startswith = list(/obj/item/light/tube/tinted/warmtint = 7,
+					/obj/item/light/tube/tinted/coldtint = 7,
+					/obj/item/light/tube/large/tinted/warmtint = 4)


### PR DESCRIPTION
Fixes: #1444 

Janitor's closet now spawns with a box of replacement incandescent light tubes - (small and large)
Autolathes now support incandescent and tinted lights as recipes to fabricate.