### PR TITLE
More Shoe-Tactical Espionage

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -162,6 +162,7 @@
 	flashlight_max_bright = 0.25
 	flashlight_inner_range = 0.1
 	flashlight_outer_range = 2
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/device/flashlight/maglight
 	name = "maglight"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -11,6 +11,7 @@
 	var/translate_hive = 0
 	var/syndie = 0
 	var/list/channels = list()
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/device/encryptionkey/attackby(obj/item/W as obj, mob/user as mob)
 

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -38,6 +38,7 @@
 	origin_tech = list(TECH_MATERIAL = 1)
 	slot_flags = SLOT_EARS
 	attack_verb = list("burnt", "singed")
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/flame/match/Process()
 	set_light(0.4, 0.3, 2, l_color = COLOR_WARM_YELLOW )

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -14,6 +14,7 @@
 	var/malfunction = 0
 	var/known //if advanced scanners would name these in results
 	var/hidden //if scanners will locate this implant at all
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/implant/proc/trigger(emote, source)
 	return

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -1087,6 +1087,7 @@ BLIND     // can't see anything
 	gender = NEUTER
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_DIONA)
 	var/undergloves = 1
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 
 /obj/item/clothing/get_pressure_weakness(pressure,zone)


### PR DESCRIPTION
Some additional tiny items you can hide in shoes to sneak into the Brig if you are caught, or just for the hell of it.

**List:**

Pen Lights
Radio Encryption Keys
Implant Injectors
Matches
Rings (For sleepy rings, mainly)
