### PR TITLE
Removes Pun Pun from the Bar + Tiny Nerva Fixes.

### DIFF
--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -18313,6 +18313,10 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/command/aiupload)
+"Gm" = (
+/obj/structure/lattice,
+/turf/simulated/floor/plating,
+/area/space)
 "Gn" = (
 /obj/machinery/suit_cycler/science,
 /obj/machinery/camera/network/research{
@@ -22102,6 +22106,11 @@
 /turf/simulated/floor/tiled/white,
 /area/command/seniorntoffice)
 "RP" = (
+/obj/structure/sign/monkey_painting{
+	pixel_y = -32;
+	name = "\improper Pun Pun portrait";
+	desc = "Under the painting a plaque reads: "Sleep well, Pun Pun. You valiantly tore up the bar every shift until you tragically fell into disposals for the last time.'"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
 "RQ" = (
@@ -41251,7 +41260,7 @@ af
 ZW
 TC
 af
-tf
+Gm
 ap
 Ps
 ap
@@ -41453,7 +41462,7 @@ af
 wH
 XY
 SJ
-tf
+Gm
 ap
 YL
 ap

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -14550,9 +14550,6 @@
 	codes = list("patrol" = 1, "next_patrol" = "Bridge Starboard");
 	location = "Bar"
 	},
-/mob/living/carbon/human/monkey/punpun{
-	real_name = "Pun Pun"
-	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
 "azx" = (
@@ -19387,13 +19384,11 @@
 /turf/simulated/floor/wood/walnut,
 /area/rnd/office)
 "aHN" = (
-/obj/machinery/computer/modular/preset/nervasci{
-	icon_state = "console"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
 	pixel_y = 28
 	},
+/obj/machinery/computer/modular/preset/nervasci,
 /turf/simulated/floor/wood/walnut,
 /area/rnd/office)
 "aHO" = (
@@ -23637,7 +23632,6 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/floor_decal/borderfloor/corner,
 /turf/simulated/floor/carpet,
 /area/rnd/dorms)
 "aOS" = (


### PR DESCRIPTION
**Fixes & Additions:**

- Removes Pun Pun from the bar... he was too good at being a shitter.
- Adds a plaque to Pun Pun in the Kitchen Freezer, god speed little man.
- Removes rogue floor tile decal under Research Locker Bed.
- Removes Broken Map Icon for Nerva Sci Computer.
- Medbay Toilet Maintenance now has plating under the grilles, making it a viable way to sneak in.