### PR TITLE
Updates Cryopod and Seed Storage Vendor UI

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -46,15 +46,16 @@
 	var/dat
 
 	dat += "<hr/><br/><b>[storage_name]</b><br/>"
-	dat += "<i>Welcome, [user.real_name].</i><br/><br/><hr/>"
-	dat += "<a href='?src=\ref[src];log=1'>View storage log</a>.<br>"
+	dat += "<i>Welcome, <b>[user.real_name]</b>.</i><br/><br/><hr/>"
+	dat += "<a href='?src=\ref[src];log=1'>View crew storage log</a><br>"
 	if(allow_items)
-		dat += "<a href='?src=\ref[src];view=1'>View objects</a>.<br>"
-		dat += "<a href='?src=\ref[src];item=1'>Recover object</a>.<br>"
-		dat += "<a href='?src=\ref[src];allitems=1'>Recover all objects</a>.<br>"
+		dat += "<a href='?src=\ref[src];view=1'>View item storage log</a><br>"
+		dat += "<a href='?src=\ref[src];item=1'>Recover stored item</a><br>"
+		dat += "<a href='?src=\ref[src];allitems=1'>Recover all stored items</a><br>"
 
-	show_browser(user, dat, "window=cryopod_console")
-	onclose(user, "cryopod_console")
+	var/datum/browser/popup = new(user, "cryopod_console", "Cryogenic Storage Console", 400, 280)
+	popup.set_content(dat)
+	popup.open()
 
 /obj/machinery/computer/cryopod/OnTopic(user, href_list, state)
 	if(href_list["log"])
@@ -62,18 +63,23 @@
 		for(var/person in frozen_crew)
 			dat += "[person]<br/>"
 		dat += "<hr/>"
-		show_browser(user, dat, "window=cryolog")
+		var/datum/browser/popup = new(user, "cryolog", "Cryogenic Crew Storage Log", 400, 280)
+		popup.set_content(dat)
+		popup.open()
+
 		. = TOPIC_REFRESH
 
 	else if(href_list["view"])
 		if(!allow_items) return
 
-		var/dat = "<b>Recently stored objects</b><br/><hr/><br/>"
+		var/dat = "<b>Recently stored items</b><br/><hr/><br/>"
 		for(var/obj/item/I in frozen_items)
 			dat += "[I.name]<br/>"
 		dat += "<hr/>"
 
-		show_browser(user, dat, "window=cryoitems")
+		var/datum/browser/popup = new(user, "cryoitems", "Cryogenic Item Storage Log", 400, 280)
+		popup.set_content(dat)
+		popup.open()
 		. = TOPIC_HANDLED
 
 	else if(href_list["item"])
@@ -83,7 +89,7 @@
 			to_chat(user, SPAN_NOTICE("There is nothing to recover from storage."))
 			return TOPIC_HANDLED
 
-		var/obj/item/I = input(user, "Please choose which object to retrieve.","Object recovery",null) as null|anything in frozen_items
+		var/obj/item/I = input(user, "Please choose which items to retrieve.","Item recovery",null) as null|anything in frozen_items
 		if(!I || !CanUseTopic(user, state))
 			return TOPIC_HANDLED
 

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -156,7 +156,7 @@
 /obj/machinery/seed_storage/interact(mob/user as mob)
 	user.set_machine(src)
 
-	var/dat = "<center><h1>Seed storage contents</h1></center>"
+	var/dat = ""
 	if (length(piles) == 0)
 		dat += SPAN_COLOR("red", "No seeds")
 	else
@@ -261,8 +261,9 @@
 			dat += "</tr>"
 		dat += "</table>"
 
-	show_browser(user, dat, "window=seedstorage;size=800x500")
-	onclose(user, "seedstorage")
+	var/datum/browser/popup = new(user, "seedstorage", "Seed Storage", 500, 800)
+	popup.set_content(dat)
+	popup.open()
 
 /obj/machinery/seed_storage/Topic(href, list/href_list)
 	if (..())


### PR DESCRIPTION
Cryopod and Seed Storage now use Fake NanoUI, instead of ugly white html - now will look slightly nicer.

**Cryopod:**

- Updates some of the vague text options you had available to you.
- Storage Log is now Crew Storage Log
- Object is now Items.
- Your name is now **bold**, fancy.
- All Sub-Menus are also updated.

![image](https://github.com/user-attachments/assets/cc7f68bc-eb2a-4456-9e42-29693da62da2)

**Seed Storage Vendor:**

- Adjusts window for /datum/browser/popup.
- All old features kept the same, including notes for warnings such as VINE, etc.

![image](https://github.com/user-attachments/assets/34ffb3d6-ae63-4135-95c4-3c8f0f3a6c3c)

