### PR TITLE
Additional Glloydstation Fixing

### DIFF
--- a/maps/glloydstation/Glloydstation2-1.dmm
+++ b/maps/glloydstation/Glloydstation2-1.dmm
@@ -4612,7 +4612,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "Blueshield Offices"
+	c_tag = "Blueshield Offices";
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood/walnut,
 /area/bridge/blueshield)
@@ -5414,7 +5415,9 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge)
 "alJ" = (
-/obj/structure/sign/warning/high_voltage,
+/obj/structure/sign/warning/high_voltage{
+	pixel_x = -32
+	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/bridge)
 "alK" = (
@@ -6374,6 +6377,10 @@
 /obj/effect/floor_decal/corner/brown{
 	icon_state = "corner_white";
 	dir = 6
+	},
+/obj/machinery/newscaster{
+	pixel_x = 28;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -8126,6 +8133,10 @@
 /obj/item/device/assembly/timer,
 /obj/item/device/assembly/signaler,
 /obj/item/device/assembly/signaler,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/bridge)
 "arP" = (
@@ -8147,10 +8158,6 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "arR" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
-	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
@@ -8199,27 +8206,32 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "arV" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/bridge)
-"arW" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/high;
 	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge)
+"arW" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/blue{
 	icon_state = "corner_white";
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -10793,6 +10805,10 @@
 	icon_state = "warning";
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/teleporter)
 "awZ" = (
@@ -12059,10 +12075,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "azM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13878,7 +13890,7 @@
 	},
 /obj/machinery/mass_driver{
 	dir = 4;
-	id_tag = "chapelgun"
+	id_tag = "chapelgun";
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/effect/floor_decal/corner/black/diagonal{
@@ -27744,12 +27756,11 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/command/hos)
 "bfH" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
@@ -33166,9 +33177,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/genetics_cloning)
 "bqb" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = 25;
@@ -34171,6 +34179,11 @@
 /area/medical/genetics_cloning)
 "brZ" = (
 /obj/machinery/dna_scannernew,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/genetics_cloning)
 "bsa" = (
@@ -37640,9 +37653,6 @@
 	pixel_y = 25;
 	req_access = list("ACCESS_SECURITY");
 	tag_door = "security_shuttle_hatch"
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/structure/bed/chair/urist/shuttle{
 	icon_state = "shuttlechair";
@@ -42513,10 +42523,6 @@
 	icon_state = "corner_white";
 	dir = 6
 	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "bIs" = (
@@ -42530,6 +42536,10 @@
 	},
 /obj/effect/floor_decal/corner/lime/three_quarters{
 	dir = 8
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
@@ -44496,9 +44506,6 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/machinery/camera/network/mining{
-	c_tag = "Cargo Bay North"
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "bMh" = (
@@ -44509,6 +44516,9 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
+	},
+/obj/machinery/camera/network/mining{
+	c_tag = "Cargo Bay North"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
@@ -45188,6 +45198,9 @@
 /obj/structure/closet/secure_closet/bar{
 	req_access = list("ACCESS_KITCHEN")
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/bar)
 "bNq" = (
@@ -45519,10 +45532,6 @@
 	pixel_x = -26;
 	pixel_y = 0;
 	pixel_z = 0
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
 	},
 /obj/effect/floor_decal/corner/lime/three_quarters,
 /turf/simulated/floor/tiled,
@@ -46178,9 +46187,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/bar)
 "bPs" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/closet/gmcloset{
 	icon_state = "black";
 	name = "formal wardrobe"
@@ -47119,10 +47125,6 @@
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
 "bRB" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -47174,6 +47176,10 @@
 	},
 /obj/machinery/camera/network/research{
 	c_tag = "Research Director's Office North"
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/command/rd)
@@ -48164,6 +48170,10 @@
 "bTA" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
+	dir = 8
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -49225,6 +49235,9 @@
 /mob/living/bot/mulebot{
 	suffix = "#1"
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "bVF" = (
@@ -49988,9 +50001,6 @@
 /obj/machinery/navbeacon{
 	codes = list("delivery" = 1, "dir" = 8);
 	location = "QM #2"
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/machinery/light_switch{
 	dir = 4;
@@ -50969,7 +50979,9 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "bZp" = (
-/mob/living/carbon/human/monkey/punpun,
+/mob/living/carbon/human/monkey/punpun{
+	real_name = "Pun Pun"
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
 "bZq" = (
@@ -51146,11 +51158,11 @@
 /obj/structure/table/standard,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/command/rd)
 "bZM" = (
@@ -52072,10 +52084,6 @@
 /obj/structure/table/standard,
 /obj/item/folder/white,
 /obj/item/stamp/rd,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -56533,9 +56541,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/camera/network/mining{
 	c_tag = "Trading Post";
 	dir = 8;
@@ -56959,9 +56964,6 @@
 /area/rnd/xenobiology)
 "cla" = (
 /obj/structure/closet/secure_closet/scientist,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/storage/backpack/satchel/tox,
 /obj/item/storage/backpack/duffel/duffel_tox,
 /obj/item/clothing/suit/storage/hooded/wintercoat/science,
@@ -59563,6 +59565,11 @@
 /area/shuttle/mining/station)
 "cqh" = (
 /obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/mining/station)
 "cqi" = (
@@ -59578,9 +59585,6 @@
 	pixel_y = -8;
 	req_access = list("ACCESS_EXTERNAL","ACCESS_MINING");
 	tag_door = "mining_shuttle_hatch"
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor/shuttle/white,
 /area/shuttle/mining/station)
@@ -79364,10 +79368,10 @@
 	},
 /obj/machinery/door/airlock/hatch{
 	icon_state = "door_locked";
-	id_tag = "engine_electrical_maintenance";
 	locked = 1;
 	name = "Engine Electrical Maintenance";
-	req_access = list("ACCESS_ENGINEERING")
+	req_access = list("ACCESS_ENGINEERING");
+	id_tag = "engine_electrical_maintenance";
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -80725,14 +80729,14 @@
 /obj/machinery/camera/network/engineering{
 	c_tag = "Drone Fabricator"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "dhu" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -82885,9 +82889,6 @@
 	req_access = list("ACCESS_EXTERNAL","ACCESS_ENGINE_EQUIP","ACCESS_ATMOS");
 	tag_door = "engineering_shuttle_hatch"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/bed/chair/urist/shuttle{
 	icon_state = "shuttlechair";
 	dir = 4
@@ -82912,6 +82913,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/constructionsite/station)
@@ -83093,6 +83099,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
+"ebb" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "enX" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light{
@@ -83513,6 +83526,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
+/area/bridge)
+"hIZ" = (
+/obj/structure/sign/warning/high_voltage{
+	pixel_x = 32
+	},
+/turf/simulated/wall/r_wall/prepainted,
 /area/bridge)
 "hKy" = (
 /obj/machinery/firealarm{
@@ -84472,6 +84491,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
+"pXE" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/securityoutpost/station)
 "qaF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -84538,6 +84566,13 @@
 	},
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_hall)
+"qJn" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology)
 "qKz" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -95947,7 +95982,7 @@ buc
 bvR
 bnE
 bzi
-bzi
+pXE
 bzi
 bBb
 aaa
@@ -101845,8 +101880,8 @@ aVJ
 aXR
 aZG
 bbL
-bdI
 bfH
+bdI
 bhz
 aLn
 bhj
@@ -109331,7 +109366,7 @@ cdJ
 bGN
 cgQ
 ciH
-bGN
+ebb
 bGN
 cng
 bBB
@@ -119804,7 +119839,7 @@ aae
 aaa
 aaa
 aaa
-alJ
+hIZ
 amO
 anK
 aoE
@@ -132975,7 +133010,7 @@ cez
 cgg
 cia
 cjy
-ckZ
+qJn
 cmD
 cob
 cpH

--- a/maps/glloydstation/Glloydstation2-1.dmm
+++ b/maps/glloydstation/Glloydstation2-1.dmm
@@ -13890,7 +13890,7 @@
 	},
 /obj/machinery/mass_driver{
 	dir = 4;
-	id_tag = "chapelgun";
+	id_tag = "chapelgun"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/effect/floor_decal/corner/black/diagonal{
@@ -14494,17 +14494,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fore)
 "aFn" = (
-/obj/machinery/button/remote/driver{
-	id_tag = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = 25
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
+/obj/machinery/button/mass_driver{
+	pixel_x = 32;
+	id_tag = "chapelgun"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fore)
 "aFo" = (
@@ -41528,11 +41527,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
 "bGp" = (
-/obj/machinery/button/remote/driver{
-	id_tag = "toxinsdriver";
-	pixel_x = -25;
-	pixel_y = 3
-	},
 /obj/item/device/radio/intercom{
 	dir = 2;
 	name = "Station Intercom (General)";
@@ -41544,14 +41538,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/alarm{
-	pixel_y = 30
-	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
 "bGr" = (
 /obj/machinery/computer/modular/preset/aislot/research{
 	dir = 8
+	},
+/obj/machinery/button/mass_driver{
+	pixel_y = 32;
+	id_tag = "toxinsdriver"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
@@ -42481,6 +42476,11 @@
 	c_tag = "Toxins Mass Driver";
 	dir = 4;
 	icon_state = "camera"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/mixing)
@@ -79141,17 +79141,13 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/button/remote/airlock{
-	desiredstate = 1;
-	id_tag = "engine_electrical_maintenance";
-	name = "Door Bolt Control";
-	pixel_x = 5;
-	pixel_y = -25;
-	req_access = list("ACCESS_ENGINEERING");
-	specialfunctions = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
+	},
+/obj/machinery/button/alternate/door/bolts{
+	pixel_y = -32;
+	name = "Door Bolt Control";
+	id_tag = "engine_electrical_maintenance"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_smes)
@@ -79371,7 +79367,7 @@
 	locked = 1;
 	name = "Engine Electrical Maintenance";
 	req_access = list("ACCESS_ENGINEERING");
-	id_tag = "engine_electrical_maintenance";
+	id_tag = "engine_electrical_maintenance"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -79429,6 +79425,15 @@
 	req_access = list("ACCESS_ENGINEERING")
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/button/remote/airlock{
+	desiredstate = 1;
+	id_tag = "engine_electrical_maintenance";
+	name = "Door Bolt Control";
+	pixel_x = 5;
+	pixel_y = -25;
+	req_access = list("ACCESS_ENGINEERING");
+	specialfunctions = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_airlock)
 "deD" = (

--- a/maps/glloydstation/Glloydstation2-5.dmm
+++ b/maps/glloydstation/Glloydstation2-5.dmm
@@ -1197,9 +1197,6 @@
 /turf/simulated/floor/plating,
 /area/outpost/research/eva)
 "cQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	cycle_to_external_air = 1;
 	frequency = 1379;
@@ -1219,6 +1216,9 @@
 /obj/effect/floor_decal/corner/mauve/three_quarters{
 	icon_state = "corner_white_three_quarters";
 	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/research/eva)
@@ -1623,10 +1623,6 @@
 	dir = 4;
 	pixel_x = -23;
 	pixel_y = 0
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
 	},
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -2347,6 +2343,22 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space,
 /area/space)
+"gP" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/void/mining,
+/obj/item/device/scanner/mining,
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/eva)
 "mg" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
 	dir = 8;
@@ -15707,7 +15719,7 @@ dk
 bK
 bK
 dF
-dR
+gP
 dV
 ef
 ew

--- a/maps/glloydstation/Glloydstation2-7.dmm
+++ b/maps/glloydstation/Glloydstation2-7.dmm
@@ -659,17 +659,15 @@
 /turf/simulated/floor/carpet,
 /area/outpost/research/hallway)
 "cg" = (
-/obj/machinery/button/remote/airlock{
-	id_tag = "rdorm1";
-	name = "Door Bolt Control";
-	pixel_x = 25;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/button/alternate/door/bolts{
+	pixel_x = 32;
+	id_tag = "rdorm1";
+	name = "Door Bolt Control"
+	},
 /turf/simulated/floor/carpet,
 /area/outpost/research/hallway)
 "ch" = (
@@ -695,17 +693,15 @@
 /turf/simulated/floor/tiled,
 /area/outpost/research/hallway)
 "ck" = (
-/obj/machinery/button/remote/airlock{
-	id_tag = "rdorm2";
-	name = "Door Bolt Control";
-	pixel_x = -25;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	id_tag = "rdorm2";
+	pixel_x = -32
+	},
 /turf/simulated/floor/carpet,
 /area/outpost/research/hallway)
 "cl" = (
@@ -835,7 +831,7 @@
 	},
 /obj/machinery/door/airlock{
 	name = "Dorm 1";
-	id_tag = "rdorm1";
+	id_tag = "rdorm1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	color = "#4444ff";
@@ -877,7 +873,7 @@
 	},
 /obj/machinery/door/airlock{
 	name = "Dorm 2";
-	id_tag = "rdorm2";
+	id_tag = "rdorm2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1393,18 +1389,16 @@
 /turf/simulated/floor/tiled/freezer,
 /area/outpost/research/hallway)
 "dJ" = (
-/obj/machinery/button/blast_door{
-	name = "Door Bolt Control";
-	pixel_x = 0;
-	pixel_y = -25;
-	req_access = "0";
-	id_tag = "rbath";
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	pixel_y = -32;
+	id_tag = "rbath"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/outpost/research/hallway)
@@ -1415,7 +1409,7 @@
 	},
 /obj/machinery/door/airlock{
 	name = "Bathroom";
-	id_tag = "rbath";
+	id_tag = "rbath"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7519,15 +7513,13 @@
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
 "pD" = (
-/obj/machinery/button/remote/airlock{
-	id_tag = "miningdorm1";
-	name = "Door Bolt Control";
-	pixel_x = 25;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	id_tag = "miningdorm1";
+	pixel_x = 32
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -7544,15 +7536,13 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/dorms)
 "pG" = (
-/obj/machinery/button/remote/airlock{
-	id_tag = "secplanetdorm8";
-	name = "Door Bolt Control";
-	pixel_x = -25;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	id_tag = "secplanetdorm8";
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -7637,28 +7627,24 @@
 /turf/simulated/floor/planet/jungle/rock,
 /area/planet/jungle)
 "pW" = (
-/obj/machinery/button/remote/airlock{
-	id_tag = "miningdorm2";
-	name = "Door Bolt Control";
-	pixel_x = 25;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	id_tag = "miningdorm2";
+	pixel_x = 32
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
 "pX" = (
-/obj/machinery/button/remote/airlock{
-	id_tag = "secplanetdorm2";
-	name = "Door Bolt Control";
-	pixel_x = -25;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	id_tag = "secplanetdorm2";
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -7794,15 +7780,13 @@
 /turf/simulated/floor/tiled/white,
 /area/outpost/mining_main/dorms)
 "qx" = (
-/obj/machinery/button/remote/airlock{
-	id_tag = "miningdorm3";
-	name = "Door Bolt Control";
-	pixel_x = 25;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	id_tag = "miningdorm3";
+	pixel_x = 32
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -7827,15 +7811,13 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/dorms)
 "qA" = (
-/obj/machinery/button/remote/airlock{
-	id_tag = "secplanetdorm7";
-	name = "Door Bolt Control";
-	pixel_x = -25;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	id_tag = "secplanetdorm7";
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -8156,15 +8138,13 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/dorms)
 "rv" = (
-/obj/machinery/button/remote/airlock{
-	id_tag = "secplanetdorm6";
-	name = "Door Bolt Control";
-	pixel_x = -25;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	id_tag = "secplanetdorm6";
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -12462,6 +12442,13 @@
 "KH" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
+/area/planet/jungle)
+"Rj" = (
+/obj/machinery/button/alternate/door/bolts{
+	name = "Door Bolt Control";
+	pixel_y = -32
+	},
+/turf/simulated/floor/planet/jungle,
 /area/planet/jungle)
 "RQ" = (
 /obj/machinery/barrier,
@@ -32848,7 +32835,7 @@ bn
 bn
 bn
 bn
-bn
+Rj
 bn
 bn
 bn

--- a/maps/glloydstation/Glloydstation2-7.dmm
+++ b/maps/glloydstation/Glloydstation2-7.dmm
@@ -834,8 +834,8 @@
 	name = "Firelock"
 	},
 /obj/machinery/door/airlock{
+	name = "Dorm 1";
 	id_tag = "rdorm1";
-	name = "Dorm 1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	color = "#4444ff";
@@ -876,8 +876,8 @@
 	name = "Firelock"
 	},
 /obj/machinery/door/airlock{
+	name = "Dorm 2";
 	id_tag = "rdorm2";
-	name = "Dorm 2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1199,9 +1199,6 @@
 /obj/structure/hygiene/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/alarm{
 	frequency = 1441;
 	pixel_y = 22
@@ -1392,6 +1389,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/freezer,
 /area/outpost/research/hallway)
 "dJ" = (
@@ -1400,7 +1398,7 @@
 	pixel_x = 0;
 	pixel_y = -25;
 	req_access = "0";
-	id_tag = "rbath"
+	id_tag = "rbath";
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1416,8 +1414,8 @@
 	name = "Firelock"
 	},
 /obj/machinery/door/airlock{
+	name = "Bathroom";
 	id_tag = "rbath";
-	name = "Bathroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1737,6 +1735,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/analysis)
 "ew" = (
@@ -1745,10 +1744,6 @@
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -7186,9 +7181,6 @@
 	c_tag = "Research Outpost Isolation Cell A";
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_a)
 "oB" = (
@@ -7213,9 +7205,6 @@
 	c_tag = "Research Outpost Isolation Cell B";
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/research/isolation_b)
 "oE" = (
@@ -7234,9 +7223,6 @@
 /obj/machinery/camera/network/research_outpost{
 	c_tag = "Research Outpost Isolation Cell C";
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/isolation_c)
@@ -7261,6 +7247,7 @@
 /area/outpost/research/isolation_b)
 "oL" = (
 /obj/machinery/artifact_scanpad,
+/obj/machinery/light,
 /turf/simulated/floor/bluegrid,
 /area/outpost/research/isolation_b)
 "oM" = (
@@ -7276,6 +7263,7 @@
 "oO" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/outpost/research/isolation_c)
 "oP" = (
@@ -7531,15 +7519,15 @@
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
 "pD" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/button/remote/airlock{
 	id_tag = "miningdorm1";
 	name = "Door Bolt Control";
 	pixel_x = 25;
 	pixel_y = 0;
 	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -7564,7 +7552,7 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/small{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -7574,8 +7562,12 @@
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
 "pI" = (
-/turf/simulated/wall,
-/area/planet/jungle)
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/outpost/security/storage)
 "pJ" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/carpet,
@@ -7645,15 +7637,15 @@
 /turf/simulated/floor/planet/jungle/rock,
 /area/planet/jungle)
 "pW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/button/remote/airlock{
 	id_tag = "miningdorm2";
 	name = "Door Bolt Control";
 	pixel_x = 25;
 	pixel_y = 0;
 	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -7666,7 +7658,7 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/small{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -7802,15 +7794,15 @@
 /turf/simulated/floor/tiled/white,
 /area/outpost/mining_main/dorms)
 "qx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/button/remote/airlock{
 	id_tag = "miningdorm3";
 	name = "Door Bolt Control";
 	pixel_x = 25;
 	pixel_y = 0;
 	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -7843,7 +7835,7 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/small{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -8172,7 +8164,7 @@
 	specialfunctions = 4
 	},
 /obj/machinery/light/small{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/outpost/mining_main/dorms)
@@ -10304,6 +10296,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
 "wv" = (
@@ -10323,9 +10318,6 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "mining_internal";
 	name = "mining conveyor"
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -10469,7 +10461,6 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/security/storage)
 "wJ" = (
@@ -10656,9 +10647,6 @@
 /obj/machinery/status_display{
 	pixel_x = 0;
 	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12458,10 +12446,32 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/planet/jungle)
+"Jh" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "KH" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/planet/jungle)
+"RQ" = (
+/obj/machinery/barrier,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/outpost/security/storage)
 
 (1,1,1) = {"
 aa
@@ -20134,7 +20144,7 @@ pe
 pe
 px
 pB
-pI
+pe
 ac
 ac
 py
@@ -23235,7 +23245,7 @@ ud
 uJ
 vk
 vF
-wh
+RQ
 wh
 uJ
 xN
@@ -24262,8 +24272,8 @@ tE
 ud
 uJ
 vo
-vJ
 wj
+pI
 wJ
 uJ
 uK
@@ -34544,7 +34554,7 @@ qs
 qs
 vX
 qs
-xe
+Jh
 xB
 tm
 yO

--- a/maps/glloydstation/glloydstation_define.dm
+++ b/maps/glloydstation/glloydstation_define.dm
@@ -12,6 +12,17 @@
 	company_short = "NT"
 	ert_context = "NanoTrasen"
 	lobby_screens = list('maps/glloydstation/glloydstation_lobby.png')
+	lobby_tracks = list(
+		/singleton/audio/track/df_theme,
+		/singleton/audio/track/digit_one,
+		/singleton/audio/track/dilbert,
+		/singleton/audio/track/chasing_time,
+		/singleton/audio/track/human,
+		/singleton/audio/track/lysendraa,
+		/singleton/audio/track/level3_mod,
+		/singleton/audio/track/rimward_cruise,
+		/singleton/audio/track/ambispace
+	)
 	current_lobby_screen = 'maps/glloydstation/glloydstation_lobby.png'
 
 	station_levels = list(1)


### PR DESCRIPTION
Thought I'd caught most of it in https://github.com/UristMcStation/UristMcStation/pull/1609, but after walking around the station for an hour or so I catalogued some more stuff to fix.

### Bugfixing:


- [x]  Fix Pun-Pun losing his name, he now has a Real_Name var set.
- [x]  Chapel Mass Driver ID_Tag is broken.
- [x]  Toxins Mass Driver ID_Tag is broken.
- [x]  Engineering SMES Door Bolt button ID_Tag is broken.
- [x]  Research Outpost Toilet Bolt ID_Tag is broken.
- [x]  Research Outpost Dorms Bolt ID_Tag is broken.
- [x]  Jungle Dorms Bolt ID_Tag is broken.

### Mapfixing:

Everything below is already fixed.

#### Layout:
- Moves Bridge APC to the left by one tile, as it was overlapping with light tube, slight rewire.
- Moves signage to not be blocked by lights.

#### Light Overlapping Issues
- Security Port Shuttle
- HoS Office
- Perma Brig Botany
- Jungle Outpost
- Jungle Security Storage
- Drone Fabrication
- Teleporter Room
- Captain's Office
- Bridge
- Engineering Shuttle
- Bartender's Office
- RD's Office
- Xenobiology
- Research Outpost Toilets
- Research Mining Bay
- Cargo Mech Bay
- Jungle Outpost Dorms

#### Cameras:

- Cargo Department - 1 Obscured by Light, Another Obscured by Newscaster.
- Blueshield - Still obscured by NT Sign, my bad. Oops.



