### PR TITLE
Adds debug versions of Floor Lights. (Updates Example)

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3491,6 +3491,7 @@
 #include "code\modules\urist\kingrescues\smithing.dm"
 #include "code\modules\urist\loadout\loadout_uniform_urist.dm"
 #include "code\modules\urist\machinery\atmos.dm"
+#include "code\modules\urist\machinery\floor_lights.dm"
 #include "code\modules\urist\machinery\misc.dm"
 #include "code\modules\urist\machinery\monkey_recycler.dm"
 #include "code\modules\urist\machinery\party.dm"

--- a/code/modules/urist/machinery/floor_lights.dm
+++ b/code/modules/urist/machinery/floor_lights.dm
@@ -1,0 +1,24 @@
+/obj/machinery/floor_light/developer // Developer/Example Map Usage.
+	name = "enhanced floor light"
+	icon = 'icons/obj/machines/floor_light.dmi'
+	icon_state = "base"
+	desc = "A backlit floor panel with an enhanced lighting panel, for when you REALLY want to see things."
+	layer = ABOVE_TILE_LAYER
+	anchored = FALSE
+	use_power = POWER_USE_OFF
+	idle_power_usage = 0
+	active_power_usage = 0
+	power_channel = LIGHT
+	health_max = 5
+	damage_hitsound = 'sound/effects/Glasshit.ogg'
+	default_light_power = 1
+	default_light_range = 20
+	default_light_colour = "#ffffff"
+
+/obj/machinery/floor_light/developer/mapped_off
+	anchored = TRUE
+	use_power = POWER_USE_OFF
+
+/obj/machinery/floor_light/developer/mapped_on
+	anchored = TRUE
+	use_power = POWER_USE_ACTIVE

--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -134,7 +134,7 @@
 /area/constructionsite)
 "qo" = (
 /obj/landmark/start,
-/obj/machinery/floor_light/mapped_on,
+/obj/machinery/floor_light/developer/mapped_on,
 /turf/simulated/floor/tiled,
 /area/constructionsite)
 "rt" = (

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -435,7 +435,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "JO" = (
-/obj/machinery/floor_light/mapped_on,
+/obj/machinery/floor_light/developer/mapped_on,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "KN" = (

--- a/maps/example/example-3.dmm
+++ b/maps/example/example-3.dmm
@@ -176,7 +176,7 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/fsmaint2)
 "T" = (
-/obj/machinery/floor_light/mapped_on,
+/obj/machinery/floor_light/developer/mapped_on,
 /turf/simulated/floor/tiled,
 /area/maintenance/fsmaint2)
 


### PR DESCRIPTION
Adds floor_light/developer.
These have much higher power, and aren't intended to be used outside of testing in example, etc.

Can be mapped on and off.