### PR TITLE
Sharpened Floor + Wep Construction Adjustment

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -24,11 +24,11 @@
 	obj_flags = 0
 
 /obj/item/stack/tile/attackby(obj/item/I as obj, var/mob/user as mob)
-	if(is_sharp(I) && throwforce < 20)
+	if(is_sharp(I) && throwforce < 10)
 		to_chat(user, "<span class = 'notice'>You begin to sharpen \the [src] with \the [I].</span>")
 		if(do_after(user, 30, src))
 			to_chat(user, "<span class = 'notice'>You sharpen \the [src]'s edges to a sharp point.</span>")
-			throwforce = 20
+			throwforce = 10
 			return
 	..()
 

--- a/code/modules/urist/modules/shipbattles/shipweapons/weapon_construction.dm
+++ b/code/modules/urist/modules/shipbattles/shipweapons/weapon_construction.dm
@@ -56,7 +56,7 @@
 					to_chat(user, "You wrench the weapon into place on the hardpoint.")
 					anchored = TRUE
 					state = 1
-					desc = "It's a ship-to-ship weapon assembly. It is missing external sheeting."
+					desc = "It's a ship-to-ship weapon assembly. It is missing some metal sheeting."
 					update_icon()
 
 		if(1)
@@ -67,7 +67,7 @@
 					to_chat(user, "<span class='notice'>You add some metal sheeting to the exterior frame.</span>")
 					state = 2
 					update_icon()
-					desc = "It's a ship-to-ship weapon assembly. It has some loose external sheeting."
+					desc = "It's a ship-to-ship weapon assembly. It has some loose unwelded metal sheeting."
 					return
 
 			else if(isWrench(W))
@@ -93,17 +93,17 @@
 					if(F.remove_fuel(0,user))
 						playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
 						if(do_after(user, 20, src))
-							to_chat(user, "You weld the external sheeting securely into place.")
+							to_chat(user, "You weld the metal sheeting securely into place.")
 							state = 3
 							update_icon()
-							desc = "It's a ship-to-ship weapon assembly with secured external plating. It is missing wiring."
+							desc = "It's a ship-to-ship weapon assembly with secured metal sheeting. It is missing wiring."
 					return
 
 			if(isCrowbar(W))
 				playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
 				to_chat(user, "You pry off the external sheeting.")
 				new /obj/item/stack/material/steel(get_turf(src), 2)
-				desc = "It's a ship-to-ship weapon assembly. It is missing external sheeting."
+				desc = "It's a ship-to-ship weapon assembly. It is missing metal sheeting."
 				state = 1
 				update_icon()
 				return
@@ -127,7 +127,7 @@
 					if(F.remove_fuel(0,user))
 						playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
 						if(do_after(user, 20, src))
-							desc = "It's a ship-to-ship weapon assembly. It has some loose external sheeting."
+							desc = "It's a ship-to-ship weapon assembly. It has some loose metal sheeting."
 							state = 2
 							update_icon()
 					return
@@ -135,7 +135,7 @@
 		if(4)
 			if(isScrewdriver(W))
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, "<span class='warning'>You secure the wires and screw down the external hatches: the weapon is ready to fire.</span>")
+				to_chat(user, "<span class='warning'>You secure the wires and screw down the metal hatches: the weapon is ready to fire.</span>")
 				var/obj/machinery/shipweapons/S = new weapon_type(get_turf(src))
 				if(shipid)
 					S.shipid = shipid
@@ -147,7 +147,7 @@
 				new /obj/item/stack/cable_coil(get_turf(src), 2)
 				playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
 				to_chat(user, "<span class='notice'>You cut the wires from the weapon assembly.</span>")
-				desc = "It's a ship-to-ship weapon assembly with secured external plating. It is missing wiring."
+				desc = "It's a ship-to-ship weapon assembly with secured metal plating. It is missing wiring."
 				state = 3
 				update_icon()
 				return


### PR DESCRIPTION
shouldn't mess with merge stuff
- sharpened floor tiles are slightly less anti-material, they currently have one of the highest throwforce vars in the game, bar the bowler hat and some other things.
- adjusts hardpoint weapon construction to be slightly more clear you need to add metal then weld it for the first part, i can tweak the verbage if it sounds weird