### PR TITLE
Ports Client Screen Recoil from Upstream.

### DIFF
--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -62,6 +62,11 @@
 /// The cotangent of degrees
 #define Cot(degrees) (1 / tan(degrees))
 
+#define MODULUS_FLOAT(X, Y) ( (X) - (Y) * round((X) / (Y)) )
+
+// Will filter out extra rotations and negative rotations
+// E.g: 540 becomes 180. -180 becomes 180.
+#define SIMPLIFY_DEGREES(degrees) (MODULUS_FLOAT((degrees), 360))
 
 /// The 2-argument arctangent of x and y
 /proc/Atan2(x, y)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -331,6 +331,17 @@ var/global/list/organ_rel_size = list(
 		M.client.eye=oldeye
 		M.shakecamera = 0
 
+/proc/recoil_camera(mob/camera_mob, duration = 1, angle = 180, strength = 1, easing = CUBIC_EASING|EASE_OUT)
+	if(!camera_mob?.client || duration < 1 || !easing)
+		return
+	var/client/camera_client = camera_mob.client
+
+	angle = clamp(angle, 0, 360)
+	var/hypotenuse = strength*world.icon_size
+	var/offset_y = round(hypotenuse*sin(angle), 0.1)
+	var/offset_x = round(hypotenuse*-cos(angle), 0.1)
+	animate(camera_client, pixel_x = offset_x, pixel_y = offset_y, time = duration, easing = easing, flags = ANIMATION_RELATIVE)
+	animate(pixel_x = -offset_x, pixel_y = -offset_y, time = duration, easing = easing, flags = ANIMATION_RELATIVE)
 
 /mob/proc/abiotic(full_body = FALSE)
 	var/holding_simulated_item = FALSE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -76,6 +76,14 @@
 	var/fire_anim = null
 	/// The amount your screen shakes when firing. Shouldn't be greater than 2 unless zoomed.
 	var/screen_shake = 0
+		/**
+	 * If this gun has client recoil, this stores info such as amount and duration.
+	 *
+	 * - "strength": How far to move the screen
+	 * - "duration": The length of the animation
+	 * - "easing": special type of easing to be used, can be null
+	 */
+	var/list/client_recoil_animation_information = null
 	/// Whether or not this weapon moves the shooter backwards when fired in space.
 	var/space_recoil = 0
 	var/silenced = FALSE
@@ -375,6 +383,20 @@
 		if(screen_shake)
 			spawn()
 				shake_camera(user, screen_shake+1, screen_shake)
+
+		if(LAZYLEN(client_recoil_animation_information))
+			var/skill_modifier = user.get_skill_value(SKILL_WEAPONS) * 0.1
+			var/duration = client_recoil_animation_information["duration"]
+			if (isnull(duration))
+				duration = 1
+			duration = max(duration - skill_modifier, 1)
+			var/strength = client_recoil_animation_information["strength"]
+			if (isnull(strength))
+				strength = 0.5
+			strength = max(strength - skill_modifier, 0.1)
+			var/easing = client_recoil_animation_information["easing"] || CUBIC_EASING|EASE_OUT
+			var/recoil_angle = SIMPLIFY_DEGREES(Get_Angle(target, user) + 90)
+			recoil_camera(user, duration, recoil_angle, strength, easing)
 
 	if(combustion)
 		var/turf/curloc = get_turf(src)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -6,7 +6,10 @@
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	w_class = ITEM_SIZE_NORMAL
 	matter = list(MATERIAL_STEEL = 1000)
-	screen_shake = 1
+	client_recoil_animation_information = list(
+		"strength" = 0.35,
+		"duration" = 2,
+	)
 	space_recoil = 1
 	combustion = 1
 	can_dual_wield = 1			//pistol dual wielding


### PR DESCRIPTION
It's an open PR but it seems more or less done, this is just a port of the screen recoil system.
screen_shake did not look nice, so I'm glad we have a new system now.

This has dependancies on another PR, which I'll PR soon which will have individually set the values for guns. Currently all guns use the default parent value.


https://github.com/user-attachments/assets/5dc94b94-b4cf-48a6-8951-6d550f969b1e

This is the basic default value per the Upstream PR, we can adjust the strength, duration and easing to make this a lot worst for big powerful guns.