### PR TITLE
fixes fountains pulling an old urist icon instead of the bay one

### DIFF
--- a/code/modules/urist/modules/jungle/temple.dm
+++ b/code/modules/urist/modules/jungle/temple.dm
@@ -395,7 +395,7 @@
 
 //structures
 
-/obj/structure/fountain
+/obj/structure/fountain/strange/urist
 	name = "fountain"
 	desc = "A fountain that appears to be spewing red water. Wait... Is that blood?"
 	icon = 'icons/urist/jungle/64x64.dmi'


### PR DESCRIPTION
note that this will have an effect on #1596 @Laniakeaaa. if you want the icon to be the same as you currently have it, you'll need to update the path on the fountain you've placed to what I've done here.