### PR TITLE
Standarizes almost all RIG Control Modules to support Backpacks in Suit Storage Slot

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -54,7 +54,8 @@
 		/obj/item/storage/firstaid,
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/roller_bed,
-		/obj/item/device/suit_cooling_unit
+		/obj/item/device/suit_cooling_unit,
+		/obj/item/storage/backpack
 	)
 
 /obj/item/clothing/shoes/magboots/rig/combat
@@ -139,7 +140,8 @@
 		/obj/item/storage/firstaid,
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/roller_bed,
-		/obj/item/device/suit_cooling_unit
+		/obj/item/device/suit_cooling_unit,
+		/obj/item/storage/backpack
 	)
 
 /obj/item/clothing/shoes/magboots/rig/military

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -57,7 +57,8 @@
 		/obj/item/gun,
 		/obj/item/storage/firstaid,
 		/obj/item/reagent_containers/hypospray,
-		/obj/item/roller_bed
+		/obj/item/roller_bed,
+		/obj/item/storage/backpack
 	)
 
 /obj/item/clothing/shoes/magboots/rig/ert

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -37,7 +37,8 @@
 		/obj/item/handcuffs,
 		/obj/item/tank,
 		/obj/item/device/suit_cooling_unit,
-		/obj/item/cell
+		/obj/item/cell,
+		/obj/item/storage/backpack
 	)
 
 /obj/item/clothing/gloves/rig/light

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -91,7 +91,8 @@
 		/obj/item/ammo_casing,
 		/obj/item/melee/baton,
 		/obj/item/melee/energy/sword,
-		/obj/item/handcuffs
+		/obj/item/handcuffs,
+		/obj/item/storage/backpack
 	)
 
 /obj/item/clothing/shoes/magboots/rig/merc

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -79,7 +79,8 @@
 		/obj/item/device/t_scanner,
 		/obj/item/pickaxe,
 		/obj/item/rcd,
-		/obj/item/rpd
+		/obj/item/rpd,
+		/obj/item/storage/backpack
 	)
 
 /obj/item/clothing/shoes/magboots/rig/industrial
@@ -152,7 +153,8 @@
 		/obj/item/inflatable_dispenser,
 		/obj/item/device/t_scanner,
 		/obj/item/rcd,
-		/obj/item/rpd
+		/obj/item/rpd,
+		/obj/item/storage/backpack
 	)
 
 /obj/item/clothing/shoes/magboots/rig/eva
@@ -247,7 +249,8 @@
 		/obj/item/device/t_scanner,
 		/obj/item/pickaxe,
 		/obj/item/rcd,
-		/obj/item/rpd
+		/obj/item/rpd,
+		/obj/item/storage/backpack
 	)
 /obj/item/clothing/shoes/magboots/rig/ce
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
@@ -308,7 +311,8 @@
 		/obj/item/device/gps,
 		/obj/item/pinpointer/radio,
 		/obj/item/pickaxe/xeno,
-		/obj/item/storage/bag/fossils
+		/obj/item/storage/bag/fossils,
+		/obj/item/storage/backpack
 	)
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_RESOMI,SPECIES_IPC)
 	sprite_sheets = list(
@@ -382,7 +386,8 @@
 		/obj/item/stack/medical,
 		/obj/item/roller_bed,
 		/obj/item/auto_cpr,
-		/obj/item/inflatable_dispenser
+		/obj/item/inflatable_dispenser,
+		/obj/item/storage/backpack
 	)
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_RESOMI,SPECIES_IPC)
 	sprite_sheets = list(
@@ -449,7 +454,8 @@
 		/obj/item/device/flashlight,
 		/obj/item/tank,
 		/obj/item/device/suit_cooling_unit,
-		/obj/item/melee/baton
+		/obj/item/melee/baton,
+		/obj/item/storage/backpack
 	)
 
 /obj/item/clothing/shoes/magboots/rig/hazard

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -46,7 +46,8 @@
 		/obj/item/device/radio,
 		/obj/item/melee/baton,
 		/obj/item/gun,
-		/obj/item/pickaxe
+		/obj/item/pickaxe,
+		/obj/item/storage/backpack
 	)
 
 /obj/item/clothing/shoes/magboots/rig/vox_rig


### PR DESCRIPTION
Standardizes all RIGs to allow for Backpacks.

Certain RIG Suits were missing the ability to carry a backpack in suit storage, mainly CE + CMO, while other RIG Suits already supported this. Made it so pretty much every RIG suit can place a Backpack in Suit Storage. 

RIG's aren't as common here but it's another feature to make it worthwhile to use one, probably some balance considerations as well for this.