### PR TITLE
Adds Firearm Attachment Uplink Catergory, URIST_CODE new name for silencers, etc.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -526,6 +526,7 @@
 #include "code\datums\underwear\undershirt.dm"
 #include "code\datums\underwear\underwear.dm"
 #include "code\datums\uplink\ammunition.dm"
+#include "code\datums\uplink\attachments.dm"
 #include "code\datums\uplink\augments.dm"
 #include "code\datums\uplink\badassery.dm"
 #include "code\datums\uplink\devices and tools.dm"

--- a/code/datums/uplink/attachments.dm
+++ b/code/datums/uplink/attachments.dm
@@ -1,0 +1,10 @@
+// Firearm and Melee Weaponry Attachments - Urist
+
+/datum/uplink_item/item/attachment
+	category = /datum/uplink_category/attachment
+
+/datum/uplink_item/item/attachment/universal_suppressor
+	name = "Universal Suppressor - Attachment"
+	desc = "A universal suppressor, designed to attach to the threaded barrel of a firearm to give a significant reduction in sound profile."
+	item_cost = 12
+	path = /obj/item/silencer

--- a/code/datums/uplink/uplink_categories.dm
+++ b/code/datums/uplink/uplink_categories.dm
@@ -15,6 +15,9 @@
 /datum/uplink_category/ammunition
 	name = "Ammunition"
 
+/datum/uplink_category/attachment
+	name = "Weapon Attachments"
+
 /datum/uplink_category/grenades
 	name = "Grenades"
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -243,8 +243,13 @@
 	magazine_type = /obj/item/ammo_magazine/pistol/flash
 
 /obj/item/silencer
+	#ifdef INCLUDE_URIST_CODE
+	name = "universal suppressor" // Rename for Urist.
+	desc = "A universal suppressor that can be attached to any weapon with a threaded barrel."
+	#else
 	name = "silencer"
 	desc = "A silencer."
+	#endif
 	icon = 'icons/obj/guns/holdout_pistol.dmi'
 	icon_state = "silencer"
 	w_class = ITEM_SIZE_SMALL


### PR DESCRIPTION
- Adds a Firearm Attachment catergory to the Traitor Uplink, currently just housing the Universal Suppressor, but I'd like to add more items eventually to this, especially in non-universal attachments for specific gear.

- Sets up a URIST_CODE for silencers, making them be renamed and changing the desc from silencers to suppressors.