### PR TITLE
Ports Nebula's Kicking Lying Ammo Casing

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -77,6 +77,24 @@
 
 	update_icon()
 
+// Nebula-Port: Kicking casings around
+
+/obj/item/ammo_casing/Crossed(atom/AM)
+	..()
+
+	if(isliving(AM))
+		var/mob/living/L = AM
+
+		if(L.buckled)
+			return
+
+		if(!MOVING_DELIBERATELY(L) && prob(10))
+			playsound(src, pick(fall_sounds), 50, 1)
+			var/turf/turf_current = get_turf(src)
+			var/turf/turf_destination = get_step(turf_current, AM.dir)
+			if(turf_destination.Adjacent(turf_current))
+				throw_at(turf_destination, 2, 2, spin = FALSE)
+				animate(src, pixel_x = rand(-16, 16), pixel_y = rand(-16, 16), transform = turn(matrix(), rand(120, 300)), time = rand(3, 8))
 
 /obj/item/ammo_casing/proc/leave_residue()
 	var/mob/living/carbon/human/H = get_holder_of_type(src, /mob/living/carbon/human)


### PR DESCRIPTION
Ports a Nebula feature for moving ammo casings when you run over them.
Walking and Creeping doesn't kick casings, only when you run, at a 10% chance.

It's a fun change to previous firefight areas.

[2025-10-26 15-53-41.webm](https://github.com/user-attachments/assets/798ddbfb-891c-4adb-b457-05831a2216af)
