### PR TITLE
Traitor Uplink - Cleaning & Maintenance

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -6,20 +6,20 @@
 	category = /datum/uplink_category/ammunition
 
 /datum/uplink_item/item/ammo/holdout
-	name = "Small Magazine"
-	desc = "A magazine for small pistols. Contains 8 rounds."
+	name = "Small Pistol Magazine (9mm)"
+	desc = "A magazine for small 9mm pistols. Contains 8 rounds."
 	item_cost = 3
 	path = /obj/item/ammo_magazine/pistol/small
 
 /datum/uplink_item/item/ammo/empslug
-	name = "Haywire Slug"
+	name = "Haywire Slug (12g)"
 	desc = "Single 12-gauge shotgun slug fitted with a single-use ion pulse generator."
 	item_cost = 1
 	path = /obj/item/ammo_casing/shotgun/emp
 
 /datum/uplink_item/item/ammo/holdout_speedloader
-	name = "Small Speedloader"
-	desc = "A speedloader for small revolvers. Contains 6 rounds."
+	name = "Small Speedloader (9mm)"
+	desc = "A speedloader for small 9mm revolvers. Contains 6 rounds."
 	item_cost = 3
 	path = /obj/item/ammo_magazine/speedloader/small
 
@@ -29,84 +29,84 @@
 	path = /obj/item/ammo_magazine/chemdart
 
 /datum/uplink_item/item/ammo/speedloader
-	name = "Standard Speedloader"
-	desc = "A speedloader for standard revolvers. Contains 6 rounds."
+	name = "Standard Speedloader (10mm)"
+	desc = "A speedloader for standard 10mm revolvers. Contains 6 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/speedloader
 
 /datum/uplink_item/item/ammo/rifle
-	name = "Rifle Magazine"
-	desc = "A magazine for assault rifles. Contains 20 rounds."
+	name = "Rifle Magazine (7.62mm)"
+	desc = "A magazine for assault rifles that use 7.62mm. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/rifle
 
 /datum/uplink_item/item/ammo/bullpup //for zipguns
-	name = "Bullpup Rifle Magazine"
-	desc = "A magazine for bullpup assault rifles. Contains 15 rounds."
+	name = "Bullpup Rifle Magazine (5.56mm)"
+	desc = "A magazine for bullpup assault rifles using 5.56mm. Contains 15 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/mil_rifle/heavy
 
 /datum/uplink_item/item/ammo/sniperammo
-	name = "Ammobox of Sniper Rounds"
-	desc = "A container of rounds for the anti-materiel rifle. Contains 7 rounds."
+	name = "Ammobox of Sniper Rounds (14.5mm)"
+	desc = "A container of 14.5mm rounds for a anti-materiel rifle. Contains 7 rounds."
 	item_cost = 8
 	path = /obj/item/storage/box/ammo/sniperammo
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/sniperammo/apds
-	name = "Ammobox of APDS Sniper Rounds"
-	desc = "A container of armor piercing rounds for the anti-materiel rifle. Contains 3 rounds."
+	name = "Ammobox of APDS Sniper Rounds (14.5MM APDS)" // yeah im reiterating it again just for label sake
+	desc = "A container of armor piercing rounds for a anti-materiel rifle. Contains 3 rounds."
 	item_cost = 12
 	path = /obj/item/storage/box/ammo/sniperammo/apds
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/shotgun_shells
-	name = "Ammobox of Shotgun Shells"
+	name = "Ammobox of Shotgun Shells (12g)"
 	desc = "An ammobox with 2 sets of shell holders. Contains 8 buckshot shells total."
 	item_cost = 8
 	path = /obj/item/storage/box/ammo/shotgunshells
 
 /datum/uplink_item/item/ammo/flechette_shells
-	name = "Ammobox of Flechette Shells"
+	name = "Ammobox of Flechette Shells (12g)"
 	desc = "An ammobox with 2 sets of shell holders. Contains 8 extra accurate flechette shells."
 	item_cost = 12
 	path = /obj/item/storage/box/ammo/flechetteshells
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/shotgun_slugs
-	name = "Ammobox of Shotgun Slugs"
+	name = "Ammobox of Shotgun Slugs (12g)"
 	desc = "An ammobox with 2 sets of shell holders. Contains 8 slugs total."
 	item_cost = 8
 	path = /obj/item/storage/box/ammo/shotgunammo
 
 /datum/uplink_item/item/ammo/machine_pistol
-	name = "Standard Stick Magazine"
-	desc = "A magazine for standard machine pistols. Contains 16 rounds."
+	name = "Machine Pistol Stick Magazine (10mm)"
+	desc = "A magazine for standard 10mm machine pistols. Contains 16 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/machine_pistol
 
 /datum/uplink_item/item/ammo/smg
-	name = "Standard Box Magazine"
-	desc = "A magazine for standard SMGs. Contains 20 rounds."
+	name = "SMG Box Magazine (10mm)"
+	desc = "A magazine for 10mm SMGs. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/smg
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/pistol
-	name = "Standard Doublestack Magazine"
-	desc = "A magazine for standard military pistols. Contains 15 rounds."
+	name = "Doublestack Magazine (10mm)"
+	desc = "A magazine for 10mm military pistols. Contains 15 rounds."
 	item_cost = 9
 	path = /obj/item/ammo_magazine/pistol/double
 
 /datum/uplink_item/item/ammo/magnum
-	name = "Magnum Magazine"
-	desc = "A magazine for magnum pistols. Contains 7 rounds."
+	name = "Magnum Magazine (15mm)"
+	desc = "A magazine for 15mm magnum pistols. Contains 7 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/magnum
 
 /datum/uplink_item/item/ammo/speedloader_magnum
-	name = "Magnum Speedloader"
-	desc = "A speedloader for magnum revolvers. Contains 6 rounds."
+	name = "Magnum Speedloader (15mm)"
+	desc = "A speedloader for 15mm magnum revolvers. Contains 6 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/speedloader/magnum
 
@@ -118,25 +118,25 @@
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/ammo/pistol_emp
-	name = "Standard EMP Ammo Box"
-	desc = "A box of EMP ammo for standard pistols. Contains 15 rounds."
+	name = "EMP Ammo Box (10mm)"
+	desc = "A box of 10mm EMP ammo for standard pistols. Contains 15 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/box/emp/pistol
 
 /datum/uplink_item/item/ammo/holdout_emp
-	name = "Small EMP Ammo Box"
-	desc = "A box of EMP ammo for small pistols and revolvers. Contains 8 rounds."
+	name = "Small EMP Ammo Box (9mm)"
+	desc = "A box of 9mm EMP ammo for small pistols and revolvers. Contains 8 rounds."
 	item_cost = 6
 	path = /obj/item/ammo_magazine/box/emp/smallpistol
 
 /datum/uplink_item/item/ammo/stripperclip
-	name = "Stripper Clip"
-	desc = "A stripper clip used to load bolt action rifles. Contains just 5 rounds."
+	name = "Stripper Clip (7.62mm)"
+	desc = "A stripper clip used to load bolt action rifles chambered in 7.62mm. Contains just 5 rounds."
 	item_cost = 2
 	path = /obj/item/ammo_magazine/speedloader/clip
 
 /datum/uplink_item/item/ammo/stripperclip_broomstick
-	name = "Broomstick Stripper Clip"
-	desc = "A stripper clip used to load antique broomstick pistols. Contains 10 rounds."
+	name = "Broomstick Stripper Clip (9mm)"
+	desc = "A pistol stripper clip used to load antique broomstick pistols chambered in 9mm. Contains 10 rounds."
 	item_cost = 6
 	path = /obj/item/ammo_magazine/speedloader/broomstick

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -97,7 +97,7 @@
 
 /datum/uplink_item/item/tools/space_suit
 	name = "Voidsuit and Tactical Mask"
-	desc = "A satchel containing a non-regulation voidsuit, voidsuit helmet, tactical mask, and oxygen tank. \
+	desc = "A satchel containing a non-regulation voidsuit, voidsuit helmet, tactical mask, portable cooling unit and oxygen tank. \
 	Conceal your identity, while also not dying in space."
 	item_cost = 28
 	path = /obj/item/storage/backpack/satchel/syndie_kit/space
@@ -164,13 +164,14 @@
 	desc = "A remote-activated phoron-oxygen bomb assembly with an included signaler. \
 			A flashing disclaimer begins with the warning 'SOME DISASSEMBLY/REASSEMBLY REQUIRED.'"
 
-/datum/uplink_item/item/tools/polychromic_dye_bottle
+/* /datum/uplink_item/item/tools/polychromic_dye_bottle  --- Urist Specific Change - Moved to Reagents & Plants
 	name = "Extra-Strength Polychromic Dye"
 	item_cost = 10
 	path = /obj/item/reagent_containers/glass/bottle/dye/polychromic/strong
 	desc = "15 units of a tasteless dye that causes chemical mixtures to take on the color of the dye itself. \
 			Very useful for disguising poisons to the untrained eye; even large amounts of reagents can be fully recolored with only a few drops of dye. \
 			Like the mundane variety of polychromic dye, you can use the bottle in your hand to change the dye's color to suit your needs."
+*/
 
 /datum/uplink_item/item/tools/handcuffs
 	name = "Handcuffs"
@@ -183,9 +184,3 @@
 	item_cost = 32
 	path = /obj/item/device/radio_jammer
 	desc = "A small jammer that can fit inside a pocket. Capable of disrupting nearby radios and NTnet transmitters."
-
-/datum/uplink_item/item/tools/declumsifier
-	name = "De-Clumsy Device"
-	desc = "A single-use device that removes the Clumsy mutation when activated."
-	item_cost = 16
-	path = /obj/item/device/uplink_service/declumsifier

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -12,28 +12,31 @@
 
 /datum/uplink_item/item/visible_weapons/shuriken
 	name = "Box of shurikens"
-	desc = "A small box with six shuriken, notably dangerous."
+	desc = "A small box with six shuriken, which have a high chance to embed into a limb."
 	item_cost = 16
 	path = /obj/item/storage/box/syndie_kit/shuriken
 
 /datum/uplink_item/item/visible_weapons/dartgun
 	name = "Dart Gun"
 	desc = "A gas-powered dart gun capable of delivering chemical payloads across short distances. \
+			Requires beakers to be added to the mixer to set what payload to deliver. \
 			Uses a unique cartridge loaded with hollow darts."
 	item_cost = 12
 	path = /obj/item/gun/projectile/dartgun
 
 /datum/uplink_item/item/visible_weapons/crossbow
 	name = "Energy Crossbow"
-	desc = "A self-recharging, almost silent weapon employed by stealth operatives."
+	desc = "A self-recharging, almost silent weapon employed by stealth operatives. \
+			The darts are coated with a toxin that stuns and poisons quickly."
 	item_cost = 24
 	path = /obj/item/gun/energy/crossbow
 
-/datum/uplink_item/item/visible_weapons/pikecube
+/* /datum/uplink_item/item/visible_weapons/pikecube    Urist Specific Change - Moved to Stealthy Catergory to be in the same area as the carp cube.
 	name = "Pike Cube"
 	desc = "While it looks like a normal monkey cube, the animal produced is, instead, a space pike. \ Note: The space pike does not like you."
 	item_cost = 36
 	path = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/pikecube
+*/
 
 /datum/uplink_item/item/visible_weapons/katana
 	name = "Katana"
@@ -50,15 +53,15 @@
 	antag_costs = list(MODE_PARANOIA = 96)
 
 /datum/uplink_item/item/visible_weapons/silenced
-	name = "Silenced Holdout Pistol"
-	desc = "A kit with a pocket-sized holdout pistol, silencer, and an extra magazine. \
+	name = "Silenced Holdout Pistol (9mm)"
+	desc = "A kit with a pocket-sized holdout 9mm pistol, silencer, and an extra magazine. \
 			Attaching the silencer will make it too big to conceal in your pocket."
 	item_cost = 20
 	path = /obj/item/storage/box/syndie_kit/silenced
 
 /datum/uplink_item/item/visible_weapons/broomstick
-	name = "Broomstick Pistol"
-	desc = "An antique pistol stolen from a museum. Be warned, it may be faulty and comes unloaded."
+	name = "Broomstick Pistol (9mm)"
+	desc = "An antique 9mm pistol stolen from a museum. Be warned, it may be faulty and comes unloaded."
 	item_cost = 40
 	path = /obj/item/gun/projectile/pistol/broomstick
 
@@ -75,8 +78,8 @@
 	path = /obj/item/gun/energy/gun
 
 /datum/uplink_item/item/visible_weapons/revolver //357 and 44 revolvers are functionally identical
-	name = "Revolver, .357"
-	desc = ".357 Magnum revolver, with ammunition."
+	name = "Magnum Revolver (15mm)"
+	desc = "A 15mm magnum revolver, with ammunition."
 	item_cost = 36
 	path = /obj/item/storage/backpack/satchel/syndie_kit/revolver
 
@@ -95,24 +98,24 @@
 
 //These are for traitors (or other antags, perhaps) to have the option of purchasing some merc gear.
 /datum/uplink_item/item/visible_weapons/submachinegun
-	name = "C20r Submachine Gun"
+	name = "C20r Submachine Gun (10mm)"
 	item_cost = 64
 	path = /obj/item/gun/projectile/automatic/c20r
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
-	name = "STS-35 Assault Rifle"
+	name = "STS-35 Assault Rifle (7.62mm)"
 	item_cost = 68
 	path = /obj/item/gun/projectile/automatic/sts35
 
 /datum/uplink_item/item/visible_weapons/battlerifle
-	name = "Battle Rifle"
+	name = "Battle Rifle (5.56mm)"
 	desc = "Predecessor to the Assault Rifle, works just as well as the new guns."
 	item_cost = 65
 	path = /obj/item/gun/projectile/automatic/battlerifle
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/semistrip
-	name = "Carbine Rifle"
+	name = "Carbine Rifle (15mm)"
 	desc = "For arming your comrades on the (not so) cheap!"
 	item_cost = 55
 	path = /obj/item/gun/projectile/sniper/semistrip
@@ -139,38 +142,38 @@
 */
 
 /datum/uplink_item/item/visible_weapons/machine_pistol
-	name = "Standard Machine Pistol"
+	name = "Machine Pistol (10mm)"
 	desc = "A high rate of fire weapon in a smaller form factor, able to sling standard ammunition almost as quick as a submachine gun."
 	item_cost = 45
 	path = /obj/item/gun/projectile/automatic/machine_pistol
 
 /datum/uplink_item/item/visible_weapons/combat_shotgun
-	name = "Combat Shotgun"
+	name = "Combat Shotgun (12g)"
 	desc = "A high compacity, pump-action shotgun regularly used for repelling boarding parties in close range scenarios."
 	item_cost = 52
 	path = /obj/item/gun/projectile/shotgun/pump/combat
 	antag_roles = list(MODE_MERCENARY)
 
 /datum/uplink_item/item/visible_weapons/sawnoff
-	name = "Sawnoff Shotgun"
+	name = "Sawnoff Shotgun (12g)"
 	desc = "A shortened double-barrel shotgun, able to fire either one, or both, barrels at once."
 	item_cost = 40
 	path = /obj/item/gun/projectile/shotgun/doublebarrel/sawn
 
 /datum/uplink_item/item/visible_weapons/deagle
-	name = "Magnum Pistol"
-	desc = "A .50 pistol that packs a punch."
+	name = "Magnum Pistol (15mm)"
+	desc = "A 15mm pistol that packs a punch."
 	item_cost = 60
 	path = /obj/item/gun/projectile/pistol/magnum_pistol
 
 /datum/uplink_item/item/visible_weapons/sigsauer
-	name = "10mm Pistol"
+	name = "Military Pistol (10mm)"
 	item_cost = 40
 	path = /obj/item/gun/projectile/pistol/optimus
 
 /datum/uplink_item/item/visible_weapons/detective_revolver
-	name = "Small Revolver"
-	desc = "A pocket-sized holdout revolver. Easily concealable.."
+	name = "Small Revolver (9mm)"
+	desc = "A pocket-sized holdout revolver. Easily concealable."
 	item_cost = 24
 	path = /obj/item/gun/projectile/revolver/holdout
 
@@ -216,7 +219,7 @@
 	path = /obj/item/gun/energy/incendiary_laser
 
 /datum/uplink_item/item/visible_weapons/boltaction
-	name = "Bolt Action Rifle"
+	name = "Bolt Action Rifle (7.62mm)"
 	desc = "For arming your comrades on the cheap!"
 	item_cost = 12
 	path = /obj/item/gun/projectile/heavysniper/boltaction

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -12,13 +12,13 @@
 
 /datum/uplink_item/item/medical/combatstim
 	name = "Combat Stimulants"
-	desc = "A single-use medical injector filled with performance enhancing drugs."
+	desc = "A single-use medical injector containing inaprovaline, hyperzine and synaptizine for performance enhancing effects."
 	item_cost = 10
 	path = /obj/item/reagent_containers/hypospray/autoinjector/combatstim
 
 /datum/uplink_item/item/medical/stabilisation
 	name = "Slimline Stabilisation Kit"
-	desc = "A pocket-sized medkit filled with lifesaving equipment."
+	desc = "A pocket-sized medkit filled with lifesaving equipment in single-use medical injector form."
 	item_cost = 16
 	path = /obj/item/storage/firstaid/sleekstab
 

--- a/code/datums/uplink/reagents_and_plants.dm
+++ b/code/datums/uplink/reagents_and_plants.dm
@@ -6,3 +6,17 @@
 	desc = "Certified chemical demolitions kit. May or may not melt steel beams."
 	item_cost = 8
 	path = /obj/item/storage/box/syndie_kit/jetfuel
+
+/datum/uplink_item/item/reagents_and_plants/random_toxin
+	name = "Random Toxin Vial"
+	desc = "Contains one of an assortment of nasty toxins, with a single syringe included. Don't worry, its labeled. "
+	item_cost = 8
+	path = /obj/item/storage/box/syndie_kit/toxin
+
+/datum/uplink_item/item/tools/polychromic_dye_bottle
+	name = "Extra-Strength Polychromic Dye"
+	item_cost = 10
+	path = /obj/item/reagent_containers/glass/bottle/dye/polychromic/strong
+	desc = "15 units of a tasteless dye that causes chemical mixtures to take on the color of the dye itself. \
+			Very useful for disguising poisons to the untrained eye; even large amounts of reagents can be fully recolored with only a few drops of dye. \
+			Like the mundane variety of polychromic dye, you can use the bottle in your hand to change the dye's color to suit your needs."

--- a/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
+++ b/code/datums/uplink/stealthy_and_inconspicuous_weapons.dm
@@ -21,12 +21,12 @@
 	item_cost = 8
 	path = /obj/item/cane/concealed
 
-/datum/uplink_item/item/stealthy_weapons/random_toxin
+/*/datum/uplink_item/item/stealthy_weapons/random_toxin  -- Urist Specific Change - Moved catergory to Reagents & Plants
 	name = "Random Toxin Vial"
 	desc = "Contains one of an assortment of nasty toxins, with a single syringe included. Don't worry, its labeled. "
 	item_cost = 8
 	path = /obj/item/storage/box/syndie_kit/toxin
-
+*/
 /datum/uplink_item/item/stealthy_weapons/sleepy
 	name = "Paralytic Pen"
 	desc = "Looks and works like a pen, but prick someone with it, and 30 seconds later, they'll be on the ground mumbling."
@@ -56,6 +56,12 @@
 	desc = "An innocuous-looking space carp plushie. Add water and step back for a nasty surprise!"
 	item_cost = 10
 	path = /obj/item/reagent_containers/food/snacks/dehydrated_carp
+
+/datum/uplink_item/item/visible_weapons/pikecube
+	name = "Pike Cube"
+	desc = "While it looks like a normal monkey cube, the animal produced is, instead, a space pike. \ Note: The space pike does not like you."
+	item_cost = 36
+	path = /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/pikecube
 
 /datum/uplink_item/item/stealthy_weapons/plush_bomb
 	name = "Plushie Bomb"


### PR DESCRIPTION
### Features:

- All weapons & ammo have their calibre next to them again, making it easier to read and tell at a glance.
- Description updated for Voidsuit to show it comes with a portable cooler.
- Pikecube moved to same catergory as Carp cube, to keep them consistent.
- Random Toxin and Polychromatic Dye moved to Reagents & Plants Catergory
- Removed duplicate Clown De-Clumsy device.
- Expands description of combat stimulants to explain which chemicals.
- Expands slimline stabilizer to state it all comes in autoinjectors.
- Expands shruiken desc to state that it has a high chance to embed.