### PR TITLE
Refactors + Optimizes Planet Code for huge performance gains + footstep sounds for planet turfs + other fixes

### DIFF
--- a/code/controllers/subsystems/plants.dm
+++ b/code/controllers/subsystems/plants.dm
@@ -41,9 +41,6 @@ SUBSYSTEM_DEF(plants)
 	/// Live count of run plants.
 	var/static/run_plant_counter = 0
 
-	//urist vars for jungle plant initialization
-	var/static/list/fruit_icon_states = list("badrecipe","kudzupod","reishi","lime","grapes","boiledrorocore","chocolateegg")
-	var/static/list/reagent_effects = list("toxin","anti_toxin","stoxin","space_drugs","mindbreaker","zombiepowder","impedrezene")
 
 /datum/controller/subsystem/plants/UpdateStat(time)
 	if (PreventUpdateStat(time))
@@ -124,8 +121,6 @@ SUBSYSTEM_DEF(plants)
 		plant_gene_datums[mask] = plantgene
 		gene_masked_list += list(list("tag" = tag, "mask" = mask))
 
-	fruit_icon_states = shuffle(fruit_icon_states)
-	reagent_effects = shuffle(reagent_effects)
 
 /datum/controller/subsystem/plants/proc/create_random_seed(station_environment)
 	var/datum/seed/seed = new

--- a/code/controllers/subsystems/plants.dm
+++ b/code/controllers/subsystems/plants.dm
@@ -41,6 +41,9 @@ SUBSYSTEM_DEF(plants)
 	/// Live count of run plants.
 	var/static/run_plant_counter = 0
 
+	//urist vars for jungle plant initialization
+	var/static/list/fruit_icon_states = list("badrecipe","kudzupod","reishi","lime","grapes","boiledrorocore","chocolateegg")
+	var/static/list/reagent_effects = list("toxin","anti_toxin","stoxin","space_drugs","mindbreaker","zombiepowder","impedrezene")
 
 /datum/controller/subsystem/plants/UpdateStat(time)
 	if (PreventUpdateStat(time))
@@ -121,6 +124,8 @@ SUBSYSTEM_DEF(plants)
 		plant_gene_datums[mask] = plantgene
 		gene_masked_list += list(list("tag" = tag, "mask" = mask))
 
+	fruit_icon_states = shuffle(fruit_icon_states)
+	reagent_effects = shuffle(reagent_effects)
 
 /datum/controller/subsystem/plants/proc/create_random_seed(station_environment)
 	var/datum/seed/seed = new

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -44,8 +44,19 @@ SUBSYSTEM_DEF(skybox)
 		space.icon_state = "white"
 		space.AddOverlays(dust)
 		space_appearance_cache[index] = space.appearance
-	background_color = RANDOM_RGB
-
+	var/month = text2num(time2text(world.timeofday, "MM"))
+	if(month == 6) //There's probably a better way to do this, but this works -Vak
+		if(prob(50))
+			background_icon = "rainbow"
+			background_color = null
+		else
+			background_color = RANDOM_RGB
+	else
+		if(prob(5))
+			background_icon = "rainbow"
+			background_color = null
+		else
+			background_color = RANDOM_RGB
 
 /datum/controller/subsystem/skybox/proc/get_skybox(z)
 	if (!skybox_cache["[z]"])
@@ -111,19 +122,3 @@ SUBSYSTEM_DEF(skybox)
 		skybox_cache.Cut()
 		for (var/client/client as anything in GLOB.clients)
 			client.update_skybox(TRUE)
-
-/datum/controller/subsystem/skybox/Initialize(timeofday)
-	..(timeofday)
-	var/month = text2num(time2text(world.timeofday, "MM"))
-	if(month == 6) //There's probably a better way to do this, but this works -Vak
-		if(prob(50))
-			background_icon = "rainbow"
-			background_color = null
-		else
-			background_color = RANDOM_RGB
-	else
-		if(prob(5))
-			background_icon = "rainbow"
-			background_color = null
-		else
-			background_color = RANDOM_RGB

--- a/code/modules/urist/modules/jungle/planet_plants.dm
+++ b/code/modules/urist/modules/jungle/planet_plants.dm
@@ -162,10 +162,6 @@
 		to_chat(user, "<span class='notice'> You pick a fruit off [src].</span>")
 
 		var/obj/item/reagent_containers/food/snacks/grown/jungle_fruit/J = new (src.loc)
-//		J.potency = plant_strength
-//		J.icon_state = fruit_icon_states[fruit_type]
-//		J.reagents.add_reagent(reagent_effects[fruit_type], 1+round((plant_strength / 20), 1))
-//		J.bitesize = 1+round(J.reagents.total_volume / 2, 1)
 		J.attack_hand(user)
 
 		CutOverlays(fruit_overlay)

--- a/code/modules/urist/modules/jungle/planet_plants.dm
+++ b/code/modules/urist/modules/jungle/planet_plants.dm
@@ -14,19 +14,22 @@
 	var/stump = 0
 	atom_flags = ATOM_FLAG_CLIMBABLE
 
-/obj/structure/bush/New()
-
-	icon_state = "bushnew[rand(1,4)]"
-
-	if(prob(20))
-		name = "thick foliage"
-		opacity = 1
-		desc = "Very thick scrub that blocks your vision. It'll take something sharp and a lot of determination to clear away"
-		icon_state = "thickbush[rand(1,2)]"
+/obj/structure/bush/Initialize()
+	. = ..()
 
 	if(indestructable)
 		icon_state = "thickbush[rand(1,2)]"
-	..()
+
+	else
+		if(prob(20))
+			name = "thick foliage"
+			opacity = 1
+			desc = "Very thick scrub that blocks your vision. It'll take something sharp and a lot of determination to clear away"
+			icon_state = "thickbush[rand(1,2)]"
+
+		else
+			icon_state = "bushnew[rand(1,4)]"
+
 
 /obj/structure/bush/Bumped(M as mob)
 	if (istype(M, /mob/living/simple_animal))
@@ -107,15 +110,6 @@
 // Strange, fruit-bearing plants //
 //*******************************//
 
-var/global/list/fruit_icon_states = list("badrecipe","kudzupod","reishi","lime","grapes","boiledrorocore","chocolateegg")
-var/global/list/reagent_effects = list("toxin","anti_toxin","stoxin","space_drugs","mindbreaker","zombiepowder","impedrezene")
-var/global/jungle_plants_init = 0
-
-/proc/init_jungle_plants()
-	jungle_plants_init = 1
-	fruit_icon_states = shuffle(fruit_icon_states)
-	reagent_effects = shuffle(reagent_effects)
-
 /obj/item/reagent_containers/food/snacks/grown/jungle_fruit
 	name = "jungle fruit"
 	desc = "It smells weird and looks off."
@@ -130,10 +124,10 @@ var/global/jungle_plants_init = 0
 /obj/structure/jungle_plant
 	icon = 'icons/jungle.dmi'
 	icon_state = "plant1"
-	desc = "Looks like some of that fruit might be edible."
+	desc = "A strange jungle plant. Looks like some of that fruit might be edible."
 	anchored = TRUE
-	var/fruits_left = 3
-	var/fruit_type = -1
+	var/fruits_left
+	var/fruit_type
 	var/icon/fruit_overlay
 //	var/plant_strength = 1
 	var/fruit_r
@@ -141,21 +135,26 @@ var/global/jungle_plants_init = 0
 	var/fruit_b
 
 
-/obj/structure/jungle_plant/New()
-	if(!jungle_plants_init)
-		init_jungle_plants()
-
+/obj/structure/jungle_plant/Initialize()
+	. = ..()
+	pixel_x = rand(-6,6)
+	pixel_y = rand(-6,6)
 	fruit_type = rand(1,7)
-	icon_state = "plant[fruit_type]"
 	fruits_left = rand(1,5)
-	fruit_overlay = icon('icons/jungle.dmi',"fruit[fruits_left]")
-	fruit_r = 255 - fruit_type * 36
-	fruit_g = rand(1,255)
-	fruit_b = fruit_type * 36
-	fruit_overlay.Blend(rgb(fruit_r, fruit_g, fruit_b), ICON_ADD)
-	AddOverlays(fruit_overlay)
+	queue_icon_update()
+
 //	plant_strength = rand(20,200)
-	..()
+
+/obj/structure/jungle_plant/on_update_icon()
+	. = ..()
+	if(fruit_type && !fruit_overlay)
+		icon_state = "plant[fruit_type]"
+		fruit_overlay = icon('icons/jungle.dmi',"fruit[fruits_left]")
+		fruit_r = 255 - fruit_type * 36
+		fruit_g = rand(1,255)
+		fruit_b = fruit_type * 36
+		fruit_overlay.Blend(rgb(fruit_r, fruit_g, fruit_b), ICON_ADD)
+		AddOverlays(fruit_overlay)
 
 /obj/structure/jungle_plant/attack_hand(mob/user as mob)
 	if(fruits_left > 0)
@@ -201,16 +200,9 @@ var/global/jungle_plants_init = 0
 	icon_state = "reedbush_1"
 	anchored = TRUE
 
-/obj/structure/flora/reeds/New()
-	if(prob(25))
-		icon_state = "reedbush_1"
-	if(prob(25))
-		icon_state = "reedbush_2"
-	if(prob(25))
-		icon_state = "reedbush_3"
-	if(prob(25))
-		icon_state = "reedbush_4"
-	..()
+/obj/structure/flora/reeds/Initialize()
+	icon_state = "reedbush_[rand(1,4)]"
+	. = ..()
 
 /obj/structure/flora/reeds/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(istype(I, /obj/item/material/hatchet) || istype(I, /obj/item/material/sword/machete) || istype(I, /obj/item/carpentry/axe))
@@ -232,6 +224,6 @@ var/global/jungle_plants_init = 0
 	desc = "Some dry, virtually dead grass."
 	icon_state = "tall_grass_1"
 
-/obj/structure/flora/grass/arid/New()
-	..()
+/obj/structure/flora/grass/arid/Initialize()
+	. = ..()
 	icon_state = "tall_grass_[rand(1,8)]"

--- a/code/modules/urist/modules/jungle/planet_turfs.dm
+++ b/code/modules/urist/modules/jungle/planet_turfs.dm
@@ -21,13 +21,15 @@
 	var/small_tree_type = /obj/structure/flora/tree/planet/jungle/small
 	var/large_tree_type = /obj/structure/flora/tree/planet/jungle/large
 
-	var/spawn_scrap = 0
+	var/spawn_scrap = FALSE //do we spawn scrap piles at random
 
 	var/planet_light = TRUE //do we use the fancy planet lighting
 
 	var/generate_things = TRUE //do we generate things at all
+
+	//these two vars are used for init processes, don't touch them
 	var/list/spawn_list = list()
-	var/plant_overlay = FALSE //do we have an overlay for plants
+	var/plant_overlay = FALSE
 
 /turf/simulated/floor/planet/update_air_properties() //No, you can't flood the jungle with phoron silly.
 	return
@@ -78,8 +80,6 @@
 		AddOverlays(I)
 
 /turf/simulated/floor/planet/proc/generate_planet_objects()
-//	set waitfor = FALSE
-
 	var/bushes = FALSE
 	var/tree = FALSE
 
@@ -207,11 +207,6 @@
 		/mob/living/simple_animal/hostile/retaliate/parrot/jungle,
 		/mob/living/simple_animal/huntable/monkey
 	)
-
-
-
-///turf/simulated/floor/planet/jungle/get_footstep_sound()
-//	return safepick(footstep_sounds[FOOTSTEP_GRASS])
 
 /turf/simulated/floor/planet/jungle/med
 	large_trees_chance = 1

--- a/code/modules/urist/modules/jungle/planetoid.dm
+++ b/code/modules/urist/modules/jungle/planetoid.dm
@@ -1,7 +1,7 @@
 /obj/overmap/visitable/sector/planetoid
 	name = "a generic planetoid"
 	is_planet = TRUE
-	sector_flags = FLAGS_OFF  // unknown, untargetable & non-starting-loc - it's a planet(oid)
+	sector_flags = OVERMAP_SECTOR_KNOWN //planetoids are known, like exoplanets. still can't spacewalk to them though.
 
 	var/static_name = null // if we don't want to generate a name
 	var/atmo_color = COLOR_WHITE //do we have atmos, and if so, what color are the clouds

--- a/maps/away/stations/pirate/pirate_station.dm
+++ b/maps/away/stations/pirate/pirate_station.dm
@@ -35,11 +35,11 @@ var/global/const/access_away_pirate_station = "ACCESS_AWAY_PIRATE_STATION"
 	station_holder = /mob/living/simple_animal/hostile/overmapship/station_holder/pirate
 	total_ships = 2
 	remaining_ships = 4
-	layer = ABOVE_LIGHTING_LAYER
-	plane = EFFECTS_ABOVE_LIGHTING_PLANE
+	sensor_visibility = 10
 	hidden = TRUE
+	sector_flags = FLAGS_OFF
 	spawn_ships = TRUE
-	spawn_types = list(/mob/living/simple_animal/hostile/overmapship/pirate/small, /mob/living/simple_animal/hostile/overmapship/pirate/med, /mob/living/simple_animal/hostile/overmapship/pirate/gantry)
+	spawn_types = list(/mob/living/simple_animal/hostile/overmapship/pirate/small, /mob/living/simple_animal/hostile/overmapship/pirate/gantry)
 	assigned_contracts = list(/datum/contract/shiphunt/pirate, /datum/contract/station_destroy/pirate)
 	initial_generic_waypoints = list(
 		"nav_piratestation_1",
@@ -102,6 +102,8 @@ var/global/const/access_away_pirate_station = "ACCESS_AWAY_PIRATE_STATION"
 		color = "#660000"
 		hidden = FALSE
 		make_known(TRUE)
+		layer = ABOVE_LIGHTING_LAYER
+		plane = EFFECTS_ABOVE_LIGHTING_PLANE
 
 //money values are very much in flux
 

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -24,7 +24,7 @@
 	icon_state = "meteor4"
 	hide_from_reports = TRUE
 	sensor_visibility = 10
-	color = "#a08444"
+	color = "#fc1100"
 	initial_generic_waypoints = list(
 		"nav_voxbase_1"
 	)


### PR DESCRIPTION
This saves fully 10-20 seconds on init times on Nerva, and probably has some gains on glloydstation too, although I haven't tested to see how significant it is there. 

I was wondering why init time was taking so long while testing something unrelated, and tracked down one of the major causes - the absolute unoptimized pile of dogshit that is planet code, parts of which haven't been touched in **11 years.** Some of that code is even older, from at least 2013. Suffice to say, it fucking sucks. It could probably use a full rewrite, but this still brings significant improvements with zero changes in functionality.

Main points:
Initialize() for planet turfs has been totally reworked - no longer do we have an insane chain of if(prob) checks, things are slightly more organized and sane, and we also don't run down that whole chain if we're not even generating anything. Now, that's handled by the generate_planet_things() proc, which handles most of what Initialize() used to handle, and returns a lateInitialize hint, allowing a ton of turfs to init way quicker than before because they're not checking a million things on init. Importantly, for the turfs that do spawn things, all the actual spawning of things has been moved to LateInitialize - all of the things to be spawned are added to a list on init, which is then spawned in during LateInitialize using create_objects_in_loc(), which is a much smoother way of handling spawning potentially multiple atoms at once. Possibly more importantly, instead of being dealt with in Initialize(), expensive icon ops are queued to be handled by the icon update subsystem on planet turfs, and on the jungle plants, which have also had some of their init stuff reworked.

This also purges a bunch of old, unused, or otherwise dogshit code that is not needed, and in doing so, actually adds proper footstep sounds for planet turfs (or readds? I think we had that at some point for the jungle at least but who the fuck knows with this mess)

Death to me 11 years ago

This PR also fixes a couple unrelated issues that popped up as I was testing this:
Skyboxes were just broken - bad merge.
Pirate station and voxship appearances were slightly obvious.
I also removed medium pirate ships from spawning pending some changes to spawning code.