### PR TITLE
Floating Messages (runechat) are now set to shown by default.

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -313,8 +313,8 @@ var/global/list/_client_preferences_by_type
 /datum/client_preference/floating_messages
 	description = "Floating chat messages"
 	key = "FLOATING_CHAT"
-	options = list(GLOB.PREF_HIDE, GLOB.PREF_SHOW)
-	default_value = GLOB.PREF_HIDE
+	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
+	default_value = GLOB.PREF_SHOW
 
 /datum/client_preference/scan_results_in_window
 	description = "Display scanner results in window"

--- a/maps/away/abandoned_colony/abandoned_colony.dmm
+++ b/maps/away/abandoned_colony/abandoned_colony.dmm
@@ -1774,11 +1774,6 @@
 /obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/wood/walnut,
 /area/planet/abandoned_colony)
-"fp" = (
-/turf/simulated/floor/wood/walnut{
-	icon_state = "walnut_broken0"
-	},
-/area/planet/abandoned_colony)
 "fq" = (
 /obj/machinery/light/colored{
 	icon_state = "yellow1";
@@ -1839,14 +1834,19 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/planet/abandoned_colony)
 "fA" = (
-/turf/simulated/floor/wood/walnut{
-	icon_state = "walnut_broken1"
+/obj/decal/cleanable/dirt,
+/obj/decal/cleanable/blood/drip,
+/turf/simulated/floor/fixed/uristturf/geminus{
+	icon_state = "square_grey";
+	color = "#cccccc"
 	},
 /area/planet/abandoned_colony)
 "fB" = (
-/turf/simulated/floor/wood/walnut{
-	icon_state = "walnut_broken4"
+/obj/machinery/door/airlock{
+	name = "Bar Backroom"
 	},
+/obj/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/dark,
 /area/planet/abandoned_colony)
 "fC" = (
 /obj/structure/table/woodentable/walnut,
@@ -1878,8 +1878,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/planet/abandoned_colony)
 "fG" = (
-/turf/simulated/floor/wood/walnut{
-	icon_state = "walnut_broken2"
+/obj/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/uristturf/geminus{
+	icon_state = "square_black"
 	},
 /area/planet/abandoned_colony)
 "fH" = (
@@ -1935,11 +1936,6 @@
 /area/planet/abandoned_colony)
 "fQ" = (
 /turf/simulated/floor/tiled/white,
-/area/planet/abandoned_colony)
-"fR" = (
-/turf/simulated/floor/wood/walnut{
-	icon_state = "walnut_broken6"
-	},
 /area/planet/abandoned_colony)
 "fS" = (
 /obj/structure/hygiene/toilet,
@@ -2163,9 +2159,7 @@
 	pixel_y = 32;
 	color = "#4c0000"
 	},
-/turf/simulated/floor/wood/walnut{
-	icon_state = "walnut_broken2"
-	},
+/turf/simulated/floor/wood/walnut,
 /area/planet/abandoned_colony)
 "gz" = (
 /obj/machinery/light/small/red{
@@ -2214,6 +2208,8 @@
 	name = "dirty syringe";
 	desc = "Probably has at least five incurable STDs."
 	},
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
 /turf/simulated/floor/tiled/dark,
 /area/planet/abandoned_colony)
 "gD" = (
@@ -2302,6 +2298,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/clothing/suit/surgicalapron,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
@@ -2369,15 +2366,15 @@
 /obj/item/reagent_containers/syringe/drugs,
 /obj/item/reagent_containers/syringe/drugs,
 /obj/item/reagent_containers/syringe/steroid,
-/obj/item/reagent_containers/syringe/steroid,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
 /area/planet/abandoned_colony)
 "ha" = (
 /obj/structure/table/standard,
-/obj/item/clothing/suit/surgicalapron,
-/obj/item/clothing/suit/surgicalapron,
+/obj/machinery/reagentgrinder,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
@@ -2387,10 +2384,7 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
+/obj/machinery/reagent_temperature,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
@@ -8103,6 +8097,7 @@
 /area/planet/abandoned_colony)
 "vf" = (
 /mob/living/simple_animal/hostile/scom/forgotten/awaymap,
+/obj/decal/cleanable/blood,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
@@ -8811,6 +8806,13 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/planet/abandoned_colony)
+"wW" = (
+/obj/machinery/door/airlock,
+/obj/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/uristturf/geminus{
+	icon_state = "square_black"
+	},
+/area/planet/abandoned_colony)
 "wY" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Hangar Bathrooms"
@@ -8968,6 +8970,13 @@
 	},
 /turf/simulated/floor/lino,
 /area/planet/abandoned_colony)
+"zP" = (
+/obj/item/clothing/mask/gas/half,
+/obj/item/reagent_containers/syringe/steroid,
+/turf/simulated/floor/tiled/uristturf/geminus{
+	icon_state = "square_black"
+	},
+/area/planet/abandoned_colony)
 "zV" = (
 /obj/structure/salvageable/machine,
 /turf/simulated/floor/tiled,
@@ -8975,6 +8984,14 @@
 "Aw" = (
 /obj/random/trash,
 /turf/simulated/floor/tiled/dark,
+/area/planet/abandoned_colony)
+"AE" = (
+/obj/item/clothing/suit/surgicalapron,
+/obj/item/clothing/mask/gas/half,
+/obj/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/uristturf/geminus{
+	icon_state = "square_black"
+	},
 /area/planet/abandoned_colony)
 "AH" = (
 /obj/structure/salvageable/machine,
@@ -9052,6 +9069,10 @@
 /obj/item/reagent_containers/food/snacks/canned/caviar,
 /turf/simulated/floor/carpet,
 /area/planet/abandoned_colony)
+"DY" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/planet/dirt/city,
+/area/planet/abandoned_colony)
 "EW" = (
 /obj/structure/salvageable/console_broken_os{
 	icon_state = "os_console_broken";
@@ -9085,6 +9106,14 @@
 /obj/random/junk,
 /turf/simulated/floor/fixed/destroyedroad{
 	icon_state = "horizontalinnermain1"
+	},
+/area/planet/abandoned_colony)
+"Hz" = (
+/obj/decal/cleanable/blood/drip,
+/obj/decal/cleanable/blood/drip,
+/obj/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/uristturf/geminus{
+	icon_state = "square_black"
 	},
 /area/planet/abandoned_colony)
 "HD" = (
@@ -9172,6 +9201,10 @@
 /obj/machinery/light/colored/green,
 /obj/random/clothing,
 /turf/simulated/floor/tiled/dark,
+/area/planet/abandoned_colony)
+"LM" = (
+/obj/machinery/seed_storage/garden,
+/turf/simulated/floor/tiled,
 /area/planet/abandoned_colony)
 "LV" = (
 /obj/machinery/light/street,
@@ -9313,6 +9346,13 @@
 	color = "#cccccc"
 	},
 /area/planet/abandoned_colony)
+"Ri" = (
+/obj/decal/cleanable/blood/drip,
+/obj/item/reagent_containers/syringe/steroid,
+/turf/simulated/floor/tiled/uristturf/geminus{
+	icon_state = "square_black"
+	},
+/area/planet/abandoned_colony)
 "Rt" = (
 /obj/random/junk,
 /turf/simulated/floor/pavement{
@@ -9383,6 +9423,10 @@
 /turf/simulated/floor/fixed/destroyedroad{
 	icon_state = "dottedhorizontalcorroded"
 	},
+/area/planet/abandoned_colony)
+"Ve" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/simulated/floor/tiled,
 /area/planet/abandoned_colony)
 "Vn" = (
 /obj/decal/cleanable/blood/drip,
@@ -9792,7 +9836,7 @@ jL
 jM
 jR
 ac
-rH
+Ve
 rH
 rH
 sY
@@ -9839,11 +9883,11 @@ dO
 fj
 eh
 eh
-fA
+eh
 eh
 eu
 fo
-fG
+eh
 fo
 ac
 fu
@@ -9894,7 +9938,7 @@ jQ
 dy
 hN
 ac
-rH
+LM
 kc
 rH
 jj
@@ -9939,7 +9983,7 @@ dD
 ac
 dP
 eh
-fp
+eh
 eh
 eh
 vJ
@@ -10044,7 +10088,7 @@ fk
 en
 eh
 eh
-fB
+eh
 eu
 fo
 eh
@@ -10149,7 +10193,7 @@ et
 eu
 eh
 eG
-fR
+eh
 eL
 ac
 ac
@@ -11478,7 +11522,7 @@ al
 eh
 gp
 ct
-fR
+eh
 hu
 ft
 ez
@@ -12001,7 +12045,7 @@ am
 gz
 ac
 gD
-el
+zP
 gZ
 ac
 el
@@ -12107,9 +12151,9 @@ vf
 ha
 ac
 el
-el
-cP
-am
+fG
+wW
+cv
 cm
 am
 am
@@ -12205,14 +12249,14 @@ am
 al
 ac
 gF
-el
+Ri
 hb
 ac
 ht
-el
+fG
 ac
 cl
-cm
+fA
 al
 ab
 cl
@@ -12307,11 +12351,11 @@ am
 al
 ac
 ac
-gR
+fB
 ac
 ac
 gI
-el
+fG
 ac
 bZ
 am
@@ -12409,10 +12453,10 @@ am
 al
 ac
 dU
-el
-el
-el
-el
+fG
+AE
+Hz
+fG
 el
 hC
 al
@@ -18923,9 +18967,9 @@ aq
 aq
 aq
 aq
-aq
-aq
-aq
+DY
+DY
+DY
 aq
 al
 am

--- a/maps/away/abandoned_colony/abandoned_colony.dmm
+++ b/maps/away/abandoned_colony/abandoned_colony.dmm
@@ -1774,6 +1774,11 @@
 /obj/structure/table/woodentable/walnut,
 /turf/simulated/floor/wood/walnut,
 /area/planet/abandoned_colony)
+"fp" = (
+/turf/simulated/floor/wood/walnut{
+	icon_state = "walnut_broken0"
+	},
+/area/planet/abandoned_colony)
 "fq" = (
 /obj/machinery/light/colored{
 	icon_state = "yellow1";
@@ -1834,19 +1839,14 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/planet/abandoned_colony)
 "fA" = (
-/obj/decal/cleanable/dirt,
-/obj/decal/cleanable/blood/drip,
-/turf/simulated/floor/fixed/uristturf/geminus{
-	icon_state = "square_grey";
-	color = "#cccccc"
+/turf/simulated/floor/wood/walnut{
+	icon_state = "walnut_broken1"
 	},
 /area/planet/abandoned_colony)
 "fB" = (
-/obj/machinery/door/airlock{
-	name = "Bar Backroom"
+/turf/simulated/floor/wood/walnut{
+	icon_state = "walnut_broken4"
 	},
-/obj/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/dark,
 /area/planet/abandoned_colony)
 "fC" = (
 /obj/structure/table/woodentable/walnut,
@@ -1878,9 +1878,8 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/planet/abandoned_colony)
 "fG" = (
-/obj/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/uristturf/geminus{
-	icon_state = "square_black"
+/turf/simulated/floor/wood/walnut{
+	icon_state = "walnut_broken2"
 	},
 /area/planet/abandoned_colony)
 "fH" = (
@@ -1936,6 +1935,11 @@
 /area/planet/abandoned_colony)
 "fQ" = (
 /turf/simulated/floor/tiled/white,
+/area/planet/abandoned_colony)
+"fR" = (
+/turf/simulated/floor/wood/walnut{
+	icon_state = "walnut_broken6"
+	},
 /area/planet/abandoned_colony)
 "fS" = (
 /obj/structure/hygiene/toilet,
@@ -2159,7 +2163,9 @@
 	pixel_y = 32;
 	color = "#4c0000"
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/wood/walnut{
+	icon_state = "walnut_broken2"
+	},
 /area/planet/abandoned_colony)
 "gz" = (
 /obj/machinery/light/small/red{
@@ -2208,8 +2214,6 @@
 	name = "dirty syringe";
 	desc = "Probably has at least five incurable STDs."
 	},
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
 /turf/simulated/floor/tiled/dark,
 /area/planet/abandoned_colony)
 "gD" = (
@@ -2298,7 +2302,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/clothing/suit/surgicalapron,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
@@ -2366,15 +2369,15 @@
 /obj/item/reagent_containers/syringe/drugs,
 /obj/item/reagent_containers/syringe/drugs,
 /obj/item/reagent_containers/syringe/steroid,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/syringe/steroid,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
 /area/planet/abandoned_colony)
 "ha" = (
 /obj/structure/table/standard,
-/obj/machinery/reagentgrinder,
+/obj/item/clothing/suit/surgicalapron,
+/obj/item/clothing/suit/surgicalapron,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
@@ -2384,7 +2387,10 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
-/obj/machinery/reagent_temperature,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
@@ -8097,7 +8103,6 @@
 /area/planet/abandoned_colony)
 "vf" = (
 /mob/living/simple_animal/hostile/scom/forgotten/awaymap,
-/obj/decal/cleanable/blood,
 /turf/simulated/floor/tiled/uristturf/geminus{
 	icon_state = "square_black"
 	},
@@ -8806,13 +8811,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/planet/abandoned_colony)
-"wW" = (
-/obj/machinery/door/airlock,
-/obj/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/uristturf/geminus{
-	icon_state = "square_black"
-	},
-/area/planet/abandoned_colony)
 "wY" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Hangar Bathrooms"
@@ -8970,13 +8968,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/planet/abandoned_colony)
-"zP" = (
-/obj/item/clothing/mask/gas/half,
-/obj/item/reagent_containers/syringe/steroid,
-/turf/simulated/floor/tiled/uristturf/geminus{
-	icon_state = "square_black"
-	},
-/area/planet/abandoned_colony)
 "zV" = (
 /obj/structure/salvageable/machine,
 /turf/simulated/floor/tiled,
@@ -8984,14 +8975,6 @@
 "Aw" = (
 /obj/random/trash,
 /turf/simulated/floor/tiled/dark,
-/area/planet/abandoned_colony)
-"AE" = (
-/obj/item/clothing/suit/surgicalapron,
-/obj/item/clothing/mask/gas/half,
-/obj/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/uristturf/geminus{
-	icon_state = "square_black"
-	},
 /area/planet/abandoned_colony)
 "AH" = (
 /obj/structure/salvageable/machine,
@@ -9069,10 +9052,6 @@
 /obj/item/reagent_containers/food/snacks/canned/caviar,
 /turf/simulated/floor/carpet,
 /area/planet/abandoned_colony)
-"DY" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/planet/dirt/city,
-/area/planet/abandoned_colony)
 "EW" = (
 /obj/structure/salvageable/console_broken_os{
 	icon_state = "os_console_broken";
@@ -9106,14 +9085,6 @@
 /obj/random/junk,
 /turf/simulated/floor/fixed/destroyedroad{
 	icon_state = "horizontalinnermain1"
-	},
-/area/planet/abandoned_colony)
-"Hz" = (
-/obj/decal/cleanable/blood/drip,
-/obj/decal/cleanable/blood/drip,
-/obj/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/uristturf/geminus{
-	icon_state = "square_black"
 	},
 /area/planet/abandoned_colony)
 "HD" = (
@@ -9201,10 +9172,6 @@
 /obj/machinery/light/colored/green,
 /obj/random/clothing,
 /turf/simulated/floor/tiled/dark,
-/area/planet/abandoned_colony)
-"LM" = (
-/obj/machinery/seed_storage/garden,
-/turf/simulated/floor/tiled,
 /area/planet/abandoned_colony)
 "LV" = (
 /obj/machinery/light/street,
@@ -9346,13 +9313,6 @@
 	color = "#cccccc"
 	},
 /area/planet/abandoned_colony)
-"Ri" = (
-/obj/decal/cleanable/blood/drip,
-/obj/item/reagent_containers/syringe/steroid,
-/turf/simulated/floor/tiled/uristturf/geminus{
-	icon_state = "square_black"
-	},
-/area/planet/abandoned_colony)
 "Rt" = (
 /obj/random/junk,
 /turf/simulated/floor/pavement{
@@ -9423,10 +9383,6 @@
 /turf/simulated/floor/fixed/destroyedroad{
 	icon_state = "dottedhorizontalcorroded"
 	},
-/area/planet/abandoned_colony)
-"Ve" = (
-/obj/machinery/smartfridge/drying_rack,
-/turf/simulated/floor/tiled,
 /area/planet/abandoned_colony)
 "Vn" = (
 /obj/decal/cleanable/blood/drip,
@@ -9836,7 +9792,7 @@ jL
 jM
 jR
 ac
-Ve
+rH
 rH
 rH
 sY
@@ -9883,11 +9839,11 @@ dO
 fj
 eh
 eh
-eh
+fA
 eh
 eu
 fo
-eh
+fG
 fo
 ac
 fu
@@ -9938,7 +9894,7 @@ jQ
 dy
 hN
 ac
-LM
+rH
 kc
 rH
 jj
@@ -9983,7 +9939,7 @@ dD
 ac
 dP
 eh
-eh
+fp
 eh
 eh
 vJ
@@ -10088,7 +10044,7 @@ fk
 en
 eh
 eh
-eh
+fB
 eu
 fo
 eh
@@ -10193,7 +10149,7 @@ et
 eu
 eh
 eG
-eh
+fR
 eL
 ac
 ac
@@ -11522,7 +11478,7 @@ al
 eh
 gp
 ct
-eh
+fR
 hu
 ft
 ez
@@ -12045,7 +12001,7 @@ am
 gz
 ac
 gD
-zP
+el
 gZ
 ac
 el
@@ -12151,9 +12107,9 @@ vf
 ha
 ac
 el
-fG
-wW
-cv
+el
+cP
+am
 cm
 am
 am
@@ -12249,14 +12205,14 @@ am
 al
 ac
 gF
-Ri
+el
 hb
 ac
 ht
-fG
+el
 ac
 cl
-fA
+cm
 al
 ab
 cl
@@ -12351,11 +12307,11 @@ am
 al
 ac
 ac
-fB
+gR
 ac
 ac
 gI
-fG
+el
 ac
 bZ
 am
@@ -12453,10 +12409,10 @@ am
 al
 ac
 dU
-fG
-AE
-Hz
-fG
+el
+el
+el
+el
 el
 hC
 al
@@ -18967,9 +18923,9 @@ aq
 aq
 aq
 aq
-DY
-DY
-DY
+aq
+aq
+aq
 aq
 al
 am


### PR DESCRIPTION
- Floating Messages now default to SHOW
- This will mainly affect new players, who will most likely be used to runechat by default as it's common in almost all branches of SS13 servers now and I would argue is one of the best UX additions.
- You can still go into preferences and hide them if you don't like em