### PR TITLE
Reverts Baystation12 Changes to Smokables - (Starting Sealed)

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
+++ b/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
@@ -11,6 +11,7 @@
 	slot_flags = SLOT_BELT
 	key_type = list(/obj/item/clothing/mask/smokable/cigarette)
 	atom_flags = ATOM_FLAG_NO_REACT | ATOM_FLAG_OPEN_CONTAINER
+	sealed = FALSE // just so it isn't adding another click for basically no difference.
 
 	/// A map? of reagents to add to this container on initialization.
 	var/list/datum/reagent/initial_reagents


### PR DESCRIPTION
- Sets Sealed = False for smokables, i.e cigarette packs, other /storage/fancy are unaffected by this change.
- Bay changed it so you need to unseal cigarette packs before you can smoke them, it's an extra click and activation prompt for something in my own view doesn't need it, one click is nice and quick and is the same on most codebases.