### PR TITLE
Fix crafting rails with aluminium

### DIFF
--- a/code/controllers/subsystems/initialization/fabrication.dm
+++ b/code/controllers/subsystems/initialization/fabrication.dm
@@ -59,7 +59,7 @@ SUBSYSTEM_DEF(fabrication)
 		return
 	var/list/stages = SSfabrication.find_crafting_recipes(target.type)
 	for (var/singleton/crafting_stage/stage in stages)
-		if (stage.can_begin_with(target) && stage.is_appropriate_tool(tool))
+		if (stage.can_begin_with(target) && stage.is_appropriate_tool(tool, user))
 			var/obj/item/crafting_holder/crafting = new (turf, stage, target, tool, user)
 			if (stage.progress_to(tool, user, crafting))
 				return crafting

--- a/code/modules/crafting/_crafting_stage.dm
+++ b/code/modules/crafting/_crafting_stage.dm
@@ -64,9 +64,16 @@
 	consume_completion_trigger = FALSE
 	var/stack_material = MATERIAL_STEEL
 
+/singleton/crafting_stage/material/is_appropriate_tool(obj/item/thing, mob/user)
+	. = ..()
+	var/obj/item/stack/material/M = thing
+	if (!istype(M) || stack_material && M.material.name != stack_material)
+		to_chat(user, SPAN_WARNING("\The [thing] is not made of the right material for that."))
+		return FALSE
+
 /singleton/crafting_stage/material/consume(mob/user, obj/item/thing, obj/item/target)
 	var/obj/item/stack/material/M = thing
-	. = istype(M) && (!stack_material || M.material.name == stack_material) && ..()
+	. = istype(M) && ..()
 
 /singleton/crafting_stage/welding
 	consume_completion_trigger = FALSE


### PR DESCRIPTION
Closes #1572 

Caused by not being able to make rails out of anything but steel, which appears to be intentional. However, deleting the cables is not intentional.
This was caused by the cables being moved into the `crafting_holder` which is later `qdel`'d before checking if the material is correct. 
Fixed by overloading the `is_appropriate_tool` proc to check for matching materials there first.
Also added a message so the user knows _why_ it failed

