### PR TITLE
Destroyed Colony - Alien AI + Neurotoxin Adjustment

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -15,6 +15,7 @@
 	health = 100
 	harm_intent_damage = 5
 	natural_weapon = /obj/item/natural_weapon/claws
+	bleed_colour = COLOR_LIME
 	attacktext = "slashed"
 	a_intent = I_HURT
 	attack_sound = 'sound/weapons/bladeslice.ogg'
@@ -30,7 +31,7 @@
 	see_in_dark = 10
 	move_to_delay = 1
 	pry_time = 6 SECONDS
-	ai_holder = /datum/ai_holder/simple_animal/melee/alien
+	ai_holder = /datum/ai_holder/simple_animal/urist_humanoid/alien/hunter
 	natural_armor = list(
 		melee = ARMOR_MELEE_KNIVES
 		)
@@ -43,6 +44,7 @@
 	health = 60
 	natural_weapon = /obj/item/natural_weapon/claws
 	move_to_delay = 2
+	ai_holder = /datum/ai_holder/simple_animal/urist_humanoid/alien/drone
 
 /mob/living/simple_animal/hostile/alien/sentinel
 	name = "alien sentinel"
@@ -55,7 +57,7 @@
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	move_to_delay = 2
-	ai_holder = /datum/ai_holder/simple_animal/ranged/kiting/aliensentinel
+	ai_holder = /datum/ai_holder/simple_animal/urist_humanoid/alien/sentinel
 	base_attack_cooldown = 20
 
 /mob/living/simple_animal/hostile/alien/queen
@@ -72,8 +74,13 @@
 	projectilesound = 'sound/weapons/pierce.ogg'
 	rapid = 1
 	base_attack_cooldown = 16
-	ai_holder = /datum/ai_holder/simple_animal/ranged/alien
+	ai_holder = /datum/ai_holder/simple_animal/urist_humanoid/alien/queen
 	status_flags = 0
+	natural_armor = list(
+		melee = ARMOR_MELEE_KNIVES,
+		laser	= ARMOR_LASER_SMALL,
+		energy	= ARMOR_ENERGY_SMALL
+		)
 
 /mob/living/simple_animal/hostile/alien/queen/large
 	name = "alien empress"
@@ -85,15 +92,17 @@
 	maxHealth = 400
 	health = 400
 	base_attack_cooldown = 12
-	ai_holder = /datum/ai_holder/simple_animal/ranged/alien/queen
+	ai_holder = /datum/ai_holder/simple_animal/urist_humanoid/alien/queen/empress
 	natural_armor = list(
-		melee = ARMOR_MELEE_KNIVES,
+		melee = ARMOR_MELEE_RESISTANT,
 		laser	= ARMOR_LASER_HANDGUNS,
-		energy	= ARMOR_ENERGY_SMALL
+		energy	= ARMOR_ENERGY_SMALL,
+		ballistic = ARMOR_BALLISTIC_MINOR
 		)
 
 /obj/item/projectile/neurotox
 	damage = 25
+	damage_type = DAMAGE_BURN
 	icon_state = "toxin"
 
 /mob/living/simple_animal/hostile/alien/death(gibbed, deathmessage, show_dead_message)
@@ -102,19 +111,90 @@
 
 // AI Holders
 
-/datum/ai_holder/simple_animal/melee/alien
+/datum/ai_holder/simple_animal/urist_humanoid/alien/hunter // Melee Based, can leap.
+	speak_chance = 0
+	aggro_sound = 'sound/voice/hiss1.ogg'
+	threaten = FALSE
+	can_breakthrough = TRUE
+	violent_breakthrough = TRUE
+	wander = TRUE
+	returns_home = FALSE
+	home_low_priority = TRUE
+	pointblank = FALSE
+	dying_threshold = 0.1
+	lose_target_timeout = 20 SECONDS
+	run_if_this_close = 0
+	melee_hitnrun_prob = 5
+	melee_slippery = FALSE
+	prefer_cover_proba = 0
+	prying = TRUE
+
+/datum/ai_holder/simple_animal/urist_humanoid/alien/drone // Melee Based, cannot leap, more likely to hit and run.
 	speak_chance = 0
 	aggro_sound = 'sound/voice/hiss2.ogg'
+	threaten = FALSE
+	can_breakthrough = TRUE
+	violent_breakthrough = TRUE
+	wander = TRUE
+	returns_home = FALSE
+	home_low_priority = TRUE
+	pointblank = FALSE
+	dying_threshold = 0.1
+	lose_target_timeout = 15 SECONDS
+	run_if_this_close = 0
+	melee_hitnrun_prob = 50
+	melee_slippery = TRUE
+	prefer_cover_proba = 0
+	prying = TRUE
 
-/datum/ai_holder/simple_animal/ranged/kiting/aliensentinel
+/datum/ai_holder/simple_animal/urist_humanoid/alien/sentinel // Swaps between Melee and Ranged, Kites if too close.
 	speak_chance = 0
-	aggro_sound = 'sound/voice/hiss2.ogg'
-	run_if_this_close = 3
+	aggro_sound = 'sound/voice/hiss3.ogg'
+	firing_lanes = FALSE
+	conserve_ammo = FALSE //Don't shoot when it can't hit target
+	can_breakthrough = TRUE //Can break through doors
+	violent_breakthrough = TRUE
+	speak_chance = 0 //Babble chance
+	cooperative = TRUE //Assist each other
+	wander = TRUE //Wander around
+	returns_home = FALSE
+	home_low_priority = TRUE //Following/helping is more important
+	pointblank = FALSE // Use your fancy melee
+	can_flee = FALSE
+	dying_threshold = 0.1
+	lose_target_timeout = 20 SECONDS
+	run_if_this_close = 2
+	melee_hitnrun_prob = 5  // probability of hit-and-run; null <=> 0 <=> disabled
+	melee_slippery = FALSE  // robust sideways dodging on melee
+	ranged_slippery = TRUE  // robust random dodging on ranged
+	prefer_cover_proba = 0
+	prying = TRUE
 
-/datum/ai_holder/simple_animal/ranged/alien/queen
+/datum/ai_holder/simple_animal/urist_humanoid/alien/queen // Primairly ranged, but will attack with Melee if close.
 	speak_chance = 0
 	aggro_sound = 'sound/voice/hiss4.ogg'
-
-/datum/ai_holder/simple_animal/ranged/alien/queen
+	cooperative = TRUE
+	firing_lanes = FALSE
+	conserve_ammo = FALSE
+	can_breakthrough = TRUE
+	violent_breakthrough = TRUE
 	speak_chance = 0
+	wander = TRUE
+	returns_home = FALSE
+	home_low_priority = TRUE //Following/helping is more important
+	pointblank = FALSE // Use your fancy melee
+	can_flee = FALSE
+	dying_threshold = 0.1
+	lose_target_timeout = 20 SECONDS
+	run_if_this_close = 0
+	melee_hitnrun_prob = 5  // probability of hit-and-run; null <=> 0 <=> disabled
+	melee_slippery = FALSE  // robust sideways dodging on melee
+	ranged_slippery = FALSE
+	prefer_cover_proba = 0
+	prying = TRUE
+
+
+/datum/ai_holder/simple_animal/urist_humanoid/alien/queen/empress // Queen but stronger
 	aggro_sound = 'sound/voice/hiss5.ogg'
+	dying_threshold = 0.1
+	lose_target_timeout = 30 SECONDS

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -29,6 +29,8 @@
 	can_escape = TRUE
 	see_in_dark = 10
 	move_to_delay = 1
+	pry_time = 6 SECONDS
+	ai_holder = /datum/ai_holder/simple_animal/melee/alien
 	natural_armor = list(
 		melee = ARMOR_MELEE_KNIVES
 		)
@@ -53,6 +55,8 @@
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	move_to_delay = 2
+	ai_holder = /datum/ai_holder/simple_animal/ranged/kiting/aliensentinel
+	base_attack_cooldown = 20
 
 /mob/living/simple_animal/hostile/alien/queen
 	name = "alien queen"
@@ -67,6 +71,8 @@
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	rapid = 1
+	base_attack_cooldown = 16
+	ai_holder = /datum/ai_holder/simple_animal/ranged/alien
 	status_flags = 0
 
 /mob/living/simple_animal/hostile/alien/queen/large
@@ -78,6 +84,8 @@
 	move_to_delay = 4
 	maxHealth = 400
 	health = 400
+	base_attack_cooldown = 12
+	ai_holder = /datum/ai_holder/simple_animal/ranged/alien/queen
 	natural_armor = list(
 		melee = ARMOR_MELEE_KNIVES,
 		laser	= ARMOR_LASER_HANDGUNS,
@@ -85,9 +93,28 @@
 		)
 
 /obj/item/projectile/neurotox
-	damage = 30
+	damage = 25
 	icon_state = "toxin"
 
 /mob/living/simple_animal/hostile/alien/death(gibbed, deathmessage, show_dead_message)
 	..(gibbed, "lets out a waning guttural screech, green blood bubbling from its maw...", show_dead_message)
 	playsound(src, 'sound/voice/hiss6.ogg', 100, 1)
+
+// AI Holders
+
+/datum/ai_holder/simple_animal/melee/alien
+	speak_chance = 0
+	aggro_sound = 'sound/voice/hiss2.ogg'
+
+/datum/ai_holder/simple_animal/ranged/kiting/aliensentinel
+	speak_chance = 0
+	aggro_sound = 'sound/voice/hiss2.ogg'
+	run_if_this_close = 3
+
+/datum/ai_holder/simple_animal/ranged/alien/queen
+	speak_chance = 0
+	aggro_sound = 'sound/voice/hiss4.ogg'
+
+/datum/ai_holder/simple_animal/ranged/alien/queen
+	speak_chance = 0
+	aggro_sound = 'sound/voice/hiss5.ogg'

--- a/code/modules/mob/living/simple_animal/natural_weapons.dm
+++ b/code/modules/mob/living/simple_animal/natural_weapons.dm
@@ -36,6 +36,7 @@
 /obj/item/natural_weapon/claws
 	name = "claws"
 	attack_verb = list("mauled", "clawed", "slashed")
+	hitsound = 'sound/weapons/bladeslice.ogg'
 	force = 15
 	sharp = TRUE
 	edge = TRUE


### PR DESCRIPTION
Alien Simple Mobs now use AI_Holders 

- Warriors and Drones will use Melee AI Holders.
- Sentinels now use a Ranged AI Holder, and will attempt to move back to continue shooting if too close to an enemy, to compensate their machine-gun spitting ability has been reduced.
- Queen and Empress now use ranged AI holders, and have slightly increased spit attacks delay, and will attack with claws up close.
- Sets up Alien specific aggro_sounds, Queens and Empress have their own specific sounds, while sentinels and melee use the same.
- Lowers the damage of alien spit by 5, so it isn't always an instant bone-breaker shot.

- Claws now have a cutting sound, meaning the aliens will now cut instead of bludgeon sound you.
