### PR TITLE
EMPs lock robolimbs up instead of liquefying them; microbattery slightly more resistant to EMP

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -156,23 +156,25 @@
 		return
 
 	var/burn_damage = 0
+	var/stun_time = 0
 	switch (severity)
 		if (EMP_ACT_HEAVY)
+			stun_time = 1 MINUTE
 			burn_damage = 30
 		if (EMP_ACT_LIGHT)
-			burn_damage = 15
-
-	var/mult = 1 + !!(BP_IS_ASSISTED(src)) // This macro returns (large) bitflags.
-	burn_damage *= mult/species.get_burn_mod(owner) //ignore burn mod for EMP damage
+			stun_time = 30 SECONDS
+			burn_damage = 30
 
 	var/power = (3 - severity)/5 //stupid reverse severity
 	for(var/obj/item/I in implants)
 		if(I.obj_flags & OBJ_FLAG_CONDUCTIBLE)
 			burn_damage += I.w_class * rand(power, 3*power)
 
-	if(owner && burn_damage)
-		owner.custom_pain("Something inside your [src] burns a [severity < 2 ? "bit" : "lot"]!", power * 15) //robotic organs won't feel it anyway
-		take_external_damage(0, burn_damage, 0, used_weapon = "Hot metal")
+	if(owner && stun_time)
+		status |= ORGAN_BROKEN
+		to_chat(owner, SPAN_WARNING("Your [src] seizes up!"))
+		spawn(stun_time)
+		status &= ~ORGAN_BROKEN
 
 	if(owner && limb_flags & ORGAN_FLAG_CAN_GRASP)
 		owner.grasp_damage_disarm(src)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -159,10 +159,10 @@
 	var/stun_time = 0
 	switch (severity)
 		if (EMP_ACT_HEAVY)
-			stun_time = 1 MINUTE
+			stun_time = 30 SECONDS
 			burn_damage = 30
 		if (EMP_ACT_LIGHT)
-			stun_time = 30 SECONDS
+			stun_time = 15 SECONDS
 			burn_damage = 30
 
 	var/power = (3 - severity)/5 //stupid reverse severity

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -63,9 +63,13 @@
 		to_chat(owner, SPAN_WARNING("Your internal battery beeps an alert code, it is low on charge!"))
 
 /obj/item/organ/internal/cell/emp_act(severity)
-	..()
 	if(cell)
-		cell.emp_act(severity)
+		cell.emp_act(severity*2)
+	switch (severity)
+		if (EMP_ACT_HEAVY)
+			take_internal_damage(8)
+		if (EMP_ACT_LIGHT)
+			take_internal_damage(5)
 
 /obj/item/organ/internal/cell/attackby(obj/item/W, mob/user)
 	if(isScrewdriver(W))

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -44,7 +44,7 @@ exactly 26 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 447 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 446 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -44,7 +44,7 @@ exactly 26 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 446 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 447 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
When EMPed all prosthetic/robolimbs will 'break' for up to 30 seconds. Timer won't stack.
Microbattery EMP damage adjusted so a full ion pistol shouldn't break it and leave you dead with no sensors in maint (just very close).

Adds another usage of spawn because I couldn't think of a better way to un-break the limbs.
This doesn't play great with bodyscanners if you happen to shove an EMP victim in there in the stun duration (shows 'Mechanical and' instead of 'Mechanical and Broken'), but goes back to normal when the EMP effects are over.