### PR TITLE
game broadcasts available offship roles at roundstart

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -53,6 +53,20 @@ SUBSYSTEM_DEF(ticker)
 	to_world(SPAN_INFO("<B>Welcome to the pre-game lobby!</B>"))
 	to_world("Please, setup your character and select ready. Game will start in [round(pregame_timeleft/10)] seconds")
 
+// Uristcode - list available offship roles to avoid people waiting past ready-up to see them
+	var/list/datum/submap/available_submap_jobs = list()
+	for(var/datum/submap/submap in SSmapping.submaps)
+		for(var/titlegrabber in submap.jobs)
+			var/datum/job/job = submap.jobs[titlegrabber]
+			available_submap_jobs += job.title
+
+	if(length(available_submap_jobs))
+		to_world("<br>" \
+			+ SPAN_BOLD(SPAN_NOTICE("Submap roles available for this round: ")) \
+			+ "[english_list(available_submap_jobs)]. " \
+			+ SPAN_INFO("Actual availability may vary.") \
+			+ "<br>" \
+		)
 
 /datum/controller/subsystem/ticker/fire(resumed, no_mc_tick)
 	switch(GAME_STATE)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -30,7 +30,7 @@ exactly 2 "/datum text paths" '"/datum'
 exactly 2 "/mob text paths" '"/mob'
 exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
-exactly 140 "to_world uses" '\sto_world\('
+exactly 141 "to_world uses" '\sto_world\('
 exactly 0 "globals with leading /" '^/var' -P
 exactly 0 "globals without global sugar" '^var/(?!global/)' -P
 exactly 0 "apparent paths with trailing /" '\w/[,\)\n]' -P


### PR DESCRIPTION
Lists submap (non-nerva ships, colonists, etc) roles you can latejoin as once the round starts, liberating you to press the ready button instead of waiting to see what you can latejoin as.