### PR TITLE
Disposal Chutes that autowrap no longer use a broken icon_state.

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -652,7 +652,7 @@
 		audible_message("No destination tag set")
 		return
 	var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(AM.loc))
-	P.icon_state = "deliverycrate"
+	P.icon_state = "parcelcrate"
 	P.wrapped = AM
 	AM.forceMove(P)
 	P.sortTag = src.currTag


### PR DESCRIPTION
Wrapped delivery chutes now use icon_state = "parcelcrate" as the previous icon does not exist anymore.
Prevents items from becoming a big red error once wrapped.