### PR TITLE
list -> alist for latest BYOND 516.1673 compatibility

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -330,7 +330,7 @@
 	var/static/expected_round_length = 2 HOURS
 
 	/// Whether the first delay per level has a custom start time
-	var/static/list/event_first_run = list(
+	var/static/list/event_first_run = alist(
 		EVENT_LEVEL_MUNDANE = null,
 		EVENT_LEVEL_MODERATE = null,
 		EVENT_LEVEL_MAJOR = list(
@@ -344,7 +344,7 @@
 	)
 
 	/// The lowest delay until next event
-	var/static/list/event_delay_lower = list(
+	var/static/list/event_delay_lower = alist(
 		EVENT_LEVEL_MUNDANE = 10 MINUTES,
 		EVENT_LEVEL_MODERATE = 30 MINUTES,
 		EVENT_LEVEL_MAJOR = 50 MINUTES,
@@ -352,7 +352,7 @@
 	)
 
 	/// The upper delay until next event
-	var/static/list/event_delay_upper = list(
+	var/static/list/event_delay_upper = alist(
 		EVENT_LEVEL_MUNDANE = 15 MINUTES,
 		EVENT_LEVEL_MODERATE = 45 MINUTES,
 		EVENT_LEVEL_MAJOR = 70 MINUTES,

--- a/code/controllers/subsystems/event.dm
+++ b/code/controllers/subsystems/event.dm
@@ -29,7 +29,7 @@ SUBSYSTEM_DEF(event)
 	if(!all_events)
 		all_events = subtypesof(/datum/event)
 	if(!event_containers)
-		event_containers = list(
+		event_containers = alist(
 				EVENT_LEVEL_MUNDANE 	= new/datum/event_container/mundane,
 				EVENT_LEVEL_MODERATE	= new/datum/event_container/moderate,
 				EVENT_LEVEL_MAJOR 		= new/datum/event_container/major,

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -29,7 +29,7 @@
 	next_turf:
 		for(var/turf/T)
 			for(var/dir in GLOB.cardinal)
-				var/list/connect_types = list(1 = 0, 2 = 0, 3 = 0)
+				var/list/connect_types = alist(1 = 0, 2 = 0, 3 = 0)
 				for(var/obj/machinery/atmospherics/pipe in T)
 					if(dir & pipe.initialize_directions)
 						for(var/connect_type in pipe.connect_types)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -8,7 +8,7 @@
 #define ASSIGNMENT_SCIENTIST "Scientist"
 #define ASSIGNMENT_SECURITY "Security"
 
-var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT_LEVEL_MODERATE = "Moderate", EVENT_LEVEL_MAJOR = "Major", EVENT_LEVEL_EXO = "Exoplanet")
+var/global/list/severity_to_string = alist(EVENT_LEVEL_MUNDANE = "Mundane", EVENT_LEVEL_MODERATE = "Moderate", EVENT_LEVEL_MAJOR = "Major", EVENT_LEVEL_EXO = "Exoplanet")
 
 /datum/event_container
 	var/severity = -1

--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -235,7 +235,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		TAG_RELIGION =  RELIGION_AGNOSTICISM
 	)
 
-	var/access_modify_region = list(
+	var/access_modify_region = alist(
 		ACCESS_REGION_SECURITY = list(access_hos, access_change_ids),
 		ACCESS_REGION_MEDBAY = list(access_cmo, access_change_ids),
 		ACCESS_REGION_RESEARCH = list(access_rd, access_change_ids),

--- a/maps/nerva/datums/nerva_jobs.dm
+++ b/maps/nerva/datums/nerva_jobs.dm
@@ -11,7 +11,7 @@
 						/datum/job/ai, /datum/job/cyborg
 						)
 
-	access_modify_region = list(
+	access_modify_region = alist(
 		ACCESS_REGION_SECURITY = list(access_change_ids),
 		ACCESS_REGION_MEDBAY = list(access_change_ids),
 		ACCESS_REGION_RESEARCH = list(access_rd),


### PR DESCRIPTION
Just changes a couple of lists to alist() so that BYOND stops screaming and works on current version.

Stops this from happening:

DM compiler version 516.1673
loading baystation12.dme    
loading interface/skin.dmf
code\controllers\configuration.dm:333:error: list: numbers are not allowed as associative list keys except in alist()
code\controllers\configuration.dm:347:error: list: numbers are not allowed as associative list keys except in alist()
code\controllers\configuration.dm:355:error: list: numbers are not allowed as associative list keys except in alist()
code\modules\events\event_container.dm:11:error: list: numbers are not allowed as associative list keys except in alist()
code\modules\admin\verbs\atmosdebug.dm:32:error: list: numbers are not allowed as associative list keys except in alist()
code\controllers\subsystems\event.dm:32:error: list: numbers are not allowed as associative list keys except in alist()
maps\mapsystem\maps.dm:238:error: list: numbers are not allowed as associative list keys except in alist()
maps\nerva\datums\nerva_jobs.dm:14:error: list: numbers are not allowed as associative list keys except in alist()
baystation12.dmb - 8 errors, 0 warnings (12/17/25 11:15 pm)
Total time: 0:16