### PR TITLE
Ports Bay Parrot Sprite Fix 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -115,6 +115,10 @@
 			  /mob/living/simple_animal/hostile/retaliate/parrot/verb/drop_held_item_player, \
 			  /mob/living/simple_animal/hostile/retaliate/parrot/proc/perch_player)
 
+	icon_state = "[icon_set]_fly"
+	icon_living = "[icon_set]_fly"
+	icon_dead = "[icon_set]_dead"
+
 	update_icon()
 
 /mob/living/simple_animal/hostile/retaliate/parrot/death(gibbed, deathmessage, show_dead_message)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -132,11 +132,6 @@
 	. = ..()
 	stat("Held Item", held_item)
 
-/mob/living/simple_animal/hostile/retaliate/parrot/on_update_icon()
-	icon_state = "[icon_set]_fly"
-	icon_living = "[icon_set]_fly"
-	icon_dead = "[icon_set]_dead"
-
 /*
  * Inventory
  */


### PR DESCRIPTION
Ports Bay Fix -  Parrots now correctly display the right sprites when dead, including for Giant Parrots, etc.
Jungle Planet now has a lot less dead flying parrots around, yay!

![image](https://github.com/user-attachments/assets/cbc4eff9-80d4-46e3-894e-e9054429e1d7)
