### PR TITLE
Uplink Ammo name & descriptions are more specific and helpful.

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -36,19 +36,19 @@
 
 /datum/uplink_item/item/ammo/rifle
 	name = "Assault Rifle Magazine (7.62mm)"
-	desc = "A 7.62mm magazine designed primairly used for the STS-35, whilst also fitting the SD-Panther & L6 Saw. Contains 20 rounds."
+	desc = "A 7.62mm magazine used for the STS-35, whilst also fitting the SD-Panther & L6 Saw. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/rifle
 
 /datum/uplink_item/item/ammo/bullpup
 	name = "Bullpup Rifle Magazine (5.56mm)"
-	desc = "A 5.56mm magazine designed to fit the Z8 Bulldog & variants, as well as the Battle Rifle. Contains 15 rounds."
+	desc = "A 5.56mm magazine designed to fit the Z8 Bulldog & variants, as well as the Battle Rifle. Contains 18 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/mil_rifle
 
 /datum/uplink_item/item/ammo/bullpup/heavy // is there actually a difference between these??
 	name = "Heavy Bullpup Rifle Magazine (5.56mm)"
-	desc = "A 5.56mm magazine designed to fit the Z8 Bulldog & variants, as well as the Battle Rifle. Contains 15 rounds."
+	desc = "A 5.56mm magazine designed to fit the Z8 Bulldog & variants, as well as the Battle Rifle. Contains 18 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/mil_rifle/heavy
 

--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -35,20 +35,20 @@
 	path = /obj/item/ammo_magazine/speedloader
 
 /datum/uplink_item/item/ammo/rifle
-	name = "Rifle Magazine (7.62mm)"
-	desc = "A magazine for assault rifles that use 7.62mm. Contains 20 rounds."
+	name = "Assault Rifle Magazine (7.62mm)"
+	desc = "A 7.62mm magazine designed primairly used for the STS-35, whilst also fitting the SD-Panther & L6 Saw. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/rifle
 
-/datum/uplink_item/item/ammo/bullpup //for zipguns
+/datum/uplink_item/item/ammo/bullpup
 	name = "Bullpup Rifle Magazine (5.56mm)"
-	desc = "A magazine for bullpup assault rifles using 5.56mm. Contains 15 rounds."
+	desc = "A 5.56mm magazine designed to fit the Z8 Bulldog & variants, as well as the Battle Rifle. Contains 15 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/mil_rifle
 
-/datum/uplink_item/item/ammo/bullpup
-	name = "Heavy Bullpup Rifle Magazine"
-	desc = "A 7mmR magazine for heavy bullpup assault rifles like the Z8 Bulldog. Contains 15 rounds."
+/datum/uplink_item/item/ammo/bullpup/heavy // is there actually a difference between these??
+	name = "Heavy Bullpup Rifle Magazine (5.56mm)"
+	desc = "A 5.56mm magazine designed to fit the Z8 Bulldog & variants, as well as the Battle Rifle. Contains 15 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/mil_rifle/heavy
 
@@ -86,14 +86,14 @@
 	path = /obj/item/storage/box/ammo/shotgunammo
 
 /datum/uplink_item/item/ammo/machine_pistol
-	name = "Machine Pistol Stick Magazine (10mm)"
-	desc = "A magazine for standard 10mm machine pistols. Contains 16 rounds."
+	name = "MP6 Vesper Stick Magazine (10mm)"
+	desc = "A stick magazine for the MP6 Vesper 10mm machine pistol. Contains 16 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/machine_pistol
 
 /datum/uplink_item/item/ammo/smg
-	name = "SMG Box Magazine (10mm)"
-	desc = "A magazine for 10mm SMGs. Contains 20 rounds."
+	name = "C20r SMG Magazine (10mm)"
+	desc = "A box magazine for 10mm C20r SMGs. Contains 20 rounds."
 	item_cost = 8
 	path = /obj/item/ammo_magazine/smg
 	antag_roles = list(MODE_MERCENARY)
@@ -143,30 +143,30 @@
 
 /datum/uplink_item/item/ammo/stripperclip
 	name = "Stripper Clip (7.62mm)"
-	desc = "A stripper clip used to load bolt action rifles chambered in 7.62mm. Contains just 5 rounds."
+	desc = "A stripper clip used to load bolt action rifles chambered in 7.62mm. Contains 5 rounds."
 	item_cost = 2
 	path = /obj/item/ammo_magazine/speedloader/clip
 
 /datum/uplink_item/item/ammo/shotgun_drum_buckshot
-	name = "Shotgun Drum Magazine"
+	name = "Shotgun Drum Magazine (12g)"
 	desc = "A drum magazine that can hold fifteen 12g shotgun shells. Loaded with buckshot."
 	item_cost = 12
 	path = /obj/item/ammo_magazine/shotgunmag/shot
 
 /datum/uplink_item/item/ammo/shotgun_drum_slugs
-	name = "Shotgun Slug Drum Magazine"
+	name = "Shotgun Slug Drum Magazine (12g)"
 	desc = "A drum magazine that can hold fifteen 12g shotgun shells. Loaded with slugs."
 	item_cost = 12
 	path = /obj/item/ammo_magazine/shotgunmag
 
 /datum/uplink_item/item/ammo/shotgun_drum_flechette
-	name = "Shotgun Flechette Drum Magazine"
+	name = "Shotgun Flechette Drum Magazine (12g)"
 	desc = "A drum magazine that can hold fifteen 12g shotgun shells. Loaded with flechettes."
 	item_cost = 12
 	path = /obj/item/ammo_magazine/shotgunmag/flechette
 
 /datum/uplink_item/item/ammo/stripperclip_broomstick
-	name = "Broomstick Stripper Clip (9mm)"
+	name = "Broomstick Pistol Stripper Clip (9mm)"
 	desc = "A pistol stripper clip used to load antique broomstick pistols chambered in 9mm. Contains 10 rounds."
 	item_cost = 6
 	path = /obj/item/ammo_magazine/speedloader/broomstick

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -187,7 +187,7 @@
 
 /obj/item/gun/projectile/automatic/z8
 	name = "bullpup assault rifle"
-	desc = "The Z8 Bulldog is an older model bullpup carbine, made by the now defunct Zendai Foundries. Uses armor piercing 7.62mm rounds. Makes you feel like a space marine when you hold it."
+	desc = "The Z8 Bulldog is an older model bullpup carbine, made by the now defunct Zendai Foundries. Uses armor piercing 5.56mm rounds. Makes you feel like a space marine when you hold it."
 	icon = 'icons/urist/items/z8carbine.dmi'
 	icon_state = "carbine"
 	item_state = "z8carbine"


### PR DESCRIPTION
**Rifle Magaine -> Assault Rifle Magazine**
- Mentions it's main weapon -  (STS-35)
- Mentions additional variants/users (SD-Panther, L6 Saw)
- Removes incorrect caliber

**Bullpup Rifle Magazine**

- Mentions it's main weapon & side weapons (Z8 Bulldog family & battle rifle
- Heavy Bullpup Ammo is purchasable again.

**Machine Pistol Ammo -> MP6 Vesper Stick Ammo**

- Mentions it's only user of said ammo.
- Makes it very clear what it's used on.

**SMG Box Ammo -> C20r SMG Magazine**

- Mentions it's singular user in both the name and description.
- Previously I thought it was that you could not buy ammo for the C20R, until I realized the name.

**Shotgun Drums**

- Adds (12g) in line with style.

**Stripper Clip**
- Gets rid of just, that's it.

**Broomstick Stripper Clip -> Broomstick Pistol Stripper Clip**
- Just makes it slightly clearer what it is.