### PR TITLE
fix byond caching/install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,26 @@ jobs:
           wget https://raw.githubusercontent.com/DiscordHooks/github-actions-discord-webhook/master/send.sh
           chmod +x send.sh
           ./send.sh failure $WEBHOOK_URL
+
+  InstallByond:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Setup Cache
+        id: setup-byond-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: ~/BYOND-${{ env.BYOND_MAJOR }}.${{ env.BYOND_MINOR }}
+          key: ${{ runner.os }}-byond-${{ env.BYOND_MAJOR }}-${{ env.BYOND_MINOR }}
+
+      - name: Install Byond
+        if: steps.setup-byond-cache.outputs.cache-hit != 'true'
+        run: ./install-byond.sh
+
   Code:
+    needs: InstallByond
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -82,7 +101,7 @@ jobs:
           ./send.sh failure $WEBHOOK_URL
   Maps:
     runs-on: ubuntu-22.04
-    needs: DreamChecker
+    needs: [DreamChecker, InstallByond]
     strategy:
       matrix:
         map_path: [example, nerva, glloydstation]
@@ -112,7 +131,7 @@ jobs:
           ./send.sh failure $WEBHOOK_URL
   AwayMaps:
     runs-on: ubuntu-22.04
-    needs: DreamChecker
+    needs: [DreamChecker, InstallByond]
     strategy:
       fail-fast: false
     steps:
@@ -143,7 +162,7 @@ jobs:
           ./send.sh failure $WEBHOOK_URL
   Templates:
     runs-on: ubuntu-22.04
-    needs: DreamChecker
+    needs: [DreamChecker, InstallByond]
     strategy:
       fail-fast: false
     steps:

--- a/install-byond.sh
+++ b/install-byond.sh
@@ -8,7 +8,7 @@ else
   mkdir -p ~/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
   cd ~/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
   echo "Installing DreamMaker to $PWD"
-  wget -O byond.zip "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip"
+  wget --user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36" -O byond.zip "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip"
   unzip -o byond.zip
   cd byond
   make here

--- a/install-byond.sh
+++ b/install-byond.sh
@@ -8,7 +8,7 @@ else
   mkdir -p ~/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
   cd ~/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
   echo "Installing DreamMaker to $PWD"
-  curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -o byond.zip
+  wget -O byond.zip "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip"
   unzip -o byond.zip
   cd byond
   make here


### PR DESCRIPTION
Downloading Byond when there is no cache is causing 429 - Too Many Requests, as each test tries to download the installer simultaneously. Adds a new Job to download and cache Byond first, so that subsequent jobs can just use the cache instead and only result in a single download