### PR TITLE
Random Item Spawners - Updated

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -58,7 +58,9 @@
 				/obj/item/crowbar,
 				/obj/item/wrench,
 				/obj/item/device/flashlight,
-				/obj/item/device/flashlight/upgraded)
+				/obj/item/device/flashlight/upgraded,
+				/obj/item/airlock_brace,
+				/obj/item/device/flashlight/maglight)
 
 /obj/random/technology_scanner
 	name = "random scanner"
@@ -230,7 +232,10 @@
 				/obj/item/reagent_containers/syringe = 3,
 				/obj/item/reagent_containers/syringe/steroid = 2,
 				/obj/item/reagent_containers/syringe/drugs = 1,
-				/obj/item/reagent_containers/food/snacks/egg/lizard = 3)
+				/obj/item/reagent_containers/food/snacks/egg/lizard = 3,
+				/obj/item/reagent_containers/glass/bottle/dye/polychromic/strong = 1,
+				/obj/item/storage/backpack/satchel/syndie_kit/clerical = 1,
+				/obj/item/clothing/shoes/laceup/sneakies = 1)
 
 /obj/random/drinkbottle
 	name = "random drink"


### PR DESCRIPTION
**Random Tools:**

Adds chance for airlock braces to spawn.
Adds chance for maglites to spawn, giving some reason to potentially find one legit. (Without killing a seccie)

**Contraband:**

Updates contraband list to spawn some antag items that are mostly harmless, as there's already some defined inside. Clerical Kit could add for some fun roleplay oppurtunities. 

Adds sneakies to contraband list.
Adds clerical kit to contraband list.
Adds polychromatic dye to contraband list.


