### PR TITLE
Removes Examine from Wire Panel View

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -113,8 +113,8 @@ var/global/list/wireColours = list("red", "blue", "green", "darkred", "orange", 
 		html += "<A href='byond://?src=\ref[src];action=1;cut=[colour]'>[IsColourCut(colour) ? "Mend" :  "Cut"]</A>"
 		html += " <A href='byond://?src=\ref[src];action=1;pulse=[colour]'>Pulse</A>"
 		html += " <A href='byond://?src=\ref[src];action=1;attach=[colour]'>[IsAttached(colour) ? "Detach" : "Attach"] Signaller</A>"
-		var/label = "Examine"
-		html += " <A href='byond://?src=\ref[src];action=1;examine=[colour]'>[label]</A></td></tr>"
+//		var/label = "Examine"
+//		html += " <A href='byond://?src=\ref[src];action=1;examine=[colour]'>[label]</A></td></tr>"
 	html += "</table>"
 	html += "</div>"
 


### PR DESCRIPTION
- Just comments out the code for showing the Examine button on wires, as it did nothing at all if you clicked it, since we have skills disabled.
- Now the Wire Panel is back to how it used to be, yay