### PR TITLE
Fixes #1424 - Chemical Powder & Masks/Helmets + User Feedback

### DIFF
--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -76,10 +76,14 @@
 
 // Proc to shove them up your nose
 
-/obj/item/reagent_containers/powder/use_tool(obj/item/W, mob/living/user, list/click_params)
+/obj/item/reagent_containers/powder/use_tool(obj/item/W, mob/living/carbon/human/user, list/click_params)
 	if(istype(W, /obj/item/glass_extra/straw) || istype(W, /obj/item/paper/cig) || istype(W, /obj/item/spacecash))
 		if(!user.check_has_mouth()) // We dont want dionae or adherents doing lines of cocaine. Probably.
-			to_chat(SPAN_WARNING("Without a nose, you seem unable to snort from \the [src]."))
+			to_chat(user, SPAN_WARNING("Without a nose, you seem unable to snort from \the [src]."))
+			return TRUE
+
+		if ((user.wear_mask && (user.wear_mask.body_parts_covered & FACE)) || (user.head && (user.head.body_parts_covered & FACE)))
+			to_chat(user, SPAN_WARNING("You need to expose your face first."))
 			return TRUE
 
 		user.visible_message(


### PR DESCRIPTION
mob/living/user changed to mob/living/carbon/human/user in order to check for head + body part coverage.

This now prevents you from snorting powder while wearing anything that covers the face, i.e bandanas, space helmets, riot helmets, etc.
This also fixes a small bug I discovered in which the to_chat wasn't going to the user, therfore the user did not get any feedback if you were a diona/adherant and didn't have a nose, and this also fixes this in the feedback for if your face is covered, yay!