### PR TITLE
Medical Smart Fridge can now store Autoinjectors

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -85,7 +85,8 @@
 		/obj/item/reagent_containers/glass,
 		/obj/item/storage/pill_bottle,
 		/obj/item/reagent_containers/pill,
-		/obj/item/reagent_containers/ivbag
+		/obj/item/reagent_containers/ivbag,
+		/obj/item/reagent_containers/hypospray
 	)
 
 /obj/machinery/smartfridge/secure/virology


### PR DESCRIPTION
Autoinjectors can now be stored in the medical fridges.
This also technically lets the hypospray be stored in it.