### PR TITLE
Some Xenophage Quick Fixes

### DIFF
--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -222,6 +222,8 @@
 
 /obj/machinery/door/unpowered/simple/resin/New(newloc,var/material_name,var/complexity)
 	..(newloc, MATERIAL_RESIN, complexity)
+	autoclose = 1
+	normalspeed = 0
 
 /obj/machinery/door/unpowered/simple/cult/New(newloc,material_name,complexity)
 	..(newloc, MATERIAL_CULT, complexity)

--- a/code/game/objects/structures/alien/node.dm
+++ b/code/game/objects/structures/alien/node.dm
@@ -4,6 +4,7 @@
 	icon_state = "weednode"
 	health = 100
 	layer = ABOVE_OBJ_LAYER
+	opacity = 0
 
 /obj/structure/alien/node/Initialize()
 	. = ..()

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -152,6 +152,7 @@
 	else
 		layer = (seed && seed.force_layer) ? seed.force_layer : ABOVE_OBJ_LAYER
 		set_density(0)
+		set_opacity(0)
 
 	if(!growth_type && !floor)
 		SetTransform(

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -22,6 +22,7 @@
 	add_language(LANGUAGE_XENOPHAGE) //Bonus language.
 	internal_organs |= new /obj/item/organ/internal/xeno/hivenode(src)
 	create_reagents(100)
+	verbs += /mob/living/proc/ventcrawl // Fuck it, we are forcing it.
 
 /mob/living/carbon/alien/larva/update_icons()
 


### PR DESCRIPTION
- Resin Doors are now able to auto-close on a fairly quick time.
- Alien Weed Nodes now have 0 opacity and can be seen through
- Alien Weeds now have 0 opacity and can be seen through.
- Larva now get the vent-crawl proc to go run around the place.