### PR TITLE
Away Map Tweakage

### DIFF
--- a/maps/away/blueriver/blueriver-2.dmm
+++ b/maps/away/blueriver/blueriver-2.dmm
@@ -589,6 +589,8 @@
 /area/bluespaceriver/ship)
 "bQ" = (
 /obj/machinery/artifact_scanpad,
+/obj/machinery/anomaly_container,
+/obj/machinery/artifact,
 /turf/simulated/floor/reinforced,
 /area/bluespaceriver/ship)
 "bR" = (

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -153,10 +153,9 @@
 /turf/simulated/floor/tiled,
 /area/casino/casino_bridge)
 "aw" = (
-/obj/item/wirecutters,
-/obj/item/stack/material/rods,
-/turf/space,
-/area/space)
+/obj/effect/landmark/corpse/chef,
+/turf/simulated/floor/tiled,
+/area/casino/casino_kitchen)
 "ax" = (
 /obj/machinery/computer/modular{
 	dir = 4
@@ -4231,6 +4230,7 @@
 "lF" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/corpse/nt/exec,
 /turf/simulated/floor/wood,
 /area/casino/casino_private_vip)
 "lG" = (
@@ -5449,6 +5449,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/casino/casino_crew_atmos)
+"Os" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/corpse/miner,
+/turf/simulated/floor/tiled,
+/area/casino/casino_crew_bunk)
 "OB" = (
 /obj/structure/window/basic{
 	dir = 4
@@ -5591,6 +5602,11 @@
 	},
 /turf/simulated/floor/airless,
 /area/casino/casino_bow)
+"SM" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/corpse/doctor,
+/turf/simulated/floor/tiled,
+/area/casino/casino_crew_bunk)
 "SP" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -10490,7 +10506,7 @@ aB
 bA
 ca
 ct
-cN
+SM
 de
 dx
 dO
@@ -10813,7 +10829,7 @@ vc
 fQ
 ht
 hw
-hw
+aw
 hV
 hw
 hw
@@ -10897,7 +10913,7 @@ bi
 bp
 bD
 ca
-cv
+Os
 cN
 dh
 dx

--- a/maps/away/mobius_rift/mobius_rift.dmm
+++ b/maps/away/mobius_rift/mobius_rift.dmm
@@ -74,7 +74,7 @@
 /turf/simulated/floor/cult,
 /area/mobius_rift)
 "Q" = (
-/obj/structure/fountain/strange,
+/obj/structure/fountain,
 /turf/simulated/floor/cult,
 /area/mobius_rift)
 "W" = (

--- a/maps/away/mobius_rift/mobius_rift.dmm
+++ b/maps/away/mobius_rift/mobius_rift.dmm
@@ -66,6 +66,21 @@
 /obj/effect/shuttle_landmark/automatic,
 /turf/unsimulated/beach/sand,
 /area/mobius_rift)
+"O" = (
+/obj/item/archaeological_find/bowl,
+/turf/simulated/floor/cult,
+/area/mobius_rift)
+"P" = (
+/turf/simulated/floor/cult,
+/area/mobius_rift)
+"Q" = (
+/obj/structure/fountain/strange,
+/turf/simulated/floor/cult,
+/area/mobius_rift)
+"W" = (
+/obj/item/archaeological_find/bowl/urn,
+/turf/simulated/floor/cult,
+/area/mobius_rift)
 
 (1,1,1) = {"
 a
@@ -9615,7 +9630,7 @@ e
 e
 e
 d
-d
+e
 f
 k
 f
@@ -10024,7 +10039,7 @@ e
 k
 k
 e
-d
+e
 b
 c
 c
@@ -10219,7 +10234,7 @@ h
 h
 e
 j
-e
+h
 h
 h
 h
@@ -10418,9 +10433,9 @@ c
 b
 d
 h
-i
-i
-d
+h
+h
+e
 e
 l
 h
@@ -10620,17 +10635,17 @@ b
 b
 d
 e
-d
 e
 e
-e
-e
-h
+W
+P
+P
+P
 h
 e
 k
 e
-d
+e
 b
 b
 b
@@ -10823,12 +10838,12 @@ d
 d
 e
 h
-e
 k
+P
+P
+Q
+O
 e
-e
-d
-d
 e
 k
 e
@@ -11026,11 +11041,11 @@ d
 e
 h
 k
-k
+O
+P
+P
+P
 e
-j
-e
-d
 k
 k
 k
@@ -11230,13 +11245,13 @@ h
 k
 e
 e
+j
 e
-d
-d
+e
 k
 k
 k
-d
+e
 b
 c
 c
@@ -11428,12 +11443,12 @@ c
 b
 d
 e
-e
+k
 f
 e
 e
-d
-i
+e
+h
 h
 k
 k
@@ -11634,7 +11649,7 @@ f
 f
 e
 j
-i
+h
 h
 h
 e
@@ -11840,7 +11855,7 @@ e
 h
 h
 e
-e
+j
 e
 d
 b

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -73,7 +73,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/giant_spider/hunter,
+/mob/living/simple_animal/hostile/giant_spider/spitter,
 /turf/simulated/floor/wood/walnut,
 /area/yacht/bridge)
 "ao" = (
@@ -1469,6 +1469,14 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/turf/simulated/floor/plating,
+/area/yacht/engine)
+"Ow" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/giant_spider/hunter,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "Ty" = (
@@ -7029,7 +7037,7 @@ bF
 aB
 bN
 ca
-cn
+Ow
 cn
 ub
 bN


### PR DESCRIPTION
**Tweaks and Additions to Away Maps:**
forgot to change my git config username, but we ball

- Bluespace River now has a anomaly inside of a anomaly container on the landed vessel that science/cargo can recover.

- Casino now has some corpses to go with all of the tomato soup on the floor.

- Moebius Rift has a mysterious fountain in one of it's maze-like areas, surrounded by some small archelogical finds (bowls, urns, etc.)

- Adjusts Casino/Yacht, adds one additional spider spawn and changes the spider in the cockpit to a spitter.