### PR TITLE
Minor Documentation tweaks for Exoplanets + SPAN_GOOD for away loading.

### DIFF
--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -401,7 +401,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 
 	for (var/datum/map_template/template in selected)
 		if (template.load_new_z())
-			report_progress("Loaded away site [template]!")
+			report_progress(SPAN_GOOD("Loaded away site [template]!"))
 		else
 			report_progress("Failed loading away site [template]!")
 #endif

--- a/maps/random_ruins/exoplanet_ruins/exoplanet_ruins.dm
+++ b/maps/random_ruins/exoplanet_ruins/exoplanet_ruins.dm
@@ -1,5 +1,8 @@
 // Hey! Listen! Update \config\exoplanet_ruin_blacklist.txt with your new ruins!
-
 /datum/map_template/ruin/exoplanet
 	prefix = "maps/random_ruins/exoplanet_ruins/"
 	var/list/ruin_tags
+
+/* Go to \maps\_maps.dm and setup a include - i.e #include "random_ruins\exoplanet_ruins\examplefolder\examplemap.dm"
+in order to setup your new exoplanet ruins you have added.
+for ease of testing, use template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED  in your /datum/map_template/ruin/exoplanet/examplemap    in order to force it each round. - Y */


### PR DESCRIPTION
Documents some setup for exoplanets in the base exoplanet_ruins.dm to help other people get stuff up and running sooner, as some parts are well hidden.

Changes Text Colour when Away Maps are correctly loaded, nice for debugging and working on aways too.

![awdawd](https://github.com/user-attachments/assets/945733c7-9d06-42ee-a09a-065897a92321)
