### PR TITLE
Away Map Maintenance - Bluespace River

### DIFF
--- a/maps/away/blueriver/blueriver-1.dmm
+++ b/maps/away/blueriver/blueriver-1.dmm
@@ -134,6 +134,10 @@
 	},
 /turf/simulated/floor/away/blueriver/alienfloor,
 /area/bluespaceriver/underground)
+"H" = (
+/obj/structure/scrap,
+/turf/simulated/floor/asteroid,
+/area/bluespaceriver/underground)
 
 (1,1,1) = {"
 a
@@ -2231,7 +2235,7 @@ a
 a
 a
 a
-a
+k
 a
 a
 a
@@ -2332,7 +2336,7 @@ a
 a
 a
 a
-a
+k
 k
 k
 k
@@ -2541,7 +2545,7 @@ k
 k
 k
 k
-a
+k
 a
 a
 a
@@ -2638,12 +2642,12 @@ a
 a
 a
 a
-a
 k
 k
 k
 k
-a
+k
+k
 a
 a
 a
@@ -4267,14 +4271,14 @@ c
 c
 c
 a
-a
-a
+k
+k
 a
 a
 a
 k
 k
-a
+k
 a
 a
 a
@@ -4472,7 +4476,7 @@ f
 c
 l
 k
-k
+a
 k
 k
 n
@@ -4483,7 +4487,7 @@ k
 k
 k
 k
-a
+H
 a
 a
 a
@@ -4577,7 +4581,7 @@ a
 a
 a
 a
-a
+k
 k
 k
 a

--- a/maps/away/blueriver/blueriver-2.dmm
+++ b/maps/away/blueriver/blueriver-2.dmm
@@ -5,8 +5,8 @@
 	},
 /area/bluespaceriver/ground)
 "ab" = (
-/turf/unsimulated/mask{
-	temperature = 230
+/turf/simulated/mineral/random{
+	mined_turf = /turf/simulated/floor/planet/jungle/clear/underground
 	},
 /area/bluespaceriver/ground)
 "ac" = (
@@ -836,12 +836,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bluespaceriver/ship)
+"yi" = (
+/obj/structure/flora/tree/dead,
+/turf/simulated/floor/exoplanet/snow{
+	temperature = 240
+	},
+/area/bluespaceriver/ground)
 "Co" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/wall/titanium,
 /area/bluespaceriver/ship)
 "Lk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/bluespaceriver/ship)
+"RP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/stool/padded,
+/obj/structure/sign/painting/snow{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/bluespaceriver/ship)
 
@@ -2003,7 +2017,7 @@ ac
 ac
 ac
 ac
-ac
+ae
 ac
 ac
 ac
@@ -2395,7 +2409,7 @@ ac
 ac
 ac
 ac
-ac
+ae
 ac
 ac
 af
@@ -2812,7 +2826,7 @@ ac
 ac
 ac
 ac
-ac
+ae
 ac
 ac
 ac
@@ -3049,7 +3063,7 @@ ac
 ac
 ac
 ac
-ac
+ae
 ac
 ac
 ac
@@ -3113,7 +3127,7 @@ ac
 ac
 ac
 ac
-ac
+ae
 ac
 ac
 ac
@@ -3156,7 +3170,7 @@ ac
 ac
 ac
 ac
-ac
+af
 ac
 ac
 ac
@@ -3333,7 +3347,7 @@ an
 ar
 ax
 aA
-aJ
+RP
 aJ
 aX
 bi
@@ -3453,7 +3467,7 @@ cm
 ac
 ac
 ac
-ac
+af
 ac
 ac
 ac
@@ -3524,7 +3538,7 @@ ac
 ac
 ac
 ac
-ac
+yi
 ac
 ac
 ac
@@ -3974,7 +3988,7 @@ ac
 ac
 ac
 ac
-ac
+ae
 ac
 ac
 ac
@@ -4044,7 +4058,7 @@ ac
 ac
 ac
 ac
-ac
+yi
 ac
 ac
 ac
@@ -4160,6 +4174,7 @@ ac
 ac
 ac
 ac
+af
 ac
 ac
 ac
@@ -4169,8 +4184,7 @@ ac
 ac
 ac
 ac
-ac
-ac
+yi
 ac
 ac
 ac
@@ -4265,6 +4279,7 @@ ac
 ac
 ac
 ac
+ae
 ac
 ac
 ac
@@ -4297,8 +4312,7 @@ ac
 ac
 ac
 ac
-ac
-ac
+yi
 ac
 ac
 ac
@@ -4480,7 +4494,7 @@ ac
 ac
 ac
 ac
-ac
+af
 ac
 ac
 ac
@@ -4541,7 +4555,7 @@ ac
 ac
 af
 ac
-ac
+yi
 ac
 ac
 ac
@@ -4830,7 +4844,7 @@ ab
 ab
 ab
 ab
-ac
+ab
 ab
 ab
 ac
@@ -4932,7 +4946,7 @@ ab
 ab
 ab
 ab
-ac
+ab
 ac
 ac
 ac
@@ -4952,7 +4966,7 @@ ac
 ac
 ac
 ac
-ac
+ae
 ac
 ac
 ac
@@ -5034,7 +5048,7 @@ ab
 ab
 ab
 ab
-ac
+ab
 ac
 ac
 ac
@@ -5107,7 +5121,7 @@ ac
 ac
 ac
 ac
-ac
+af
 ac
 ac
 ac
@@ -6033,7 +6047,7 @@ ac
 ac
 ac
 ac
-ac
+yi
 ac
 ac
 ab
@@ -6603,7 +6617,7 @@ ac
 ac
 ac
 ac
-ac
+yi
 ac
 ac
 ac
@@ -7770,7 +7784,7 @@ ac
 ac
 ac
 ac
-ac
+ab
 ab
 ab
 ab
@@ -7972,7 +7986,7 @@ ac
 ac
 ac
 ac
-ac
+yi
 ac
 ac
 ab
@@ -8133,7 +8147,7 @@ ac
 ac
 ac
 ac
-ac
+yi
 ac
 ac
 ai
@@ -8403,7 +8417,7 @@ ab
 ab
 ab
 ac
-ac
+ae
 ac
 ac
 ac
@@ -8983,7 +8997,7 @@ ac
 ac
 ac
 ac
-ac
+ae
 ac
 ac
 ac
@@ -9227,7 +9241,7 @@ ab
 ab
 ac
 ac
-ac
+ae
 ac
 ac
 ac
@@ -9569,7 +9583,7 @@ ac
 ac
 ac
 ac
-ac
+yi
 ac
 ac
 ac
@@ -9793,7 +9807,7 @@ ac
 ac
 ac
 ac
-ac
+yi
 ac
 ac
 ab

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -178,6 +178,52 @@
 /turf/unsimulated/wall/supermatter/no_spread/Process()
 	return PROCESS_KILL
 
+/turf/unsimulated/wall/supermatter/no_spread/attack_ghost(mob/user as mob)
+	user.examinate(src)
+
+/turf/unsimulated/wall/supermatter/no_spread/attack_ai(mob/user as mob)
+	return user.examinate(src)
+
+/turf/unsimulated/wall/supermatter/no_spread/attack_hand(mob/user as mob)
+	user.visible_message("<span class=\"warning\">\The [user] reaches out and touches \the [src]... And then blinks out of existance.</span>",\
+		"<span class=\"danger\">You reach out and touch \the [src]. Everything immediately goes quiet. Your last thought is \"That was not a wise decision.\"</span>",\
+		"<span class=\"warning\">You hear an unearthly noise.</span>")
+
+	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
+
+	Consume(user)
+
+/turf/unsimulated/wall/supermatter/no_spread/attackby(obj/item/W as obj, mob/living/user as mob)
+	user.visible_message("<span class=\"warning\">\The [user] touches \a [W] to \the [src] as a silence fills the room...</span>",\
+		"<span class=\"danger\">You touch \the [W] to \the [src] when everything suddenly goes silent.\"</span>\n<span class=\"notice\">\The [W] flashes into dust as you flinch away from \the [src].</span>",\
+		"<span class=\"warning\">Everything suddenly goes silent.</span>")
+
+	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
+
+	user.drop_from_inventory(W)
+	Consume(W)
+
+/turf/unsimulated/wall/supermatter/no_spread/Bumped(atom/AM as mob|obj)
+	if(istype(AM, /mob/living))
+		AM.visible_message("<span class=\"warning\">\The [AM] slams into \the [src] inducing a resonance... \his body starts to glow and catch flame before flashing into ash.</span>",\
+		"<span class=\"danger\">You slam into \the [src] as your ears are filled with unearthly ringing. Your last thought is \"Oh, fuck.\"</span>",\
+		"<span class=\"warning\">You hear an unearthly noise as a wave of heat washes over you.</span>")
+	else
+		AM.visible_message("<span class=\"warning\">\The [AM] smacks into \the [src] and rapidly flashes to ash.</span>",\
+		"<span class=\"warning\">You hear a loud crack as you are washed with a wave of heat.</span>")
+
+	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
+
+	Consume(AM)
+
+/turf/unsimulated/wall/supermatter/no_spread/proc/Consume(var/atom/A)
+	if(isobserver(A))
+		return
+	if(!A.simulated)
+		return
+	qdel(A)
+
+
 /obj/structure/deity
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "tomealtar"


### PR DESCRIPTION
Supermatter Cascade walls don't seem to really be defined as anything anymore in current Baymerge.

**Main Fixes:**

**turf/unsimulated/mask -> turf/simulated/mineral/random:**

Outskirt turf now uses simulated turf, meaning your lungs and the entire area won't get nuked if someone wants to do a little mining as a treat. Lets people get more minerals and artifacts too.

**Bluespace Liquid:**

Readds bluespace liquid melting just about anything it touches, supermatter cascade walls seem to be mostly removed in current Baymerge sadly, so the functionality seemed to be lost.

**Flora:**

Adds some more trees and such, gives it a little bit more life.

**Tunnels:**

Makes tunnels less straight, slightly more organic look.

![StrongDMM-2024-08-24 01 38 27](https://github.com/user-attachments/assets/9fadf722-2537-45cc-a0e7-199b2f2bfaac)
![StrongDMM-2024-08-24 01 38 34](https://github.com/user-attachments/assets/51298c42-6fa7-4ce6-a900-275f06e80bcf)
