### PR TITLE
Holdout Revolvers, Single Pistol Bullets & Screwdrivers can be hidden in shoes.

### DIFF
--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -16,6 +16,7 @@
 	attack_verb = list("stabbed")
 	lock_picking_level = 5
 	sharp = TRUE
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 	var/build_from_parts = TRUE
 	var/valid_colours = list(COLOR_RED, COLOR_CYAN_BLUE, COLOR_PURPLE, COLOR_CHESTNUT, COLOR_GREEN, COLOR_TEAL, COLOR_ASSEMBLY_YELLOW, COLOR_BOTTLE_GREEN, COLOR_VIOLET, COLOR_GRAY80, COLOR_GRAY20)

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -4,6 +4,7 @@
 	projectile_type = /obj/item/projectile/bullet/pistol
 	icon_state = "pistolcasing"
 	spent_icon = "pistolcasing-spent"
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/ammo_casing/pistol/rubber
 	desc = "A rubber pistol bullet casing."

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -88,6 +88,7 @@
 	one_hand_penalty = 0
 	bulk = 0
 	fire_delay = 7
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 /obj/item/gun/projectile/revolver/holdout/on_update_icon()
 	. = ..()


### PR DESCRIPTION
**Features:**

- Holdout Revolvers - Can be hidden inside shoes.
- Pistol Bullets (Empty/Loaded) - Can be hidden inside shoes (singular)
- Screwdrivers - Can be hidden inside shoes.  (Bay Change - late 2023ish, we'll be getting it when we merge either way.)

With the Holdout Revolver, my intention is to make it more concealable at the cost of less magazine capacity & loudness, vs the Holdout Pistol which can be silenced & have more magazine capacity at the cost of not being as easily hidable if surpressed, or if pockets are checked. 