### PR TITLE
Exploration Command HCM Rig - Module Adjustments + Minor Changes.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -179,7 +179,7 @@
 		return
 
 	user.set_machine(src)
-	var/dat = "<B><HR>[FONT_LARGE(name)]</B><BR><HR>"
+	var/dat = "<B>[FONT_LARGE(name)]</B>"
 
 	for(var/entry in species.hud.gear)
 		var/list/slot_ref = species.hud.gear[entry]
@@ -220,9 +220,15 @@
 	dat += "<BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>"
 
-	show_browser(user, dat, text("window=mob[name];size=340x540"))
+
+	var/datum/browser/popup = new(user, name, 860, 300)
+	popup.set_content(dat)
+	popup.open()
+
+/*	show_browser(user, dat, text("window=mob[name];size=340x540"))
 	onclose(user, "mob[name]")
 	return
+*/
 
 // called when something steps onto a human
 // this handles mulebots and vehicles

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -179,7 +179,7 @@
 		return
 
 	user.set_machine(src)
-	var/dat = "<B>[FONT_LARGE(name)]</B>"
+	var/dat = "<B><HR>[FONT_LARGE(name)]</B><BR><HR>"
 
 	for(var/entry in species.hud.gear)
 		var/list/slot_ref = species.hud.gear[entry]
@@ -220,15 +220,9 @@
 	dat += "<BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>"
 
-
-	var/datum/browser/popup = new(user, name, 860, 300)
-	popup.set_content(dat)
-	popup.open()
-
-/*	show_browser(user, dat, text("window=mob[name];size=340x540"))
+	show_browser(user, dat, text("window=mob[name];size=340x540"))
 	onclose(user, "mob[name]")
 	return
-*/
 
 // called when something steps onto a human
 // this handles mulebots and vehicles

--- a/maps/nerva/obj/nerva_clothes.dm
+++ b/maps/nerva/obj/nerva_clothes.dm
@@ -296,7 +296,7 @@
 	boot_type = /obj/item/clothing/shoes/magboots/rig/command/exploration
 	glove_type = /obj/item/clothing/gloves/rig/command/exploration
 
-	allowed = list(/obj/item/storage/backpack,/obj/item/gun, /obj/item/device/flashlight, /obj/item/device/radio, /obj/item/tank, /obj/item/device/suit_cooling_unit, /obj/item/storage/backpack)
+	allowed = list(/obj/item/storage/backpack, /obj/item/gun, /obj/item/device/flashlight, /obj/item/device/radio, /obj/item/tank, /obj/item/device/suit_cooling_unit)
 	req_access = list(access_qm)
 
 /obj/item/clothing/head/helmet/space/rig/command/exploration
@@ -326,7 +326,9 @@
 	initial_modules = list(
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/flash,
-		/obj/item/rig_module/cooling_unit
+		/obj/item/rig_module/cooling_unit,
+		/obj/item/rig_module/vision/meson,
+		/obj/item/rig_module/grenade_launcher/light
 		)
 
 


### PR DESCRIPTION
_Adjusts the Exploration HCM RIG's modules to bring it more in line with a Pathfinder RIG._

**Modules:**

Meson Vision Module
Illumination Grenade Launcher - (Capable of firing only illumination grenades - 6 shots.)

- Removes duplicate /obj/item/storage/backpack definition at the end.
- Adds space to /obj/item/gun.

Had some minor commit issues as I accidently commited my changes to my own baymerge-testing, but I've fixed it on my end, so the commit history might look wack