### PR TITLE
Comments in /var/suffix for away map creation.

### DIFF
--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -10,7 +10,7 @@
 	var/player_cost = 0
 
 	var/prefix = null
-	var/suffixes = null
+	var/suffixes = null	 // Ensure you add a map_data landmark with your specified z-levels in the height var on the highest z-level of your map, so that they are all loaded, or you will only get one z-level of your ruin.
 	template_flags = 0 // No duplicates by default
 
 	// !! Currently only implemented for away sites


### PR DESCRIPTION
As away map z-levels are defined using var/suffixes, leaves a comment at the base value specifying how to create a map_data landmark in order to allow your ruin to spawn with more than 1 z-level.

I spent a few hours trying to bugfix an away and found this is what I was missing, hopefully other people can find this if they are stuck and save themself a few minutes or hours.

// Ensure you add a map_data landmark with your specified z-levels in the height var on the highest z-level of your map, so that they are all loaded, or you will only get one z-level of your ruin.
