### PR TITLE
Welding Tank Packs are less OSHA compliant

### DIFF
--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -33,7 +33,7 @@
 					SPAN_DANGER("You hold \the [T] up to \the [src], causing an explosion!")
 				)
 				log_and_message_admins("triggered a fueltank explosion.", user)
-				explosion(get_turf(src), 9, EX_ACT_HEAVY)
+				explosion(get_turf(src), 7, EX_ACT_HEAVY)
 				if (!QDELETED(src))
 					qdel(src)
 				return TRUE

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -33,7 +33,7 @@
 					SPAN_DANGER("You hold \the [T] up to \the [src], causing an explosion!")
 				)
 				log_and_message_admins("triggered a fueltank explosion.", user)
-				explosion(get_turf(src), 4, EX_ACT_HEAVY)
+				explosion(get_turf(src), 9, EX_ACT_HEAVY)
 				if (!QDELETED(src))
 					qdel(src)
 				return TRUE


### PR DESCRIPTION
- Welding Tool Backpacks do significantly more damage to the nearby surroundings
- These don't spawn on the Nerva anyways, and the current explosion they make is pitiful at best
- Makes them peak industrial accident.

**Old:**
<img width="1301" height="1306" alt="image" src="https://github.com/user-attachments/assets/34e62fa3-f7d0-408b-896f-cbdbdccf3154" />

**New:**
<img width="1374" height="1304" alt="image" src="https://github.com/user-attachments/assets/d5df4161-f894-40ff-822d-0a9f3e78e0ab" />

