### PR TITLE
Advanced Surgical Toolset (CBM) & Covert Engineering Toolset (CBM) to Uplink

### DIFF
--- a/code/datums/uplink/augments.dm
+++ b/code/datums/uplink/augments.dm
@@ -49,3 +49,18 @@
 	It is unconcealable from body-scanners, and easily detectable due to it's weight. It requires NON-ORGANIC arms."
 	item_cost = 60
 	path = /obj/item/device/augment_implanter/powerfist
+
+/datum/uplink_item/item/augment/aug_engineerig_toolset
+	name = "Covert Engineering Toolset CBM (hand)"
+	desc = "A covert CBM augmentation allowing you to configure your hand into multiple common tools, perfect for breaking and entry or for the a clean prison break. \
+	It is detectable in body-scanners, however remains undetectable to close inspection. It can be installed in both ORGANIC or SYNTHETIC hands."
+	item_cost = 28
+	path = /obj/item/device/augment_implanter/engineering_toolset_syndicate
+
+/datum/uplink_item/item/augment/aug_surgical_toolset
+	name = "Advanced Surgical Toolset CBM (hand)"
+	desc = "A highly advanced surgical CBM toolset that allows it's user to access an entire surgical suite of tools, capable of treating the most grevious of wounds. It additionally comes with a robot component scanner. \
+	It is unconceable in both body-scanner and manual inspection. Can be installed on both ORGANIC or SYNTHETIC hands."
+	item_cost = 48 // Bone Gel, FixoVein, Bruise Packs for Organs & Robotic Component Scanner.
+	path = /obj/item/device/augment_implanter/surgical_toolset_syndicate
+	antag_roles = list(MODE_MERCENARY)

--- a/code/modules/urist/antagonist/uplink_items.dm
+++ b/code/modules/urist/antagonist/uplink_items.dm
@@ -28,3 +28,39 @@
 	var/namepick = pick("Urist's", "Koganusan", "Armok's", "Urist McDwarf's")
 	var/typepick = pick("Moonshine", "Craftdwarf Homebrew", "Vile Force of Distillery", "Forgotten Brew")
 	name = "[namepick] [typepick]"
+
+// Augments
+
+/obj/item/organ/internal/augment/active/polytool/surgical/syndicate // An upgraded surgical toolset capable of Organic + Synthetic repairs.
+	name = "advanced surgical toolset"
+	action_button_name = "Deploy Surgical Tool"
+	desc = "A highly advanced surgical toolset common among frontline medics, this device contains an entire surgical suite of tools for organic and synthetic repair."
+	icon_state = "multitool_medical"
+	augment_flags = AUGMENT_MECHANICAL | AUGMENT_BIOLOGICAL | AUGMENT_INSPECTABLE | AUGMENT_SCANNABLE
+	paths = list(
+		/obj/item/bonesetter,
+		/obj/item/cautery,
+		/obj/item/circular_saw,
+		/obj/item/hemostat,
+		/obj/item/retractor,
+		/obj/item/scalpel/laser,
+		/obj/item/surgicaldrill,
+		/obj/item/bonegel,
+		/obj/item/FixOVein,
+		/obj/item/device/robotanalyzer,
+		/obj/item/stack/medical/advanced/bruise_pack
+	// No Nanopaste, but otherwise it's a pretty good deal.
+	)
+
+/obj/item/organ/internal/augment/active/polytool/engineer/syndicate
+	name = "covert engineering toolset"
+	desc = "A lightweight augmentation for the engineer on-the-go, designed with covert operations in mind this is compatible with both synthetic and organ limbs."
+	augment_flags = AUGMENT_MECHANICAL | AUGMENT_BIOLOGICAL | AUGMENT_SCANNABLE
+
+// CBMs
+
+/obj/item/device/augment_implanter/engineering_toolset_syndicate
+	augment = /obj/item/organ/internal/augment/active/polytool/engineer/syndicate
+
+/obj/item/device/augment_implanter/surgical_toolset_syndicate
+	augment = /obj/item/organ/internal/augment/active/polytool/surgical/syndicate


### PR DESCRIPTION
### Features:
Two Additional CBMs on the Uplink.

#### Adds the Covert Engineering Toolset - (CBM) - (Hand)
**Cost: 28 TC.**

- A Engineering Toolset capable of being bought on the Uplink.
- Detectable via Body-Scanners, but cannot be detected via manual inspection of limbs.
- Useful for loud antagonists who may want to carry a belt of ammo, meds or something else.
- Compatible with both Synthetic & Organic limbs (unlike the original), making it an alternative to doing R&D and breaking into Robotics.

#### Adds the Advanced Surgical Toolset - (CBM) - (Hand)
**Cost: 48TC**
**Mercenary Purchase Only.**

- An advanced surgical toolset, capable of being bought on the Uplink.
- Additional Equipment: Bone Gel, FixoVein, Bruise Packs, Laser Scalpel instead of Basic.
- Direct upgrade to the original surgical toolset augment, capable of treating more grevious injuries & organ issues.
- Can be installed on both Synthetic & Organic limbs - (unlike the original).
- Adds a robot component scanner for use of Synthetic Mercs/Crew.
- More expensive than buying a surgical kit from the Uplink, but offers greater flexibility for a Mercenary Medic, as they can now carry additional gear, such as ammo, weaponry, or more medical supplies.

Not that we ever really have Merc, but still.
