### PR TITLE
Inventory Screen is no longer blinding html white

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -179,7 +179,7 @@
 		return
 
 	user.set_machine(src)
-	var/dat = "<B><HR>[FONT_LARGE(name)]</B><BR><HR>"
+	var/dat = "<B>[FONT_LARGE(name)]</B>"
 
 	for(var/entry in species.hud.gear)
 		var/list/slot_ref = species.hud.gear[entry]
@@ -220,9 +220,15 @@
 	dat += "<BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>"
 
-	show_browser(user, dat, text("window=mob[name];size=340x540"))
+
+	var/datum/browser/popup = new(user, name, 860, 300)
+	popup.set_content(dat)
+	popup.open()
+
+/*	show_browser(user, dat, text("window=mob[name];size=340x540"))
 	onclose(user, "mob[name]")
 	return
+*/
 
 // called when something steps onto a human
 // this handles mulebots and vehicles

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -221,7 +221,7 @@
 	dat += "<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>"
 
 
-	var/datum/browser/popup = new(user, name, 540, 400)
+	var/datum/browser/popup = new(user, name, 540, 340)
 	popup.set_content(dat)
 	popup.open()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -221,14 +221,9 @@
 	dat += "<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>"
 
 
-	var/datum/browser/popup = new(user, name, 860, 300)
+	var/datum/browser/popup = new(user, name, 540, 400)
 	popup.set_content(dat)
 	popup.open()
-
-/*	show_browser(user, dat, text("window=mob[name];size=340x540"))
-	onclose(user, "mob[name]")
-	return
-*/
 
 // called when something steps onto a human
 // this handles mulebots and vehicles


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0a03bce8-1a69-47e4-b679-dcc42c554bfd)

Updated show_inv to use fake Nano, since people run into a lot of NanoUI issues, this is probably the best option as a mid-point. Updates when items are removed/added, etc.

