### PR TITLE
Loadout Adjustments - Cigarette Packs, Cig Crafting Gear, Rolled Cigs, Chewing Tobacco + Survial Kit change

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3680,6 +3680,7 @@
 #include "maps\deepmaint\deepmaint_rooms\normal\_normal_rooms.dm"
 #include "maps\deepmaint_wfc\wfc_deepmaint.dm"
 #include "maps\glloydstation\glloydstation_define.dm"
+#include "maps\nerva\loadout\loadout_misc.dm"
 #include "maps\RandomZLevels\maze1.dm"
 #include "maps\torch\torch_define.dm"
 #include "maps\wyrm\items\smcult.dm"

--- a/code/modules/urist/items/miscitems.dm
+++ b/code/modules/urist/items/miscitems.dm
@@ -886,3 +886,14 @@
 	hitsound = "swing_hit"
 	flashlight_max_bright = 0.75
 	flashlight_outer_range = 6
+
+/obj/item/clothing/mask/smokable/cigarette/rolled/tobacco
+	filling = list(/datum/reagent/tobacco = 3)
+
+/obj/item/clothing/mask/smokable/cigarette/rolled/psilocybin
+	desc = "A hand rolled cigarette using dried mushroom matter."
+	filling = list(/datum/reagent/drugs/psilocybin = 5)
+
+/obj/item/clothing/mask/smokable/cigarette/rolled/hextro
+	desc = "A hand rolled cigarette using dried ambrosia leaf." // Hextro seems to be a mix of irl drugs , for now we'll say it has ambrosia leaf in it, just to make it clear to players.
+	filling = list(/datum/reagent/drugs/hextro = 10)

--- a/maps/nerva/loadout/loadout_accessories.dm
+++ b/maps/nerva/loadout/loadout_accessories.dm
@@ -38,7 +38,7 @@
 /datum/gear/tactical/tacticool
 	allowed_roles = null
 
-/datum/gear/survivalkit
+/datum/gear/utility/survivalkit
 	display_name = "survival kit"
 	path = /obj/item/storage/box/survivalkit
 	allowed_roles = SUPPLY_ROLES

--- a/maps/nerva/loadout/loadout_misc.dm
+++ b/maps/nerva/loadout/loadout_misc.dm
@@ -1,0 +1,84 @@
+// Misc Items:
+
+datum/gear/cigpack
+	display_name = "cigarette pack selection"
+	path = /obj/item/storage/fancy/smokable
+	cost = 1
+
+/datum/gear/cigpack/New()
+	..()
+	var/cig = list()
+	cig += /obj/item/storage/fancy/smokable/transstellar
+	cig += /obj/item/storage/fancy/smokable/dromedaryco
+	cig += /obj/item/storage/fancy/smokable/dromedaryco
+	cig += /obj/item/storage/fancy/smokable/luckystars
+	cig += /obj/item/storage/fancy/smokable/jerichos
+	cig += /obj/item/storage/fancy/smokable/menthols
+	cig += /obj/item/storage/fancy/smokable/carcinomas
+	cig += /obj/item/storage/fancy/smokable/professionals
+	cig += /obj/item/storage/fancy/smokable/trident
+	cig += /obj/item/storage/fancy/smokable/trident_fruit
+	cig += /obj/item/storage/fancy/smokable/trident_mint
+	cig += /obj/item/storage/fancy/smokable/urist/uplift
+	cig += /obj/item/storage/fancy/smokable/urist/devil
+	cig += /obj/item/storage/fancy/smokable/urist/carp
+	cig += /obj/item/storage/fancy/smokable/urist/midori
+	cig += /obj/item/storage/fancy/smokable/urist/shadyjim
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(cig)
+
+/datum/gear/rolledcig
+	display_name = "rolled cigarette selection"
+	path = /obj/item/clothing/mask/smokable/cigarette/rolled
+	cost = 1
+
+/datum/gear/rolledcig/New()
+	..()
+	var/rolled = list()
+	rolled += /obj/item/clothing/mask/smokable/cigarette/rolled/tobacco
+	rolled += /obj/item/clothing/mask/smokable/cigarette/rolled/psilocybin
+	rolled += /obj/item/clothing/mask/smokable/cigarette/rolled/hextro
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(rolled)
+
+/datum/gear/tobacco
+	display_name = "rolling tobacco selection"
+	path = /obj/item/storage/chewables/rollable
+	path = 1
+
+/datum/gear/tobacco/New()
+	..()
+	var/tobacco = list()
+	tobacco += /obj/item/storage/chewables/rollable/bad
+	tobacco += /obj/item/storage/chewables/rollable/generic
+	tobacco += /obj/item/storage/chewables/rollable/fine
+	tobacco += /obj/item/storage/chewables/rollable/rollingkit
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(tobacco)
+
+/datum/gear/chewing
+	display_name = "chewing tobacco selection"
+	path = /obj/item/storage/chewables/tobacco
+	cost = 1
+
+/datum/gear/chewing/New()
+	..()
+	var/chewing = list()
+	chewing += /obj/item/storage/chewables/tobacco
+	chewing += /obj/item/storage/chewables/tobacco2
+	chewing += /obj/item/storage/chewables/tobacco3
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(chewing)
+
+datum/gear/rollingpaper
+	display_name = "rolling paper selection"
+	path = /obj/item/paper/cig
+	cost = 1
+
+/datum/gear/rollingpaper/New()
+	..()
+	var/rollingpaper = list()
+	rollingpaper += /obj/item/paper/cig
+	rollingpaper += /obj/item/paper/cig/fancy
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(rollingpaper)
+
+datum/gear/misc/rollingfilter
+	display_name = "cigarette filters"
+	path = /obj/item/paper/cig/filter
+	cost = 1


### PR DESCRIPTION
**Cigarettes:**

- You can now buy cigarette packets using loadout points, allowing you to buy all normal + urist cigarettes, no antag ciggies. 
- You can buy cigarette crafting gear (rolling tobacco, filters, full cig kit)
- You can buy chewing tobacco + chewing gum from the loadout.
- You can buy rolled cigarettes - Containing tobacco, or with a small amount of psilocibin or hextro. For true botanist mains, who enjoy their ambrosia on the job. 

**Catergories:**

- Survival Kits have been moved from General Catergory to Utility, which is better suited for it's purpose.