### PR TITLE
Hypospray is instant again + storable in a Belt or Holster

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -179,7 +179,7 @@
 		return
 
 	user.set_machine(src)
-	var/dat = "<B><HR>[FONT_LARGE(name)]</B><BR><HR>"
+	var/dat = "<B>[FONT_LARGE(name)]</B>"
 
 	for(var/entry in species.hud.gear)
 		var/list/slot_ref = species.hud.gear[entry]
@@ -220,9 +220,15 @@
 	dat += "<BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>"
 
-	show_browser(user, dat, text("window=mob[name];size=340x540"))
+
+	var/datum/browser/popup = new(user, name, 860, 300)
+	popup.set_content(dat)
+	popup.open()
+
+/*	show_browser(user, dat, text("window=mob[name];size=340x540"))
 	onclose(user, "mob[name]")
 	return
+*/
 
 // called when something steps onto a human
 // this handles mulebots and vehicles

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -179,7 +179,7 @@
 		return
 
 	user.set_machine(src)
-	var/dat = "<B>[FONT_LARGE(name)]</B>"
+	var/dat = "<B><HR>[FONT_LARGE(name)]</B><BR><HR>"
 
 	for(var/entry in species.hud.gear)
 		var/list/slot_ref = species.hud.gear[entry]
@@ -220,15 +220,9 @@
 	dat += "<BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>"
 
-
-	var/datum/browser/popup = new(user, name, 860, 300)
-	popup.set_content(dat)
-	popup.open()
-
-/*	show_browser(user, dat, text("window=mob[name];size=340x540"))
+	show_browser(user, dat, text("window=mob[name];size=340x540"))
 	onclose(user, "mob[name]")
 	return
-*/
 
 // called when something steps onto a human
 // this handles mulebots and vehicles

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -84,8 +84,9 @@
 	possible_transfer_amounts = "1;2;5;10;15;20;30"
 	amount_per_transfer_from_this = 5
 	volume = 0
-	time = 7
+	time = 0
 	single_use = FALSE
+	slot_flags = SLOT_BELT|SLOT_HOLSTER
 
 /obj/item/reagent_containers/hypospray/vial/New()
 	..()


### PR DESCRIPTION
CMOs everywhere screaming, crying, throwing up.
Hypospray now has a 0 timer again, instead of 7, making it a valuble item to keep again + for offensive use.

You can now store Hyposprays in your Belt slot, or a holster if you want to get real cowboy showdown with it, as a Doctor.