### PR TITLE
Lar Maria - Away Map Update

### DIFF
--- a/maps/away/lar_maria/lar_maria-1.dmm
+++ b/maps/away/lar_maria/lar_maria-1.dmm
@@ -202,17 +202,18 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/lar_maria/guard/ranged,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "ay" = (
 /obj/machinery/smartfridge/chemistry/virology,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "aA" = (
 /obj/structure/table/glass,
 /obj/item/paper,
 /obj/item/folder/white,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "aB" = (
 /obj/structure/table/glass,
@@ -224,8 +225,15 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
+"aE" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/vir_access)
 "aG" = (
 /obj/machinery/light{
 	dir = 1
@@ -247,7 +255,7 @@
 /area/lar_maria/vir_main)
 "aJ" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "aK" = (
 /obj/structure/bed,
@@ -255,11 +263,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "aL" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "aM" = (
 /obj/machinery/door/airlock/virology,
@@ -281,7 +289,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "aP" = (
 /obj/machinery/light{
@@ -303,7 +311,7 @@
 /area/lar_maria/vir_main)
 "aT" = (
 /obj/machinery/door/window/westleft,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "aU" = (
 /obj/structure/bed/padded,
@@ -415,7 +423,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "bm" = (
 /obj/structure/window/reinforced,
@@ -427,19 +435,19 @@
 	},
 /obj/effect/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bn" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/door/window/northleft,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bo" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bp" = (
 /obj/effect/landmark/corpse/lar_maria/virologist_female,
@@ -448,27 +456,27 @@
 /area/lar_maria/vir_main)
 "bq" = (
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "br" = (
 /obj/structure/table/glass,
 /obj/item/paper,
 /obj/item/pen/blue,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bs" = (
 /obj/structure/table/glass,
 /obj/item/paper/lar_maria/note_4,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bt" = (
 /obj/structure/table/glass,
 /obj/item/device/flashlight/pen,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bv" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bw" = (
 /turf/simulated/floor/tiled,
@@ -515,6 +523,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/mob/living/simple_animal/hostile/lar_maria/test_subject,
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
 "bC" = (
@@ -551,7 +560,7 @@
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -560,7 +569,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/mob/living/simple_animal/hostile/lar_maria/virologist,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -570,37 +580,38 @@
 /obj/item/storage/box/masks,
 /obj/item/storage/box/gloves,
 /obj/item/reagent_containers/spray/sterilizine,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bK" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bL" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bM" = (
 /obj/structure/table/glass,
 /obj/item/paper,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bN" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bO" = (
 /obj/structure/table/glass,
-/turf/simulated/floor/tiled/white,
+/obj/item/reagent_containers/glass/beaker/vial/random_podchem,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bP" = (
 /obj/structure/closet/crate/freezer,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bQ" = (
 /obj/structure/closet/emcloset,
@@ -661,7 +672,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "ca" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -671,7 +682,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -679,7 +690,7 @@
 	},
 /obj/structure/table/glass,
 /obj/item/storage/box/bodybags,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cc" = (
 /obj/machinery/door/airlock/security,
@@ -731,7 +742,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "ci" = (
 /obj/machinery/door/airlock/virology,
@@ -741,25 +752,25 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cj" = (
 /obj/machinery/door/airlock/virology,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "ck" = (
 /obj/machinery/door/window/northright,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cl" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/item/clothing/head/surgery,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cm" = (
 /obj/structure/window/reinforced{
@@ -768,19 +779,19 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cn" = (
 /obj/machinery/door/window/northright,
 /obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "co" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cp" = (
 /obj/structure/window/reinforced{
@@ -790,15 +801,15 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cq" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cr" = (
 /mob/living/simple_animal/hostile/lar_maria/test_subject,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cs" = (
 /obj/structure/hygiene/sink{
@@ -917,7 +928,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "cD" = (
 /obj/structure/cable{
@@ -926,34 +937,34 @@
 	icon_state = "1-2"
 	},
 /mob/living/simple_animal/hostile/lar_maria/virologist,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cF" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/surgery,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cG" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/optable,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cH" = (
 /mob/living/simple_animal/hostile/lar_maria/virologist/female,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cI" = (
 /obj/structure/table/glass,
 /obj/item/scalpel,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cJ" = (
 /obj/structure/window/reinforced{
@@ -962,17 +973,17 @@
 /obj/machinery/optable,
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cK" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cL" = (
 /obj/structure/bed,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "cM" = (
 /obj/machinery/light/small{
@@ -1161,7 +1172,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1176,7 +1187,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dk" = (
 /obj/structure/sign/warning/biohazard{
@@ -1191,7 +1202,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dl" = (
 /obj/structure/cable{
@@ -1204,7 +1215,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1214,7 +1225,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dn" = (
 /obj/structure/sign/warning/biohazard{
@@ -1226,7 +1237,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "do" = (
 /obj/structure/cable{
@@ -1234,7 +1245,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dp" = (
 /obj/structure/cable{
@@ -1242,11 +1253,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dq" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dr" = (
 /turf/simulated/wall/r_wall,
@@ -1256,22 +1267,22 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "du" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "dv" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "dw" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "dx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1329,7 +1340,7 @@
 "dE" = (
 /obj/effect/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1339,7 +1350,7 @@
 	dir = 5
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1349,7 +1360,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1359,12 +1370,12 @@
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/lar_maria/guard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1373,7 +1384,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1387,14 +1398,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dL" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "dM" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "dN" = (
 /obj/effect/decal/cleanable/blood,
@@ -1403,7 +1414,7 @@
 "dO" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "dP" = (
 /obj/structure/bed/padded,
@@ -1416,15 +1427,17 @@
 /area/lar_maria/cells)
 "dR" = (
 /obj/structure/bed/padded,
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/lar_maria/guard/ranged,
+/obj/item/bedsheet/green,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "dS" = (
 /turf/simulated/wall,
 /area/lar_maria/sec_wing)
 "dT" = (
 /obj/structure/bed/padded,
-/obj/item/clothing/suit/armor/riot,
-/turf/simulated/floor/tiled,
+/obj/item/bedsheet/green,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "dU" = (
 /obj/structure/hygiene/toilet{
@@ -1433,7 +1446,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/mob/living/simple_animal/hostile/lar_maria/guard/ranged,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/sec_wing)
 "dW" = (
@@ -1453,13 +1465,13 @@
 /area/lar_maria/vir_ward)
 "dZ" = (
 /obj/machinery/door/window/southright,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "ea" = (
 /obj/machinery/door/window/southright,
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "eb" = (
 /obj/machinery/light/small{
@@ -1471,12 +1483,13 @@
 /area/lar_maria/cells)
 "ec" = (
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/tiled,
+/obj/item/clothing/suit/armor/riot,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "ed" = (
 /obj/structure/curtain/open/bed,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "ee" = (
 /obj/machinery/door/airlock/security,
@@ -1488,27 +1501,27 @@
 /obj/item/shield/riot,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/suit/armor/riot,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "eg" = (
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "eh" = (
 /obj/structure/roller_bed,
 /obj/effect/landmark/corpse/lar_maria/test_subject,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "ei" = (
 /obj/structure/roller_bed,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "ej" = (
 /obj/structure/roller_bed,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1519,16 +1532,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "el" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "em" = (
-/obj/item/storage/box/freezer,
-/turf/simulated/floor/tiled/white,
-/area/lar_maria/vir_aux)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/lar_maria/guard/ranged,
+/turf/simulated/floor/tiled/dark,
+/area/lar_maria/sec_wing)
 "en" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -1571,7 +1595,7 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/cells)
 "et" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "eu" = (
 /obj/structure/table/steel_reinforced,
@@ -1581,20 +1605,20 @@
 	tag_exterior_door = "ZHPcells_access_airlock_outer";
 	tag_interior_door = "ZHPcells_access_airlock_inner"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "ev" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "ew" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/effect/landmark/corpse/lar_maria/zhp_guard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "ex" = (
 /obj/structure/table/steel_reinforced,
@@ -1626,32 +1650,32 @@
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "ey" = (
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "ez" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "eA" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "eB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "eC" = (
 /obj/machinery/light,
 /obj/machinery/smartfridge/chemistry/virology,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "eD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1661,7 +1685,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "eE" = (
 /obj/machinery/alarm{
@@ -1672,15 +1696,17 @@
 /area/lar_maria/vir_aux)
 "eF" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/turf/simulated/floor/tiled/white,
+/obj/item/slime_extract/gold,
+/obj/item/slime_extract/gold,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "eG" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/table/glass,
-/turf/simulated/floor/tiled/white,
+/obj/item/slime_extract/green,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "eH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1695,34 +1721,33 @@
 "eI" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "eJ" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/smokes,
 /obj/item/gun/energy/taser,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "eK" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "eL" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/handcuffs,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "eM" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "eN" = (
 /obj/structure/closet,
-/obj/item/clothing/under/color/red,
 /obj/item/gun/projectile/shotgun/pump/combat,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "eO" = (
 /obj/machinery/power/apc{
@@ -1731,12 +1756,11 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "eP" = (
 /obj/structure/table/steel_reinforced,
@@ -1746,11 +1770,11 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "eQ" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "eR" = (
 /obj/machinery/power/apc{
@@ -1761,7 +1785,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "eS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1775,7 +1799,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "eT" = (
 /obj/machinery/door/firedoor,
@@ -1813,30 +1837,30 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "eV" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "eX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "eY" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/freezer,
-/turf/simulated/floor/tiled/white,
+/obj/item/slime_extract/red,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "eZ" = (
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "fa" = (
 /mob/living/simple_animal/hostile/lar_maria/virologist,
@@ -1845,8 +1869,7 @@
 "fb" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
-/obj/item/storage/box/pillbottles,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "fc" = (
 /obj/structure/table/steel_reinforced,
@@ -1866,25 +1889,25 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "ff" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/deck/cards,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fg" = (
 /obj/structure/table/rack,
 /obj/item/melee/baton,
 /obj/item/melee/baton,
 /obj/item/melee/baton,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fh" = (
 /obj/structure/table/rack,
 /obj/item/clothing/head/helmet/ballistic,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fi" = (
 /obj/structure/closet,
@@ -1894,7 +1917,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1906,7 +1929,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fk" = (
 /obj/structure/table/steel_reinforced,
@@ -1919,7 +1942,7 @@
 	tag_exterior_door = "ZHPsec__access_airlock_outer";
 	tag_interior_door = "ZHPsec__access_airlock_inner"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fl" = (
 /obj/structure/table/steel_reinforced,
@@ -1927,24 +1950,24 @@
 	id_tag = "Tech_access_BD";
 	name = "Communications Access"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fm" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fn" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/handcuffs,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fo" = (
 /obj/structure/roller_bed,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_ward)
 "fp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1958,7 +1981,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "fq" = (
 /obj/machinery/power/apc{
@@ -1972,23 +1995,25 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "fr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/glass,
 /obj/item/storage/box/masks,
 /obj/item/storage/box/gloves,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "fs" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/autoinjectors,
-/turf/simulated/floor/tiled/white,
+/obj/item/storage/box/syringes,
+/obj/item/stack/material/phoron/ten,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "ft" = (
 /obj/machinery/chem_master,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "fu" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -2008,18 +2033,18 @@
 /obj/structure/table/rack,
 /obj/item/flamethrower/full,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fw" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/glowsticks,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fx" = (
 /obj/structure/closet,
-/obj/item/clothing/under/color/red,
-/turf/simulated/floor/tiled,
+/obj/item/clothing/head/soft/lar_maria/zhp_cap,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fy" = (
 /obj/machinery/door/airlock/security,
@@ -2031,7 +2056,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2054,7 +2079,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "fA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2068,7 +2093,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2084,7 +2109,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "fD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2101,7 +2126,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "fE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2111,7 +2136,7 @@
 	dir = 1
 	},
 /obj/machinery/door/window/eastright,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "fG" = (
 /turf/simulated/floor/tiled/white,
@@ -2181,7 +2206,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 "fM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2201,7 +2226,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/lar_maria/guard/ranged,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2215,7 +2241,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2234,7 +2260,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fP" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -2249,7 +2275,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fQ" = (
 /obj/structure/reagent_dispensers/peppertank{
@@ -2264,7 +2290,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fR" = (
 /obj/machinery/door/airlock/security,
@@ -2280,7 +2306,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -2300,7 +2326,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fT" = (
 /obj/machinery/light{
@@ -2321,7 +2347,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2336,7 +2362,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2353,7 +2379,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fW" = (
 /obj/structure/sign/warning/biohazard{
@@ -2370,7 +2396,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fX" = (
 /obj/machinery/door/airlock/virology{
@@ -2394,7 +2420,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fY" = (
 /obj/machinery/light/small{
@@ -2411,7 +2437,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "fZ" = (
 /obj/machinery/door/airlock/virology{
@@ -2435,7 +2461,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "ga" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2454,13 +2481,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "gb" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "gc" = (
 /obj/structure/window/reinforced{
@@ -2472,7 +2499,7 @@
 /obj/structure/hygiene/shower{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "gd" = (
 /mob/living/simple_animal/hostile/lar_maria/virologist/female,
@@ -2480,7 +2507,9 @@
 /area/lar_maria/vir_aux)
 "ge" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/glass,
+/obj/item/storage/box/pillbottles,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_aux)
 "gf" = (
 /obj/structure/closet/crate,
@@ -2508,7 +2537,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "gi" = (
 /obj/machinery/door/airlock/security,
@@ -2541,30 +2570,30 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "gn" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "go" = (
 /obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "gp" = (
 /obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "gq" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/vending/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "gr" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "gs" = (
 /obj/machinery/light/small{
@@ -2596,11 +2625,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "gx" = (
 /mob/living/simple_animal/hostile/lar_maria/guard/ranged,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "gy" = (
 /obj/machinery/light{
@@ -2615,7 +2644,7 @@
 	tag_exterior_sensor = "ZHPvirology_access_airlock_sensor";
 	tag_interior_door = "ZHPvirology_access_airlock_inner"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "gz" = (
 /turf/simulated/wall/r_wall,
@@ -2652,13 +2681,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "gE" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "gF" = (
 /turf/simulated/floor/tiled,
@@ -2668,7 +2697,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "gH" = (
 /obj/machinery/power/smes/buildable,
@@ -2713,7 +2742,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "gO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2727,7 +2756,7 @@
 	master_tag = "ZHPvirology_access_airlock";
 	pixel_y = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_hallway)
 "gP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2745,7 +2774,7 @@
 	frequency = 1039;
 	id_tag = "ZHPvirology_access_airlock_outer"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "gQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2754,7 +2783,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "gR" = (
 /obj/effect/decal/cleanable/blood,
@@ -2764,7 +2793,7 @@
 	master_tag = "ZHPvirology_access_airlock";
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "gS" = (
 /obj/structure/bed/padded,
@@ -2790,7 +2819,7 @@
 /area/lar_maria/cells)
 "gW" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "gX" = (
 /obj/machinery/alarm{
@@ -2806,14 +2835,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "gZ" = (
 /obj/machinery/door/airlock/virology{
 	frequency = 1039;
 	id_tag = "ZHPvirology_access_airlock_outer"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "ha" = (
 /obj/machinery/light/small{
@@ -2844,27 +2873,27 @@
 "he" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "hf" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "hg" = (
 /obj/structure/closet,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "hh" = (
 /obj/structure/closet,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "hi" = (
 /obj/structure/table/standard,
 /obj/item/towel,
 /obj/random/soap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "hj" = (
 /turf/simulated/wall,
@@ -2873,30 +2902,33 @@
 /obj/structure/hygiene/shower,
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "hl" = (
 /obj/structure/hygiene/shower,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "hm" = (
 /obj/structure/hygiene/shower,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "hn" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "ho" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "hp" = (
 /obj/structure/closet/l3closet/virology,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "hq" = (
 /obj/structure/sign/warning/biohazard{
@@ -2904,7 +2936,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hr" = (
 /obj/structure/sign/warning/biohazard{
@@ -2916,7 +2948,7 @@
 	pixel_x = 25;
 	pixel_y = 15
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hs" = (
 /obj/machinery/door/airlock/security,
@@ -2936,7 +2968,7 @@
 /area/lar_maria/cells)
 "ht" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hu" = (
 /obj/machinery/power/apc{
@@ -2948,29 +2980,30 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hx" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "hy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hA" = (
 /obj/structure/closet/crate/trashcart,
@@ -2989,12 +3022,12 @@
 /area/lar_maria/sec_wing)
 "hC" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "hD" = (
 /obj/structure/table/rack,
 /obj/item/gun/energy/taser,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "hE" = (
 /obj/structure/table/standard,
@@ -3006,7 +3039,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/vir_access)
 "hF" = (
 /obj/structure/bed/chair{
@@ -3015,7 +3048,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hG" = (
 /obj/structure/cable{
@@ -3023,7 +3056,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hH" = (
 /obj/machinery/door/airlock/virology,
@@ -3033,13 +3066,13 @@
 	icon_state = "pdoor0";
 	id_tag = "VirAccessBD"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3052,7 +3085,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hK" = (
 /obj/machinery/light,
@@ -3062,7 +3095,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3071,7 +3104,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hM" = (
 /obj/machinery/door/airlock/virology,
@@ -3081,7 +3114,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3091,6 +3124,7 @@
 	dir = 4
 	},
 /obj/random/trash,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "hO" = (
@@ -3101,6 +3135,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "hP" = (
@@ -3112,6 +3147,7 @@
 	},
 /obj/effect/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "hQ" = (
@@ -3119,7 +3155,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hR" = (
 /obj/machinery/light,
@@ -3127,7 +3163,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3140,7 +3176,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hT" = (
 /obj/machinery/door/airlock/virology,
@@ -3155,7 +3191,7 @@
 	icon_state = "pdoor0";
 	id_tag = "VirAccessBD"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3164,7 +3200,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "hV" = (
 /obj/structure/hygiene/shower{
@@ -3188,7 +3224,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "hY" = (
 /obj/machinery/light{
@@ -3199,7 +3235,7 @@
 	dir = 4
 	},
 /obj/item/paper/lar_maria/note_7,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/vir_access)
 "hZ" = (
 /obj/structure/bed/chair{
@@ -3209,7 +3245,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "ia" = (
 /obj/machinery/light{
@@ -3221,11 +3257,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "ib" = (
 /obj/item/paper/lar_maria/note_8,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "ic" = (
 /obj/structure/hygiene/shower{
@@ -3250,7 +3286,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "if" = (
 /obj/machinery/door/airlock/security,
@@ -3271,7 +3307,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "ig" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3285,7 +3321,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "ih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3299,7 +3335,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "ii" = (
 /obj/structure/cable{
@@ -3307,7 +3343,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "ij" = (
 /obj/structure/cable{
@@ -3315,13 +3351,13 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "ik" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "il" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3333,7 +3369,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "im" = (
 /obj/machinery/light{
@@ -3345,7 +3381,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "in" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3354,6 +3390,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "io" = (
@@ -3366,6 +3403,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "ip" = (
@@ -3375,7 +3413,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "iq" = (
 /obj/machinery/light{
@@ -3387,7 +3425,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "ir" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3399,7 +3437,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "is" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3409,7 +3447,7 @@
 	dir = 4
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "it" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3418,12 +3456,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/vir_access)
 "iu" = (
 /obj/machinery/door/airlock/security,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "iv" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -3436,11 +3474,13 @@
 /turf/simulated/floor/tiled,
 /area/lar_maria/sec_wing)
 "iw" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "ix" = (
 /obj/effect/decal/cleanable/blood,
 /mob/living/simple_animal/hostile/lar_maria/test_subject,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "iy" = (
@@ -3476,7 +3516,7 @@
 	name = "Cells Dock Lockdown";
 	pixel_y = 7
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "iC" = (
 /obj/structure/table/steel_reinforced,
@@ -3484,7 +3524,7 @@
 	id_tag = "VirAccessBD";
 	name = "Virology Access Lockdown"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "iD" = (
 /obj/machinery/light{
@@ -3493,7 +3533,7 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/item/gun/energy/taser,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "iE" = (
 /obj/structure/closet,
@@ -3501,19 +3541,23 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/obj/item/clothing/under/rank/scientist/zeng,
+/obj/item/clothing/suit/storage/toggle/labcoat/science/zeng,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "iF" = (
 /obj/structure/closet,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/item/clothing/under/rank/scientist/zeng,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "iG" = (
 /obj/structure/hygiene/shower{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "iH" = (
@@ -3522,6 +3566,7 @@
 	},
 /obj/effect/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_access)
 "iI" = (
@@ -3530,32 +3575,32 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "iJ" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/vir_access)
 "iK" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
 /obj/item/gun/energy/taser,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "iL" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "iM" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/lar_maria/guard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/lar_maria/sec_wing)
 "iN" = (
 /obj/machinery/door/airlock/external{
@@ -3596,6 +3641,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/morgue)
+"jx" = (
+/mob/living/simple_animal/hostile/lar_maria/guard,
+/turf/simulated/floor/tiled/dark,
+/area/lar_maria/sec_wing)
 "kb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3607,6 +3656,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/morgue)
+"kg" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/lar_maria/sec_wing)
 "lb" = (
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -3615,8 +3670,31 @@
 /obj/item/storage/mirror{
 	pixel_x = 25
 	},
+/mob/living/simple_animal/hostile/lar_maria/guard,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/sec_wing)
+"mE" = (
+/obj/structure/bed,
+/obj/effect/landmark/corpse/lar_maria/test_subject,
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/vir_aux)
+"ns" = (
+/obj/item/clothing/head/soft/lar_maria/zhp_cap,
+/turf/simulated/floor/tiled/dark,
+/area/lar_maria/sec_wing)
+"nZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/vir_access)
+"pr" = (
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/vir_aux)
+"sk" = (
+/mob/living/simple_animal/hostile/lar_maria/virologist,
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/vir_ward)
 "ts" = (
 /obj/machinery/door/airlock/security,
 /obj/structure/cable{
@@ -3626,6 +3704,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/sec_wing)
+"yj" = (
+/obj/item/storage/box/freezer,
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/vir_aux)
+"yn" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/lar_maria/virologist/female,
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/vir_ward)
+"zi" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/lar_maria/sec_wing)
+"BW" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/lar_maria/guard,
+/turf/simulated/floor/plating,
+/area/lar_maria/cells)
 "FB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3633,6 +3736,81 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
+/area/lar_maria/sec_wing)
+"GT" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/freezer,
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/vir_aux)
+"Hy" = (
+/obj/structure/bed/padded,
+/mob/living/simple_animal/hostile/lar_maria/test_subject,
+/turf/simulated/floor/tiled,
+/area/lar_maria/cells)
+"HQ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/lar_maria/test_subject,
+/turf/simulated/floor/plating,
+/area/lar_maria/cells)
+"Jn" = (
+/obj/structure/closet,
+/obj/item/clothing/under/rank/scientist/zeng,
+/obj/item/clothing/suit/storage/toggle/labcoat/science/zeng,
+/turf/simulated/floor/tiled/techfloor,
+/area/lar_maria/vir_access)
+"JU" = (
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/lar_maria/sec_wing)
+"Kb" = (
+/obj/random/trash,
+/mob/living/simple_animal/hostile/lar_maria/guard,
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/vir_access)
+"Ky" = (
+/mob/living/simple_animal/hostile/lar_maria/virologist,
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/vir_aux)
+"Mn" = (
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/vir_access)
+"Ny" = (
+/obj/structure/closet,
+/obj/item/clothing/under/rank/scientist/zeng,
+/turf/simulated/floor/tiled/techfloor,
+/area/lar_maria/vir_access)
+"Pp" = (
+/turf/simulated/floor/tiled/dark/monotile,
+/area/lar_maria/sec_wing)
+"Qn" = (
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/vir_main)
+"QP" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/vir_access)
+"QT" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/shiv,
+/turf/simulated/floor/plating,
+/area/lar_maria/cells)
+"Sz" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/vir_aux)
+"SK" = (
+/mob/living/simple_animal/hostile/lar_maria/guard,
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/vir_hallway)
+"YL" = (
+/mob/living/simple_animal/hostile/lar_maria/guard,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/lar_maria/sec_wing)
 
 (1,1,1) = {"
@@ -20693,7 +20871,7 @@ bQ
 ac
 cs
 cc
-bw
+gA
 bw
 aU
 ac
@@ -21092,7 +21270,7 @@ aa
 ac
 ac
 aU
-bw
+gA
 bS
 ac
 ac
@@ -21503,7 +21681,7 @@ cu
 ac
 cR
 bx
-aU
+Hy
 ac
 er
 bw
@@ -22508,7 +22686,7 @@ ac
 bb
 bC
 ac
-bb
+HQ
 bC
 ac
 cV
@@ -22729,7 +22907,7 @@ cO
 cO
 cO
 hC
-eK
+zi
 hC
 cO
 iB
@@ -22917,8 +23095,8 @@ bD
 ac
 cX
 cO
-dR
-ec
+dT
+JU
 et
 eI
 fe
@@ -23113,7 +23291,7 @@ ac
 ac
 be
 bg
-bh
+BW
 cd
 cw
 cN
@@ -23323,10 +23501,10 @@ cZ
 cO
 dT
 ec
-et
+ns
 eK
 eK
-et
+Pp
 fO
 cO
 gn
@@ -23532,9 +23710,9 @@ et
 fN
 cO
 go
-gF
-gF
-gF
+Mn
+QP
+QP
 ht
 hE
 hY
@@ -23720,7 +23898,7 @@ ac
 bh
 bE
 ac
-bh
+QT
 bg
 ac
 cU
@@ -23734,10 +23912,10 @@ fv
 fP
 cO
 gp
-gF
+Mn
 gW
-gF
-gF
+Mn
+Mn
 hF
 hZ
 ih
@@ -23936,16 +24114,16 @@ fw
 fQ
 cO
 gq
-gF
-gF
-gF
+Mn
+Mn
+Mn
 gW
-gF
-gF
+Mn
+Mn
 ii
 iv
 iC
-ev
+kg
 cO
 cO
 aa
@@ -24138,9 +24316,9 @@ et
 fN
 cO
 gr
-gF
-gF
-gF
+Mn
+nZ
+nZ
 hu
 hG
 ia
@@ -24546,9 +24724,9 @@ cO
 cO
 gz
 gz
-gF
+Mn
 hj
-gF
+Mn
 gz
 gz
 gz
@@ -24737,7 +24915,7 @@ dd
 bg
 dW
 ef
-et
+YL
 eO
 fj
 fy
@@ -25141,7 +25319,7 @@ df
 dB
 dW
 eg
-ev
+kg
 et
 fl
 cO
@@ -25151,12 +25329,12 @@ gt
 gJ
 cO
 hg
-gW
+Kb
 hK
 hj
 im
-gF
-hh
+Mn
+Ny
 gz
 gz
 aa
@@ -25344,7 +25522,7 @@ dC
 dW
 eg
 ew
-et
+jx
 fm
 cO
 fN
@@ -25353,12 +25531,12 @@ cO
 cO
 cO
 hh
-gF
+Mn
 hL
 hj
 hL
-gF
-hg
+Mn
+Jn
 gz
 gz
 aa
@@ -25549,17 +25727,17 @@ ex
 eP
 fn
 cO
-fN
+em
 gi
 dC
 gK
 cO
 hi
-gF
+Mn
 hL
 hj
 hL
-gF
+Mn
 hi
 gz
 gz
@@ -26152,7 +26330,7 @@ dG
 dY
 dY
 ez
-eA
+sk
 dY
 cO
 fV
@@ -26555,7 +26733,7 @@ dm
 dI
 dY
 dY
-ez
+yn
 eR
 dY
 cO
@@ -26745,7 +26923,7 @@ aa
 aa
 ag
 ag
-aS
+Qn
 aR
 bo
 bJ
@@ -26953,7 +27131,7 @@ bp
 aS
 aS
 ck
-aS
+Qn
 ag
 do
 dJ
@@ -27171,7 +27349,7 @@ gv
 gN
 gz
 hp
-gF
+Mn
 hS
 hj
 ir
@@ -27363,7 +27541,7 @@ dq
 dL
 dL
 el
-dL
+SK
 eV
 eX
 fA
@@ -27373,11 +27551,11 @@ dL
 gO
 gz
 hp
-gF
+Mn
 hL
 hj
 is
-gF
+Mn
 hp
 gz
 gz
@@ -27571,7 +27749,7 @@ dr
 fC
 dr
 dr
-gz
+Mn
 gP
 gz
 hj
@@ -27763,8 +27941,8 @@ aS
 co
 cI
 ag
-fG
-fG
+pr
+pr
 dZ
 fG
 eE
@@ -27966,9 +28144,9 @@ cp
 cJ
 ag
 dt
-dM
+mE
 du
-fG
+fa
 fG
 eC
 dr
@@ -27982,7 +28160,7 @@ hr
 gW
 gG
 ib
-gX
+aE
 gn
 gz
 gz
@@ -28170,12 +28348,12 @@ ag
 du
 du
 du
-em
 fG
-eY
+fG
+GT
 fq
 fD
-fG
+pr
 dr
 gz
 gz
@@ -28369,8 +28547,8 @@ aS
 aS
 aS
 ag
-fG
-fG
+pr
+pr
 dZ
 fG
 fG
@@ -28968,20 +29146,20 @@ aa
 ag
 ag
 aK
-aS
+Qn
 bv
 aJ
 bv
-aS
+Qn
 cL
 ag
 dw
-dN
+Sz
 ea
 dN
-dN
-fa
-fG
+Sz
+Ky
+pr
 fG
 ge
 dr
@@ -29170,7 +29348,7 @@ aa
 ag
 ag
 aL
-aS
+Qn
 aL
 aJ
 aL
@@ -29185,7 +29363,7 @@ eG
 fb
 ft
 fG
-fG
+yj
 dr
 dr
 aa

--- a/maps/away/lar_maria/lar_maria-2.dmm
+++ b/maps/away/lar_maria/lar_maria-2.dmm
@@ -719,6 +719,7 @@
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
 "bz" = (
@@ -735,6 +736,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
 "bA" = (
@@ -747,6 +749,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
 "bB" = (
@@ -761,6 +764,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
 "bC" = (
@@ -785,24 +789,27 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "bG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/engineering,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "bH" = (
 /obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/tiled,
+/obj/item/book/manual/engineering_hacking,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "bI" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "bJ" = (
 /obj/machinery/atmospherics/unary/tank/nitrogen{
@@ -848,10 +855,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "bR" = (
@@ -880,43 +889,42 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "bV" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/dorms)
 "bW" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/spline/fancy/wood/three_quarters,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/dorms)
 "bX" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/wood,
-/area/lar_maria/dorms)
+/obj/structure/table/standard,
+/obj/item/reagent_containers/food/snacks/old/taco,
+/turf/simulated/floor/tiled/techfloor,
+/area/lar_maria/mess_hall)
 "bY" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "bZ" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/dorms)
 "ca" = (
 /obj/effect/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/dorms)
 "cb" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/dorms)
 "cc" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "cd" = (
 /turf/simulated/floor/tiled,
@@ -926,16 +934,15 @@
 /turf/simulated/floor/tiled,
 /area/lar_maria/library)
 "cf" = (
-/obj/effect/landmark/corpse/lar_maria/virologist,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "cg" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/mob/living/simple_animal/hostile/lar_maria/virologist,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "ch" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/red,
@@ -957,6 +964,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "ck" = (
@@ -964,6 +972,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "cl" = (
@@ -986,52 +995,53 @@
 /area/lar_maria/dorms)
 "cp" = (
 /obj/machinery/door/airlock,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "cq" = (
 /obj/machinery/door/airlock,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/wood,
+/obj/structure/barricade,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "cr" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/engineering_guide,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "cs" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/stasis,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "ct" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "cu" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/medical_diagnostics_manual,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "cv" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/detective,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "cw" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/medical_cloning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "cx" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/hydroponics_pod_people,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "cy" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/anomaly_spectroscopy,
 /obj/item/book/manual/anomaly_testing,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/library)
 "cz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -1053,34 +1063,34 @@
 /area/lar_maria/atmos)
 "cD" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "cE" = (
 /obj/structure/table/woodentable,
 /obj/random/smokes,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "cF" = (
 /obj/structure/table/woodentable,
 /obj/random/toy,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "cG" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/glowsticks,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "cH" = (
 /obj/structure/table/woodentable,
 /obj/random/smokes,
 /obj/random/drinkbottle,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "cI" = (
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "cJ" = (
 /obj/structure/window/basic{
@@ -1088,7 +1098,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/paper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "cK" = (
 /obj/structure/window/basic{
@@ -1100,7 +1110,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "cL" = (
 /obj/structure/window/basic{
@@ -1109,7 +1119,7 @@
 /obj/structure/table/standard,
 /obj/item/paper_bin,
 /obj/item/pen/red,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "cM" = (
 /obj/structure/window/basic{
@@ -1121,7 +1131,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "cN" = (
 /obj/structure/window/basic{
@@ -1129,7 +1139,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "cO" = (
 /obj/structure/window/basic{
@@ -1140,7 +1150,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/paper/lar_maria/note_2,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "cP" = (
 /obj/structure/window/basic{
@@ -1149,7 +1159,7 @@
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "cQ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
@@ -1177,12 +1187,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "cU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "cV" = (
@@ -1208,36 +1220,36 @@
 /obj/structure/bed/chair/comfy/purple{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "cZ" = (
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/dorms)
 "da" = (
 /obj/structure/bookcase/manuals/medical,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "db" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "dc" = (
 /mob/living/simple_animal/hostile/lar_maria/guard/ranged,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "dd" = (
 /obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "de" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "df" = (
 /obj/structure/closet,
@@ -1245,31 +1257,31 @@
 /obj/random/smokes,
 /obj/random/snack,
 /obj/random/snack,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "dg" = (
 /obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "dh" = (
 /obj/structure/window/basic,
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "di" = (
 /obj/structure/window/basic{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "dj" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4;
 	icon_state = "officechair_white_preview"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "dk" = (
 /obj/machinery/light{
@@ -1279,7 +1291,7 @@
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "dl" = (
 /obj/machinery/atmospherics/unary/tank/oxygen{
@@ -1319,32 +1331,34 @@
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "ds" = (
-/mob/living/simple_animal/hostile/lar_maria/virologist,
-/turf/simulated/floor/wood,
+/mob/living/simple_animal/hostile/lar_maria/guard,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "dt" = (
 /obj/structure/bed/padded,
-/turf/simulated/floor/wood,
+/obj/item/bedsheet/green,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "du" = (
 /obj/machinery/light,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "dv" = (
 /obj/structure/closet,
 /obj/random/masks,
 /obj/random/accessory,
 /obj/random/smokes,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "dw" = (
 /obj/random/closet,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "dx" = (
 /obj/structure/bed/padded,
 /obj/random/plushie,
-/turf/simulated/floor/wood,
+/obj/item/bedsheet/green,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "dy" = (
 /obj/structure/window/basic,
@@ -1353,7 +1367,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/folder/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "dz" = (
 /obj/structure/window/basic,
@@ -1361,7 +1375,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/blue,
 /obj/item/paper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "dA" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
@@ -1412,7 +1426,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/dorms)
 "dJ" = (
 /obj/structure/window/basic{
@@ -1421,7 +1435,7 @@
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "dK" = (
 /obj/effect/landmark/corpse/lar_maria/test_subject,
@@ -1431,7 +1445,7 @@
 "dL" = (
 /obj/machinery/photocopier,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "dM" = (
 /obj/structure/table/standard,
@@ -1442,7 +1456,7 @@
 	pixel_x = 25;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "dN" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
@@ -1480,6 +1494,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "dR" = (
@@ -1492,6 +1507,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
 "dS" = (
@@ -1523,23 +1539,24 @@
 "dX" = (
 /obj/structure/bed/padded,
 /obj/random/plushie/large,
-/turf/simulated/floor/wood,
+/obj/item/bedsheet/green,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "dY" = (
 /obj/structure/closet,
 /obj/random/loot,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "dZ" = (
 /obj/structure/closet,
 /obj/random/shoes,
 /obj/random/snack,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "ea" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "eb" = (
 /obj/structure/window/basic{
@@ -1548,18 +1565,18 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "ec" = (
 /obj/structure/table/standard,
 /obj/item/pen/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "ed" = (
 /obj/structure/table/standard,
 /obj/item/pen/crayon/orange,
 /obj/item/paper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "ee" = (
 /obj/structure/window/basic{
@@ -1569,7 +1586,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/library)
 "ef" = (
 /obj/structure/closet/crate/paper_refill,
@@ -1595,40 +1612,40 @@
 /area/lar_maria/library)
 "ei" = (
 /obj/structure/bed/chair/comfy/beige,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "ej" = (
 /obj/machinery/botany,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "ek" = (
 /obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "el" = (
 /obj/effect/landmark/corpse/lar_maria/virologist_female,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/dorms)
 "em" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "en" = (
 /obj/structure/closet,
 /obj/random/loot,
 /obj/random/accessory,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "eo" = (
 /obj/structure/bed/chair/comfy/green,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "ep" = (
 /obj/structure/closet,
 /obj/random/accessory,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "eq" = (
 /turf/simulated/wall/r_wall,
@@ -1665,11 +1682,12 @@
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/office)
 "ex" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/office)
 "ey" = (
 /obj/structure/bed/padded,
-/turf/simulated/floor/tiled,
+/obj/item/bedsheet/blue,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/office)
 "ez" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1680,50 +1698,50 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/lar_maria/office)
 "eA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/lar_maria/office)
 "eB" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "eC" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
 /obj/item/pen/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "eD" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/landmark/corpse/lar_maria/virologist_female,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "eE" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "eF" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/handcuffs,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "eG" = (
 /obj/structure/table/woodentable,
 /obj/random/smokes,
 /obj/random/snack,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "eH" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/beakers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/green,
 /area/lar_maria/dorms)
 "eI" = (
 /obj/structure/hygiene/toilet,
@@ -1732,6 +1750,7 @@
 	},
 /obj/random/trash,
 /mob/living/simple_animal/hostile/lar_maria/virologist,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "eJ" = (
@@ -1740,13 +1759,14 @@
 	dir = 1
 	},
 /obj/random/trash,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "eK" = (
 /obj/structure/hygiene/urinal{
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "eL" = (
 /obj/machinery/light{
@@ -1755,7 +1775,7 @@
 /obj/random/trash,
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1789,27 +1809,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/office)
 "eS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/office)
 "eT" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "eU" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "eV" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "eW" = (
 /obj/machinery/computer/modular,
@@ -1817,6 +1837,7 @@
 /area/lar_maria/office)
 "eX" = (
 /obj/machinery/door/airlock,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "eY" = (
@@ -1824,10 +1845,10 @@
 	pixel_x = -30
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "eZ" = (
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fb" = (
 /obj/machinery/door/airlock/medical,
@@ -1840,43 +1861,44 @@
 "fd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/office)
 "fe" = (
 /obj/machinery/door/window/southleft,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "ff" = (
 /obj/structure/window/basic,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "fg" = (
 /obj/structure/window/basic,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/office)
 "fh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/wood,
-/area/lar_maria/dorms)
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/landmark/corpse/lar_maria/virologist,
+/turf/simulated/floor/tiled/techfloor,
+/area/lar_maria/mess_hall)
 "fi" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
 	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/walnut,
 /area/lar_maria/dorms)
 "fj" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fk" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fl" = (
 /obj/machinery/power/apc{
@@ -1889,7 +1911,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fm" = (
 /obj/structure/closet,
@@ -1899,7 +1921,7 @@
 /obj/item/clothing/suit/storage/toggle/labcoat,
 /obj/item/clothing/suit/storage/toggle/labcoat,
 /obj/random/gloves,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fn" = (
 /obj/machinery/light{
@@ -1908,40 +1930,41 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/office)
 "fo" = (
 /obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fp" = (
 /obj/structure/table/standard,
 /obj/item/folder/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fq" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fr" = (
 /obj/structure/table/standard,
 /obj/item/towel,
 /obj/random/soap,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fs" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "ft" = (
 /obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1955,7 +1978,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fw" = (
 /obj/machinery/door/airlock,
@@ -1972,7 +1995,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
 "fx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2011,61 +2034,62 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fA" = (
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fB" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/office)
 "fD" = (
 /obj/structure/table/standard,
 /obj/item/pen/blue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fE" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fF" = (
 /obj/structure/table/woodentable,
 /obj/item/staff/gentcane,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fG" = (
 /obj/structure/table/woodentable,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fH" = (
 /obj/structure/table/woodentable,
 /obj/random/drinkbottle,
 /obj/random/contraband,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fI" = (
 /obj/structure/table/woodentable,
 /obj/random/toolbox,
 /obj/item/scalpel,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fJ" = (
 /obj/structure/table/woodentable,
 /obj/random/snack,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fK" = (
 /obj/machinery/door/airlock,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "fL" = (
@@ -2078,20 +2102,21 @@
 "fM" = (
 /obj/structure/table/standard,
 /obj/random/gloves,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fN" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fO" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/tiled,
+/obj/item/paper/lar_maria/note_trapped,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fP" = (
 /obj/structure/table/steel,
 /obj/random/firstaid,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2105,7 +2130,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/office)
 "fR" = (
 /obj/machinery/power/apc{
@@ -2118,60 +2143,62 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/office)
 "fS" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
 /obj/item/paper,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fT" = (
 /obj/structure/table/standard,
 /obj/item/paper/lar_maria/note_9,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "fU" = (
 /obj/machinery/vending/engivend{
 	req_access = list()
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fV" = (
 /mob/living/simple_animal/hostile/lar_maria/guard,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fW" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fX" = (
 /mob/living/simple_animal/hostile/lar_maria/virologist/female,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fY" = (
 /obj/structure/closet,
 /obj/random/handgun,
 /obj/random/powercell,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "fZ" = (
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "ga" = (
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "gb" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_f)
 "gc" = (
 /obj/machinery/door/airlock,
@@ -2185,6 +2212,8 @@
 	dir = 4
 	},
 /obj/random/trash,
+/mob/living/simple_animal/hostile/lar_maria/virologist/female,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
 "ge" = (
@@ -2203,14 +2232,14 @@
 "gg" = (
 /obj/structure/table/rack,
 /obj/random/firstaid,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "gh" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "gi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2222,13 +2251,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/lar_maria/office)
 "gj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/lar_maria/office)
 "gk" = (
 /obj/machinery/door/airlock/glass,
@@ -2238,7 +2267,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
 "gm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -2246,7 +2275,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/dorms)
 "gn" = (
 /obj/machinery/power/apc{
@@ -2259,25 +2288,29 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/dorms)
 "go" = (
 /obj/structure/bed/padded,
 /obj/effect/landmark/corpse/lar_maria/virologist,
-/turf/simulated/floor/wood,
+/obj/item/bedsheet/blue,
+/turf/simulated/floor/carpet/blue3,
 /area/lar_maria/dorms)
 "gp" = (
 /obj/random/trash,
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "gq" = (
 /obj/structure/table/standard,
 /obj/item/towel,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "gr" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
 "gs" = (
@@ -2304,7 +2337,7 @@
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "gw" = (
 /obj/machinery/door/airlock,
@@ -2315,13 +2348,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "gx" = (
 /turf/simulated/wall/r_wall,
 /area/lar_maria/mess_hall)
 "gy" = (
 /obj/structure/closet/athletic_mixed,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_m)
 "gz" = (
@@ -2352,7 +2386,7 @@
 	dir = 8
 	},
 /obj/item/stool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/hallway)
 "gF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2363,13 +2397,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "gG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "gH" = (
 /obj/structure/window/basic{
@@ -2383,27 +2417,27 @@
 	dir = 8
 	},
 /obj/item/stool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/hallway)
 "gI" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "gJ" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "gK" = (
 /obj/machinery/vending/games,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "gM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2412,60 +2446,63 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "gN" = (
 /obj/structure/table/standard,
 /obj/random/snack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "gO" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "gP" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "gQ" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "gR" = (
 /obj/structure/table/standard,
 /obj/item/trash/plate,
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "gS" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "gT" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "gU" = (
 /obj/machinery/door/window/westright,
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "gV" = (
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "gW" = (
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = 25
 	},
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "gX" = (
@@ -2473,12 +2510,13 @@
 	pixel_y = 23;
 	req_access = newlist()
 	},
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "gY" = (
 /obj/machinery/door/airlock/freezer,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/mess_hall)
 "gZ" = (
 /turf/simulated/floor/tiled/freezer,
@@ -2517,14 +2555,14 @@
 	dir = 8
 	},
 /obj/item/stool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/hallway)
 "hg" = (
 /obj/structure/window/basic{
 	dir = 4
 	},
 /obj/item/stool,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/hallway)
 "hh" = (
 /obj/machinery/light{
@@ -2544,25 +2582,28 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "hj" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "hk" = (
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor,
 /obj/item/material/kitchen/utensil/fork,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "hl" = (
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "hm" = (
 /obj/machinery/cooker/grill,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "hn" = (
@@ -2585,6 +2626,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/lar_maria/virologist/female,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
 "hr" = (
@@ -2595,13 +2637,13 @@
 	pixel_y = 23;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_f)
 "hs" = (
 /obj/structure/table/standard,
 /obj/item/towel,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_f)
 "ht" = (
 /obj/structure/mopbucket,
@@ -2632,7 +2674,7 @@
 	pixel_x = -24;
 	req_access = list()
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hx" = (
 /obj/structure/cable{
@@ -2640,7 +2682,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2659,7 +2701,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2672,7 +2714,7 @@
 	},
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2684,7 +2726,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2698,7 +2740,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hC" = (
 /obj/machinery/door/firedoor,
@@ -2710,7 +2752,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "hD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -2724,7 +2766,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "hE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2735,7 +2777,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "hF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2747,7 +2789,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "hG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2758,20 +2800,22 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "hH" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "hI" = (
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor,
 /obj/item/material/kitchen/rollingpin,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "hJ" = (
 /obj/machinery/cooker/fryer,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "hK" = (
@@ -2794,28 +2838,30 @@
 	dir = 4
 	},
 /obj/random/trash,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
 "hO" = (
 /obj/structure/table/standard,
 /obj/item/towel,
 /obj/random/soap,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
 "hP" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_f)
 "hQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_f)
 "hR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_f)
 "hS" = (
 /obj/machinery/door/airlock,
@@ -2824,10 +2870,10 @@
 "hT" = (
 /obj/effect/landmark/corpse/lar_maria/zhp_guard/dark,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hU" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/hallway)
 "hV" = (
 /obj/structure/cable{
@@ -2838,7 +2884,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2846,13 +2892,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "hY" = (
 /obj/machinery/door/firedoor,
@@ -2862,43 +2908,46 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "hZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "ib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "ic" = (
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/mess_hall)
 "id" = (
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/storage/fancy/egg_box/full,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "ie" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "if" = (
 /obj/machinery/cooker/oven,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "ig" = (
@@ -2920,14 +2969,17 @@
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
 "ik" = (
 /obj/random/trash,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
 "il" = (
 /obj/structure/closet/athletic_mixed,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
 "in" = (
@@ -2942,7 +2994,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_f)
 "io" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3030,7 +3082,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/hallway)
 "iv" = (
 /obj/structure/cable{
@@ -3042,11 +3094,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "iw" = (
 /obj/item/paper/lar_maria/note_6,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/hallway)
 "ix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -3060,7 +3112,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "iz" = (
 /obj/structure/bed/chair{
@@ -3068,32 +3120,35 @@
 	},
 /obj/effect/landmark/corpse/lar_maria/virologist,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "iA" = (
 /obj/structure/table/standard,
 /obj/item/paper/lar_maria/note_3,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "iB" = (
 /obj/structure/table/standard,
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "iC" = (
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor,
 /obj/item/trash/plate,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "iD" = (
 /obj/effect/landmark/corpse/lar_maria/virologist_female,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "iE" = (
 /obj/structure/table/marble,
 /obj/machinery/cooker/cereal,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "iF" = (
@@ -3112,7 +3167,7 @@
 	},
 /obj/effect/landmark/corpse/lar_maria/test_subject,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_f)
 "iI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3127,7 +3182,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_f)
 "iJ" = (
 /obj/machinery/door/airlock,
@@ -3194,14 +3249,14 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/hallway)
 "iR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -3215,46 +3270,53 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "iT" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "iU" = (
 /obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "iV" = (
 /obj/machinery/light,
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "iW" = (
 /obj/structure/table/standard,
 /obj/item/clothing/head/soft/lar_maria/zhp_cap,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/lar_maria/mess_hall)
 "iX" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "iY" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "iZ" = (
 /obj/structure/table/marble,
 /obj/item/trash/plate,
 /obj/item/material/kitchen/utensil/fork,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "ja" = (
 /obj/structure/table/marble,
+/obj/effect/floor_decal/corner/darkgrey/diagonal,
+/obj/item/reagent_containers/food/snacks/fish/space_carp,
+/obj/item/reagent_containers/food/snacks/fish/space_carp,
+/obj/item/reagent_containers/food/snacks/fish/space_carp,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/mess_hall)
 "jb" = (
@@ -3385,6 +3447,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
+"jF" = (
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/head_f)
 "kb" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -3394,6 +3459,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
+"kT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/lar_maria/guard,
+/turf/simulated/floor/carpet/green,
+/area/lar_maria/dorms)
+"kU" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/library)
 "lb" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -3401,6 +3477,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
 "lD" = (
@@ -3408,8 +3486,13 @@
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/hallway)
+"lH" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/item/book/manual/rust_engine,
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/library)
 "mb" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
@@ -3425,6 +3508,14 @@
 	},
 /turf/simulated/open,
 /area/lar_maria/solar_control)
+"mq" = (
+/obj/random/trash,
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/library)
+"mU" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
 "nb" = (
 /obj/structure/dispenser/oxygen,
 /obj/machinery/light/small{
@@ -3439,6 +3530,16 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/lar_maria/hallway)
+"nU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/library)
+"nX" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/head_m)
 "ob" = (
 /obj/structure/ladder,
 /obj/machinery/light/small{
@@ -3447,6 +3548,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/solar_control)
+"oE" = (
+/obj/effect/landmark/corpse/lar_maria/virologist,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/library)
 "pb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -3456,6 +3562,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
+"pp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/office)
+"pI" = (
+/obj/structure/table/standard,
+/obj/item/reagent_containers/food/snacks/old/pizza,
+/turf/simulated/floor/tiled/techfloor,
+/area/lar_maria/mess_hall)
+"pQ" = (
+/mob/living/simple_animal/hostile/lar_maria/guard/ranged,
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/dorms)
+"pR" = (
+/obj/structure/closet,
+/obj/random/loot,
+/turf/simulated/floor/carpet/green,
+/area/lar_maria/dorms)
 "qb" = (
 /obj/structure/table/rack,
 /obj/random/tank,
@@ -3465,6 +3591,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
+"qd" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/lar_maria/mess_hall)
+"qY" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
 "rb" = (
 /obj/machinery/atmospherics/unary/tank/nitrogen{
 	dir = 4
@@ -3504,6 +3637,15 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/lar_maria/atmos)
+"uh" = (
+/obj/effect/landmark/corpse/lar_maria/test_subject,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
+"uq" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
 "vb" = (
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -3516,10 +3658,25 @@
 	pixel_y = 23;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
+"vf" = (
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/office)
 "vM" = (
 /obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/steel_grid,
+/area/lar_maria/hallway)
+"vW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/lar_maria/hallway)
 "wb" = (
@@ -3531,8 +3688,17 @@
 	pixel_x = 30
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/head_m)
+"wx" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/blue,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
+"wJ" = (
+/obj/structure/closet/crate/secure/boobytrapped/weapon,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/office)
 "xb" = (
 /obj/structure/hygiene/sink{
 	dir = 8;
@@ -3542,20 +3708,176 @@
 /obj/item/storage/mirror{
 	pixel_x = -30
 	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/lar_maria/head_f)
+"xZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/hallway)
+"yw" = (
+/obj/machinery/door/airlock,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/head_f)
+"zI" = (
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/hallway)
+"zS" = (
+/obj/structure/bed/padded,
+/obj/random/plushie,
+/obj/item/bedsheet/blue,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
+"Bg" = (
+/obj/random/closet,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
+"Bo" = (
+/obj/random/trash,
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/library)
+"Da" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/hallway)
+"Dt" = (
+/mob/living/simple_animal/hostile/lar_maria/virologist,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
 "DG" = (
 /obj/machinery/computer/modular{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/lar_maria/office)
+"GD" = (
+/obj/structure/hygiene/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/random/trash,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/lar_maria/head_f)
+"HJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/lar_maria/hallway)
+"IR" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/dorms)
+"Kf" = (
+/obj/machinery/computer/modular,
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/office)
+"LR" = (
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
+"LT" = (
+/obj/item/paper/lar_maria/note_2,
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/library)
+"MN" = (
+/mob/living/simple_animal/hostile/lar_maria/virologist,
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/dorms)
+"Om" = (
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/dorms)
+"Pw" = (
+/obj/machinery/door/airlock,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
+"Qn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/lar_maria/hallway)
+"QC" = (
+/turf/simulated/floor/carpet/green,
+/area/lar_maria/dorms)
+"QS" = (
+/turf/simulated/floor/tiled/monotile,
+/area/lar_maria/library)
+"Rk" = (
+/obj/structure/table/standard,
+/obj/item/reagent_containers/food/snacks/old/hamburger,
+/turf/simulated/floor/tiled/techfloor,
+/area/lar_maria/mess_hall)
+"Rq" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/lar_maria/head_m)
+"Tq" = (
+/obj/machinery/computer/modular,
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/office)
+"Ty" = (
+/obj/machinery/computer/modular{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/green,
+/area/lar_maria/dorms)
+"TR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/dorms)
+"Ur" = (
+/obj/effect/floor_decal/spline/fancy/wood/three_quarters,
+/turf/simulated/floor/wood/walnut,
+/area/lar_maria/library)
 "VZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /obj/effect/wallframe_spawn,
 /turf/simulated/floor/plating,
+/area/lar_maria/hallway)
+"XN" = (
+/obj/effect/landmark/corpse/lar_maria/virologist_female,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/carpet/green,
+/area/lar_maria/dorms)
+"XP" = (
+/obj/machinery/door/airlock/medical,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/office)
+"Yc" = (
+/obj/machinery/door/airlock,
+/obj/structure/barricade,
+/turf/simulated/floor/carpet/blue3,
+/area/lar_maria/dorms)
+"Yu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/lar_maria/hallway)
 "Yw" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -20215,8 +20537,8 @@ aq
 ad
 bw
 bw
-bH
-cc
+lH
+nU
 cr
 cJ
 dh
@@ -20417,12 +20739,12 @@ aq
 ad
 bw
 bw
-bH
-cd
+kU
+cf
 cs
 cK
 di
-ce
+Bo
 di
 eb
 er
@@ -20433,7 +20755,7 @@ fr
 er
 ga
 gp
-eZ
+Rq
 er
 hq
 gr
@@ -20619,12 +20941,12 @@ aq
 ad
 bw
 bw
-bH
-ce
+kU
+mq
 ct
 cL
 dh
-cd
+QS
 dJ
 ec
 er
@@ -20821,19 +21143,19 @@ aq
 ad
 bw
 bw
-bH
-cd
+kU
+cf
 cu
 cM
 di
-cd
+QS
 di
 eb
 er
 er
 er
 fk
-fs
+nX
 er
 er
 er
@@ -21024,11 +21346,11 @@ ad
 bw
 bw
 bH
-cd
+cf
 cv
 cN
 dh
-cd
+QS
 dJ
 ed
 er
@@ -21038,10 +21360,10 @@ eZ
 ft
 er
 gb
-gr
-gr
-gr
-gr
+jF
+jF
+jF
+jF
 hP
 xb
 xb
@@ -21226,11 +21548,11 @@ ad
 bw
 bw
 bI
-cd
+oE
 cw
 cM
 di
-cd
+QS
 di
 ee
 er
@@ -21239,9 +21561,9 @@ eZ
 eZ
 fu
 er
-gc
+yw
 ge
-gc
+yw
 ge
 hr
 hQ
@@ -21427,9 +21749,9 @@ aq
 ad
 bw
 bw
-bH
-cd
-ce
+kU
+LT
+Ur
 cd
 cd
 ce
@@ -21443,7 +21765,7 @@ fv
 er
 gd
 ge
-gd
+GD
 ge
 hs
 hR
@@ -21629,9 +21951,9 @@ aq
 ad
 bw
 bw
-bH
-cd
-cd
+kU
+cf
+Ur
 cd
 cd
 cd
@@ -21831,7 +22153,7 @@ aq
 ad
 bw
 bw
-bH
+kU
 cf
 cx
 cO
@@ -21840,7 +22162,7 @@ dy
 dL
 eg
 es
-eN
+HJ
 eN
 eN
 fx
@@ -22033,7 +22355,7 @@ aq
 ad
 bw
 bw
-bH
+kU
 cg
 cy
 cP
@@ -22042,7 +22364,7 @@ dz
 dM
 eh
 et
-eO
+vW
 eO
 eO
 fy
@@ -22448,7 +22770,7 @@ bx
 ev
 eP
 fb
-ex
+vf
 fz
 fM
 gg
@@ -22650,10 +22972,10 @@ bx
 ew
 eQ
 eu
-ex
-ex
-ex
-ex
+vf
+vf
+vf
+vf
 eu
 gB
 hc
@@ -22853,9 +23175,9 @@ eu
 eu
 eu
 fm
-ex
+vf
 fN
-ex
+vf
 eu
 gC
 hd
@@ -23051,13 +23373,13 @@ dn
 dB
 bM
 bx
+wJ
 ex
-ex
-fc
-ex
+XP
+vf
 fA
 fO
-ex
+vf
 eu
 gz
 gz
@@ -23256,7 +23578,7 @@ bx
 ey
 ey
 eu
-eW
+Kf
 fB
 fP
 gh
@@ -23265,8 +23587,8 @@ gD
 he
 hw
 hT
-iq
-iM
+Qn
+Yu
 hS
 ni
 jd
@@ -23466,7 +23788,7 @@ eu
 gE
 hf
 hx
-hU
+zI
 iu
 lD
 jd
@@ -23666,7 +23988,7 @@ fQ
 gi
 gs
 gF
-eO
+Da
 hy
 hV
 iv
@@ -23868,10 +24190,10 @@ fR
 gj
 gt
 gG
-eN
+xZ
 hz
 hW
-eN
+xZ
 iQ
 jf
 jh
@@ -24266,9 +24588,9 @@ bx
 eB
 eT
 fe
-ex
-eT
-ex
+vf
+pp
+vf
 gh
 eu
 gD
@@ -24468,10 +24790,10 @@ bx
 eC
 eU
 ff
-ex
+vf
 DG
 eW
-ex
+vf
 gu
 gu
 gu
@@ -24870,7 +25192,7 @@ dH
 dW
 bx
 eE
-eW
+Tq
 fg
 fp
 fE
@@ -24878,10 +25200,10 @@ fT
 fp
 gu
 gJ
-gT
+qd
 hE
 ia
-gT
+qd
 iT
 gx
 gx
@@ -25080,10 +25402,10 @@ eu
 eu
 gu
 gK
-gT
+qd
 hE
 ia
-gT
+qd
 iU
 gx
 gx
@@ -25265,7 +25587,7 @@ ad
 ad
 bE
 bE
-bV
+IR
 bV
 bV
 bV
@@ -25273,7 +25595,7 @@ bV
 dI
 bV
 bV
-bV
+IR
 bV
 dI
 bV
@@ -25469,14 +25791,14 @@ bE
 bE
 bV
 bV
+IR
+bV
+MN
 bV
 bV
-ds
 bV
 bV
-bV
-bV
-bV
+IR
 bV
 el
 bV
@@ -25488,7 +25810,7 @@ gM
 hG
 gT
 iA
-gO
+bX
 gx
 gx
 ad
@@ -25679,7 +26001,7 @@ co
 co
 co
 co
-fh
+bW
 co
 co
 co
@@ -25871,11 +26193,11 @@ aA
 ad
 bE
 bE
-bX
+fi
 co
-cD
+qY
 cY
-dt
+wx
 co
 dX
 ei
@@ -26073,27 +26395,27 @@ aA
 ad
 bE
 bE
-bV
-cp
-bV
-cZ
+Om
+uq
+LR
+uh
 du
 co
 bY
 ds
-bV
+QC
 cp
-bV
-cp
-bV
-bV
+bZ
+Yc
+LR
+LR
 du
 gu
 gP
+qd
 gT
 gT
-gT
-gT
+qd
 iV
 gx
 gx
@@ -26275,7 +26597,7 @@ aA
 ad
 bE
 bE
-bV
+Om
 co
 cE
 da
@@ -26285,11 +26607,11 @@ dw
 ej
 eG
 co
-bV
+Om
 co
 cI
 fU
-dw
+Bg
 gu
 gQ
 gQ
@@ -26477,7 +26799,7 @@ aA
 ad
 bE
 bE
-bY
+TR
 co
 co
 co
@@ -26487,7 +26809,7 @@ co
 co
 co
 co
-bY
+TR
 co
 co
 co
@@ -26679,27 +27001,27 @@ aA
 ad
 bE
 bE
-bV
+Om
 co
 cE
 db
-dt
+wx
 co
 dt
 ek
 cD
 co
-bV
+Om
 co
 fG
 db
-dt
+wx
 gu
-gO
+Rk
 gO
 gT
 gT
-gO
+pI
 iW
 gx
 gx
@@ -26881,23 +27203,23 @@ aA
 ad
 bE
 bE
-bV
-cq
-bZ
+Om
+Pw
+mU
 dc
 du
 co
 bY
-el
-bV
+XN
+QC
 cp
-bV
-cp
-bV
+Om
+uq
+LR
 fV
 du
 gu
-gS
+fh
 gS
 gT
 gT
@@ -27087,13 +27409,13 @@ bZ
 co
 cF
 dd
-dw
+Bg
 co
-dY
+pR
 em
-cI
+Ty
 co
-bV
+Om
 co
 fH
 fW
@@ -27295,7 +27617,7 @@ co
 co
 co
 co
-bV
+Om
 co
 co
 co
@@ -27489,19 +27811,19 @@ bE
 bE
 ca
 co
-cD
+qY
 de
-dt
+wx
 co
 dx
 ei
 cD
 co
-bV
+Om
 co
-cD
+qY
 db
-dx
+zS
 gu
 gV
 hl
@@ -27689,20 +28011,20 @@ aA
 ad
 bE
 bE
-bV
-cp
-bV
-bV
+Om
+uq
+LR
+LR
 du
 co
-bY
-bV
-bV
+kT
+QC
+QC
 cp
-bV
-cp
-bV
-bV
+Om
+uq
+LR
+Dt
 du
 gu
 gW
@@ -27891,21 +28213,21 @@ aA
 ad
 bE
 bE
-bV
+Om
 co
 cG
 df
-dw
+Bg
 co
 dZ
 en
-cI
+Ty
 co
-bV
+Om
 co
 fI
 da
-dw
+Bg
 gu
 gX
 hm
@@ -28093,7 +28415,7 @@ aA
 ad
 bE
 bE
-bY
+TR
 co
 co
 co
@@ -28103,7 +28425,7 @@ co
 co
 co
 co
-bY
+TR
 co
 co
 co
@@ -28295,21 +28617,21 @@ aA
 ad
 bE
 bE
-bV
+Om
 co
 cH
 cY
-dx
+zS
 co
 dt
 eo
 eH
 co
-bV
+Om
 co
-cD
+qY
 db
-dt
+wx
 gu
 gZ
 hn
@@ -28497,19 +28819,19 @@ aA
 ad
 bE
 bE
-bV
-cp
-bV
-bV
+pQ
+Yc
+LR
+LR
 du
 co
 bY
-bV
-bV
+QC
+QC
 cp
 cZ
 cq
-bZ
+mU
 fX
 du
 gu
@@ -28703,17 +29025,17 @@ cb
 co
 cI
 dg
-dw
+Bg
 co
 dw
 ep
-cI
+Ty
 co
 cb
 co
 fJ
 fY
-dw
+Bg
 gu
 gZ
 ho

--- a/maps/away/lar_maria/lar_maria.dm
+++ b/maps/away/lar_maria/lar_maria.dm
@@ -227,6 +227,10 @@
 	name = "paper note"
 	info = "<i><span style='color: blue'>can we get some fresh carp sometime? Or freshish? Or frozen? I just really want carp, ok? I'm willing to pay for it if so.</span></i>"
 
+/obj/item/paper/lar_maria/note_trapped
+	name = "scrawled paper note"
+	info = "<i> Tedd, if your still alive and find my office, I've managed to take one of the grenades from the armory and rigged it to my personal closet, don't open it and stay safe. - Mark. </i>"
+
 /datum/ai_holder/simple_animal/lar_maria
 	speak_chance = 50
 


### PR DESCRIPTION
## Features:

### General:

- Changed a good chunk of the default grey-floor tiles so Lar Maria looks slightly less grey.
- Scientist and Security Guards have their own dorm rooms color coded.
- Dorms have bedsheets now so no-one sleeps in the cold...
- Decal Pass on most of the map.
- Barricades added to certain areas on the map.

### Loot:

- Cafeteria has some food items that medbay/science can extract interesting chemicals from.
- Sci-Wings have some rare slime cores, phoron and chemical vial. 
- A potentially booby-trapped locker somewhere.

### Enemies:

- Enemy Placement adjusted and changed up somewhat for guards and scientists.
- Additional prisoners, virologists and guards around both floors of the Away Map, including a few more beanbag guards.

### Balancing:

- The random vial is the same as the one on the crashed pod exoplanet, meaning it will have one of the following reagents:  Reagent/Random, Rezadone, Three Eye.

### Screenshots:

![StrongDMM-2025-04-05 21 55 30](https://github.com/user-attachments/assets/dae56df9-683b-4759-980f-f823a61bee8e)
![StrongDMM-2025-04-05 21 55 50](https://github.com/user-attachments/assets/f68a6e50-f5f9-4f17-aa0a-20089bdecb94)

