### PR TITLE
Computer Tablets can now be worn on belts.

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
@@ -9,6 +9,7 @@
 	max_hardware_size = 1
 	w_class = ITEM_SIZE_SMALL
 	light_strength = 5 // same as PDAs
+	slot_flags = SLOT_BELT
 
 	interact_sounds = list('sound/machines/pda_click.ogg')
 	interact_sound_volume = 20


### PR DESCRIPTION
Considering you can fit an entire tablet in your pocket, now you can put it on your belt.