### PR TITLE
Updates Random Loot Spawners - (Contraband & Ammunition)

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -269,7 +269,8 @@
 				/obj/item/storage/toolbox/ancienttoolbox = 1,
 				/obj/item/rig_module/fabricator/energy_net = 1,
 				/obj/item/storage/box/syndie_kit/jetfuel = 2,
-				/obj/item/gun/launcher/syringe/disguised = 1 // rare enough
+				/obj/item/gun/launcher/syringe/disguised = 1, // rare enough
+				/obj/item/silencer = 2
 				)
 
 /obj/random/drinkbottle

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -270,8 +270,7 @@
 				/obj/item/rig_module/fabricator/energy_net = 1,
 				/obj/item/storage/box/syndie_kit/jetfuel = 2,
 				/obj/item/gun/launcher/syringe/disguised = 1, // rare enough
-				/obj/item/silencer = 2
-				)
+				/obj/item/silencer = 2)
 
 /obj/random/drinkbottle
 	name = "random drink"
@@ -382,8 +381,7 @@
 				/obj/item/ammo_magazine/speedloader/broomstick = 2,
 				/obj/item/ammo_magazine/speedloader/clip = 1,
 				/obj/item/ammo_magazine/rifle/military/stripper = 1,
-				/obj/item/ammo_magazine/speedloader = 2,
-				)
+				/obj/item/ammo_magazine/speedloader = 2)
 
 /obj/random/action_figure
 	name = "random action figure"

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -264,7 +264,13 @@
 				/obj/item/reagent_containers/food/snacks/egg/lizard = 3,
 				/obj/item/reagent_containers/glass/bottle/dye/polychromic/strong = 1,
 				/obj/item/storage/backpack/satchel/syndie_kit/clerical = 1,
-				/obj/item/clothing/shoes/laceup/sneakies = 1)
+				/obj/item/clothing/shoes/laceup/sneakies = 1,
+				/obj/item/clothing/mask/fakemoustache = 1,
+				/obj/item/storage/toolbox/ancienttoolbox = 1,
+				/obj/item/rig_module/fabricator/energy_net = 1,
+				/obj/item/storage/box/syndie_kit/jetfuel = 2,
+				/obj/item/gun/launcher/syringe/disguised = 1 // rare enough
+				)
 
 /obj/random/drinkbottle
 	name = "random drink"
@@ -367,8 +373,16 @@
 				/obj/item/ammo_magazine/pistol = 2,
 				/obj/item/ammo_magazine/pistol/flash = 4,
 				/obj/item/ammo_magazine/pistol/rubber = 4,
-				/obj/item/ammo_magazine/pistol = 2,
-				/obj/item/ammo_magazine/pistol/throwback = 1)
+				/obj/item/ammo_magazine/pistol/small = 2,
+				/obj/item/ammo_magazine/pistol/throwback = 1,
+				/obj/item/ammo_casing/shotgun/emp = 1, // singlular shell
+				/obj/item/ammo_magazine/speedloader/small = 2,
+				/obj/item/ammo_magazine/chemdart = 1,
+				/obj/item/ammo_magazine/speedloader/broomstick = 2,
+				/obj/item/ammo_magazine/speedloader/clip = 1,
+				/obj/item/ammo_magazine/rifle/military/stripper = 1,
+				/obj/item/ammo_magazine/speedloader = 2,
+				)
 
 /obj/random/action_figure
 	name = "random action figure"


### PR DESCRIPTION
Updates multiple loot tables of random spawners.

**Contraband Loot Spawners can also spawn the following:**

Fake Moustache - (1%)
Ancient Toolbox - (1%)
Rig Module - Energy Net - (1%)
Jet Fuel Vial - (2%)
Disguised Vape Syringe Gun - (1%)
Pistol Silencer - (2%)

**Ammunition Spawners can also spawn the following:**

Singular Haywire Shell - (1%)
9mm Holdout Speedloader - (2%)
Chem Dart - (1%)
9mm Broomstick Pistol Clip - (2%)
7.62mm Stripper Clip - (1%)
Hunting Rifle Stripper Clip - (1%)
10mm Speedloader - (2%)


Gives more contraband items that are semi harmless that crew can discover, or traitors can save TC by finding. 
Antagonists will benefit from potentially finding ammo they need by scouring maintenance at the start to save TC. Since crew cannot access most of these weapons the ammo won't be as useful to them.