### PR TITLE
Failed CPR actions have a more clear [SPAN] text.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -114,10 +114,10 @@
 					to_chat(H, SPAN_WARNING("You've done chest compressions, but they don't have a mouth to do mouth-to-mouth resuscitation!"))
 					return
 				if((H.head && (H.head.body_parts_covered & FACE)) || (H.wear_mask && (H.wear_mask.body_parts_covered & FACE)))
-					to_chat(H, SPAN_WARNING("You need to remove your mouth covering for mouth-to-mouth resuscitation!"))
+					to_chat(H, SPAN_DANGER("You need to remove your mouth covering for mouth-to-mouth resuscitation!"))
 					return 0
 				if((head && (head.body_parts_covered & FACE)) || (wear_mask && (wear_mask.body_parts_covered & FACE)))
-					to_chat(H, SPAN_WARNING("You need to remove \the [src]'s mouth covering for mouth-to-mouth resuscitation!"))
+					to_chat(H, SPAN_DANGER("You need to remove \the [src]'s mouth covering for mouth-to-mouth resuscitation!"))
 					return 0
 				if (!H.internal_organs_by_name[H.species.breathing_organ])
 					to_chat(H, SPAN_DANGER("You need lungs for mouth-to-mouth resuscitation!"))


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b9e0d8c6-7ccc-4223-bf2c-2083e5200967)

CPR that fails due to having a mask, or the subject having a mask will now span a red text, instead of blue. Making it more immediatley clear the issue. I noticed missing the failed CPR notifications for a bit as they were colored the same as normal text.