### PR TITLE
Autolathes can now print: SpaceAK & HI-2521SMG + Pistol Magazines if hacked.

### DIFF
--- a/code/modules/fabrication/designs/general/designs_arms_ammo.dm
+++ b/code/modules/fabrication/designs/general/designs_arms_ammo.dm
@@ -134,3 +134,19 @@
 /datum/fabricator_recipe/arms_ammo/hidden/rifleinternalclip
 	name = "ammunition (en-bloc clip)"
 	path = /obj/item/ammo_magazine/iclipr
+
+/datum/fabricator_recipe/arms_ammo/hidden/spaceak
+	name = "ammunition (U2442 magazine box)"
+	path = /obj/item/ammo_magazine/rifle/military/spaceak
+
+/datum/fabricator_recipe/arms_ammo/hidden/hi2521smglethal
+	name = "ammunition (HI-2521-SMG magazine)"
+	path = /obj/item/ammo_magazine/hi2521smg9mm
+
+/datum/fabricator_recipe/arms_ammo/hidden/hi2521smgrubber
+	name = "ammunition (HI-2521-SMG magazine - rubber)"
+	path = /obj/item/ammo_magazine/hi2521smg9mm/rubber
+
+/datum/fabricator_recipe/arms_ammo/hidden/hi2521pistol9mm
+	name = "ammunition (HI-2521-P pistol magazine)"
+	path = /obj/item/ammo_magazine/hi2521pistol9mm


### PR DESCRIPTION
Autolathe has additional recipes for the following:

SpaceAK (U2442) magazines can now be lathed.
HI-2521 SMG magazines (lethal & non-lethal)
HI-2521 Pistol magazine (lethal 9mm)

These require a hacked lathe and such.