### PR TITLE
Syndicate Minibomb - Uplink Item

### DIFF
--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -90,3 +90,10 @@
 	name = "5x Metal Foam Grenades"
 	item_cost = 16
 	path = /obj/item/storage/box/metalfoams
+
+/datum/uplink_item/item/grenade/minibomb
+	name = "1x Syndicate Minibomb"
+	desc = "A highly dangerous non-fragmenting explosive, capable of grevious damage to anything in it's radius."
+	item_cost = 28
+	path = /obj/item/grenade/syndieminibomb
+	antag_costs = list(MODE_MERCENARY = 38) // Lots of structural damage.

--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -91,7 +91,7 @@
 	item_cost = 16
 	path = /obj/item/storage/box/metalfoams
 
-/datum/uplink_item/item/grenade/minibomb
+/datum/uplink_item/item/grenades/minibomb
 	name = "1x Syndicate Minibomb"
 	desc = "A highly dangerous non-fragmenting explosive, capable of grevious damage to anything in it's radius."
 	item_cost = 28

--- a/code/modules/urist/items/grenades.dm
+++ b/code/modules/urist/items/grenades.dm
@@ -186,5 +186,5 @@
 	origin_tech = list(TECH_MATERIAL = 3, TECH_MAGNET = 4, TECH_ESOTERIC = 4)
 
 /obj/item/grenade/syndieminibomb/detonate()
-	explosion(src.loc, 7, EX_ACT_DEVASTATING)
+	explosion(src.loc, 6, EX_ACT_HEAVY)
 	qdel(src)


### PR DESCRIPTION
### Available for both Traitors & Mercenary.

Saw that we ported these from /tg/ at some point and wanted to re-add the classic back to the arsenal. These are a decent alternative to fragmentation grenades if you just want to explode someone, or cause a breach and explode someone, etc. They do a decent amount of damage to the area. Feedback on price, etc is always welcome.

- Traitor Cost:

28TC

- Mercenary Cost:

38TC


#### **Damage Potential:**
![mini](https://github.com/user-attachments/assets/80210fbf-5786-4191-9a4a-4a9ae0a40d8f)

